### PR TITLE
Battle-harden installation script and use xenial for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
     - aws-sdk-swift-test-bucket.localhost
   apt:
     packages:
-    - clang
+    - clang-3.8
     - libicu-dev
     - uuid-dev
     - pkg-config

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
   - osx
 language: generic
 sudo: required
-dist: trusty
+dist: xenial
 osx_image: xcode9.4
 
 addons:
@@ -12,9 +12,10 @@ addons:
 
 install:
   - source scripts/install-swift.sh
-  - if [[ $OS != "macos" ]]; then docker run -d -p 8000:8000 tray/dynamodb-local -inMemory -port 8000; fi
-  - if [[ $OS != "macos" ]]; then docker run -d -p 4569:4569 lphoward/fake-s3; fi
+  - if [ "macos" = "${OS}" ]; then docker run -d -p 8000:8000 tray/dynamodb-local -inMemory -port 8000; fi
+  - if [ "macos" = "${OS}" ]; then docker run -d -p 4569:4569 lphoward/fake-s3; fi
 
 script:
+  - source scripts/install-swift.sh
   - source scripts/help-travis-wait.sh& travis_wait 60 swift build
-  - if [[ $OS != "macos" ]]; then swift test; fi
+  - if [ "macos" = "${OS}" ]; then swift test; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ addons:
 install:
   - source scripts/install-swift.sh
   - if [ "${OS}" != "macos" ]; then docker run -d -p 8000:8000 tray/dynamodb-local -inMemory -port 8000; fi
-  - if [ "${OS}" != "macos"]; then docker run -d -p 4569:4569 lphoward/fake-s3; fi
+  - if [ "${OS}" != "macos" ]; then docker run -d -p 4569:4569 lphoward/fake-s3; fi
 
 script:
   - source scripts/install-swift.sh
   - source scripts/help-travis-wait.sh& travis_wait 60 swift build
-  - if [ "${OS}" != "macos"]; then swift test; fi
+  - if [ "${OS}" != "macos" ]; then swift test; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,21 @@ os:
 language: generic
 sudo: required
 dist: xenial
-osx_image: xcode9.4
+osx_image: xcode10
 
 addons:
   hosts:
     - aws-sdk-swift-test-bucket.localhost
+  apt:
+    packages:
+    - clang
+    - libicu-dev
+    - uuid-dev
+    - pkg-config
+    - libssl-dev
+  homebrew:
+    packages:
+    - libressl
 
 install:
   - source scripts/install-swift.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@ addons:
 
 install:
   - source scripts/install-swift.sh
-  - if [ "macos" = "${OS}" ]; then docker run -d -p 8000:8000 tray/dynamodb-local -inMemory -port 8000; fi
-  - if [ "macos" = "${OS}" ]; then docker run -d -p 4569:4569 lphoward/fake-s3; fi
+  - if [ "macos" != "${OS}" ]; then docker run -d -p 8000:8000 tray/dynamodb-local -inMemory -port 8000; fi
+  - if [ "macos" != "${OS}" ]; then docker run -d -p 4569:4569 lphoward/fake-s3; fi
 
 script:
   - source scripts/install-swift.sh
   - source scripts/help-travis-wait.sh& travis_wait 60 swift build
-  - if [ "macos" = "${OS}" ]; then swift test; fi
+  - if [ "macos" != "${OS}" ]; then swift test; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ addons:
     - aws-sdk-swift-test-bucket.localhost
   apt:
     packages:
-    - clang-3.8
     - libicu-dev
     - uuid-dev
     - pkg-config

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@ addons:
 
 install:
   - source scripts/install-swift.sh
-  - if [ "macos" != "${OS}" ]; then docker run -d -p 8000:8000 tray/dynamodb-local -inMemory -port 8000; fi
-  - if [ "macos" != "${OS}" ]; then docker run -d -p 4569:4569 lphoward/fake-s3; fi
+  - if [ "${OS}" != "macos" ]; then docker run -d -p 8000:8000 tray/dynamodb-local -inMemory -port 8000; fi
+  - if [ "${OS}" != "macos"]; then docker run -d -p 4569:4569 lphoward/fake-s3; fi
 
 script:
   - source scripts/install-swift.sh
   - source scripts/help-travis-wait.sh& travis_wait 60 swift build
-  - if [ "macos" != "${OS}" ]; then swift test; fi
+  - if [ "${OS}" != "macos"]; then swift test; fi

--- a/scripts/install-swift.sh
+++ b/scripts/install-swift.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
-VERSION="4.1.3"
+set -eux
+
+VERSION="4.2"
 
 UNAME=$(uname);
 if [ "${UNAME}" = "Darwin" ];
@@ -11,6 +13,7 @@ else
     then
         UBUNTU_RELEASE=$(lsb_release -r 2>/dev/null | cut -f2);
         case "${UBUNTU_RELEASE}" in
+            18.04) OS="ubuntu1804";;
             16.04) OS="ubuntu1604";;
             15.10) OS="ubuntu1510";;
             14.04) OS="ubuntu1404";;
@@ -23,17 +26,21 @@ if [ "macos" = "${OS}" ];
 then
     brew install libressl
 else
-    dpkg -s clang | grep Status | grep -q install 2> /dev/null
+    dpkg -s libssl-dev | grep Status | grep -q install 2> /dev/null
     if [ $? -ne 0 ];
     then
+        set +x
         echo "Installing"
+        set -x
         sudo apt-get install -y clang libicu-dev uuid-dev pkg-config libssl-dev
     fi
 
     SWIFTFILE="swift-${VERSION}-RELEASE-ubuntu${UBUNTU_RELEASE}";
     if [ -d "${PWD}/${SWIFTFILE}" ];
     then
+        set +x
         echo "Swift ${VERSION} already downloaded."
+        set -x
     else
         wget "https://swift.org/builds/swift-${VERSION}-release/${OS}/swift-${VERSION}-RELEASE/${SWIFTFILE}.tar.gz"
         tar -zxf "${SWIFTFILE}.tar.gz"

--- a/scripts/install-swift.sh
+++ b/scripts/install-swift.sh
@@ -48,4 +48,4 @@ else
     fi
 fi
 
-set +u
+set +ux

--- a/scripts/install-swift.sh
+++ b/scripts/install-swift.sh
@@ -47,3 +47,5 @@ else
         export PATH="${PWD}/${SWIFTFILE}/usr/bin:${PATH}"
     fi
 fi
+
+set +u

--- a/scripts/install-swift.sh
+++ b/scripts/install-swift.sh
@@ -3,11 +3,11 @@
 VERSION="4.1.3"
 
 UNAME=$(uname);
-if [ "Darwin" = "${UNAME}" ];
+if [ "${UNAME}" = "Darwin" ];
 then
     OS="macos";
 else
-    if [ "Linux" = "${UNAME}" ];
+    if [ "${UNAME}" = "Linux" ];
     then
         UBUNTU_RELEASE=$(lsb_release -r 2>/dev/null | cut -f2);
         case "${UBUNTU_RELEASE}" in
@@ -23,7 +23,12 @@ if [ "macos" = "${OS}" ];
 then
     brew install libressl
 else
-    sudo apt-get install -y clang libicu-dev uuid-dev pkg-config libssl-dev
+    dpkg -s clang | grep Status | grep -q install 2> /dev/null
+    if [ $? -ne 0 ];
+    then
+        echo "Installing"
+        sudo apt-get install -y clang libicu-dev uuid-dev pkg-config libssl-dev
+    fi
 
     SWIFTFILE="swift-${VERSION}-RELEASE-ubuntu${UBUNTU_RELEASE}";
     if [ -d "${PWD}/${SWIFTFILE}" ];

--- a/scripts/install-swift.sh
+++ b/scripts/install-swift.sh
@@ -1,38 +1,37 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-VERSION="4.1.2"
+VERSION="4.1.3"
 
-# Determine OS
-UNAME=`uname`;
-if [[ $UNAME == "Darwin" ]];
+UNAME=$(uname);
+if [ "Darwin" = "${UNAME}" ];
 then
     OS="macos";
 else
-    if [[ $UNAME == "Linux" ]];
+    if [ "Linux" = "${UNAME}" ];
     then
-        UBUNTU_RELEASE=`lsb_release -a 2>/dev/null`;
-        if [[ $UBUNTU_RELEASE == *"15.10"* ]];
-        then
-            OS="ubuntu1510";
-        else
-            OS="ubuntu1404";
-        fi
+        UBUNTU_RELEASE=$(lsb_release -r 2>/dev/null | cut -f2);
+        case "${UBUNTU_RELEASE}" in
+            16.04) OS="ubuntu1604";;
+            15.10) OS="ubuntu1510";;
+            14.04) OS="ubuntu1404";;
+            *) echo "Unsupported distro!"; exit 1;;
+        esac
     fi
 fi
 
-if [[ $OS == "macos" ]];
+if [ "macos" = "${OS}" ];
 then
     brew install libressl
 else
-    sudo apt-get install -y clang libicu-dev uuid-dev
+    sudo apt-get install -y clang libicu-dev uuid-dev pkg-config libssl-dev
 
-    if [[ $OS == "ubuntu1510" ]];
+    SWIFTFILE="swift-${VERSION}-RELEASE-ubuntu${UBUNTU_RELEASE}";
+    if [ -d "${PWD}/${SWIFTFILE}" ];
     then
-        SWIFTFILE="swift-$VERSION-RELEASE-ubuntu15.10";
+        echo "Swift ${VERSION} already downloaded."
     else
-        SWIFTFILE="swift-$VERSION-RELEASE-ubuntu14.04";
+        wget "https://swift.org/builds/swift-${VERSION}-release/${OS}/swift-${VERSION}-RELEASE/${SWIFTFILE}.tar.gz"
+        tar -zxf "${SWIFTFILE}.tar.gz"
+        export PATH="${PWD}/${SWIFTFILE}/usr/bin:${PATH}"
     fi
-    wget https://swift.org/builds/swift-$VERSION-release/$OS/swift-$VERSION-RELEASE/$SWIFTFILE.tar.gz
-    tar -zxf $SWIFTFILE.tar.gz
-    export PATH=$PWD/$SWIFTFILE/usr/bin:"${PATH}"
 fi


### PR DESCRIPTION
Lean into some shell best-practices and only install swift if we need to.

Turns out [Travis is failing](https://travis-ci.org/swift-aws/aws-sdk-swift/jobs/424598068) for a PR due to not having the Swift tools inside `$PATH`. This change sets `scripts/install-swift.sh` to be idempotent, and will properly update the `$PATH` and only download the correct Swift version if needed.

The other changes are largely stylistic but will help reduce errors and simplify the script as well.