### PR TITLE
Type issue converting what is a String that looks like an Int

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -153,7 +153,7 @@ let package = Package(
 	.library(name: "Xray", targets: ["Xray"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/swift-aws/aws-sdk-swift-core.git", .branch("xml-parsing")),
+        .package(url: "https://github.com/swift-aws/aws-sdk-swift-core.git", .upToNextMajor(from: "2.0.0-rc.1")),
         .package(url: "https://github.com/IBM-Swift/SwiftyJSON.git", .upToNextMajor(from: "17.0.2"))
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -153,7 +153,7 @@ let package = Package(
 	.library(name: "Xray", targets: ["Xray"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/swift-aws/aws-sdk-swift-core.git", .upToNextMajor(from: "2.0.0-rc.1")),
+        .package(url: "https://github.com/swift-aws/aws-sdk-swift-core.git", .branch("xml-parsing")),
         .package(url: "https://github.com/IBM-Swift/SwiftyJSON.git", .upToNextMajor(from: "17.0.2"))
     ],
     targets: [

--- a/Sources/AWSSDKSwift/Services/elasticloadbalancing/Elasticloadbalancing_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/elasticloadbalancing/Elasticloadbalancing_Shapes.swift
@@ -1331,15 +1331,15 @@ extension Elasticloadbalancing {
 
     public struct SourceSecurityGroup: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "OwnerAlias", required: false, type: .string), 
+            AWSShapeMember(label: "OwnerAlias", required: false, type: .integer),
             AWSShapeMember(label: "GroupName", required: false, type: .string)
         ]
         /// The owner of the security group.
-        public let ownerAlias: String?
+        public let ownerAlias: Int?
         /// The name of the security group.
         public let groupName: String?
 
-        public init(ownerAlias: String? = nil, groupName: String? = nil) {
+        public init(ownerAlias: Int? = nil, groupName: String? = nil) {
             self.ownerAlias = ownerAlias
             self.groupName = groupName
         }


### PR DESCRIPTION
@jonnymacs mentioned that we don't utilize the models to do our parsing, but I think they provide important hints on matching the types we'll use for our `Codable` structs.

For example, `Elasticloadbalancing.describeLoadBalancers` returns:

`<SourceSecurityGroup><OwnerAlias>123458855789</OwnerAlias><GroupName>https</GroupName></SourceSecurityGroup>`

which results in:

```
Fatal error: Error raised at top level: Swift.DecodingError.typeMismatch(Swift.String, Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "LoadBalancerDescriptions", intValue: nil), _DictionaryKey(stringValue: "Index 0", intValue: 0), CodingKeys(stringValue: "SourceSecurityGroup", intValue: nil), CodingKeys(stringValue: "OwnerAlias", intValue: nil)], debugDescription: "Expected to decode String but found Int instead.", underlyingError: nil)): file /home/buildnode/jenkins/workspace/oss-swift-4.1-package-linux-ubuntu-16_04/swift/stdlib/public/core/ErrorType.swift, line 191
```

Maybe it's okay to ship this patch as a temporary workaround, but it's going to be overwritten the next time we generate the code and need to be manually fixed.

Ideas and suggestions welcome! 🙏 