### PR TITLE
Ensure AWSShape always has a public init function

### DIFF
--- a/Sources/CodeGenerator/CodeGenerator.swift
+++ b/Sources/CodeGenerator/CodeGenerator.swift
@@ -393,13 +393,13 @@ extension AWSService {
                     code += "\(indt(2))public \(member.toSwiftImmutableMemberSyntax())\n"
                 }
                 code += "\n"
-                if type.members.count > 0 {
-                    code += "\(indt(2))public init(\(type.members.toSwiftArgumentSyntax())) {\n"
-                    for member in type.members {
-                        code += "\(indt(3))self.\(member.name.toSwiftVariableCase()) = \(member.name.toSwiftVariableCase())\n"
-                    }
-                    code += "\(indt(2))}\n\n"
+                code += "\(indt(2))public init(\(type.members.toSwiftArgumentSyntax())) {\n"
+                for member in type.members {
+                    code += "\(indt(3))self.\(member.name.toSwiftVariableCase()) = \(member.name.toSwiftVariableCase())\n"
+                }
+                code += "\(indt(2))}\n\n"
 
+                if type.members.count > 0 {
                     // CoadingKyes
                     code += "\(indt(2))private enum CodingKeys: String, CodingKey {\n"
 


### PR DESCRIPTION
Fixes problem with constructing STS.GetCallerIdentityRequest
Fixes #108.

I haven't run the code generator though because it seems to be re-ordering all the code. This isn't too much of a problem except when it is re-ordering the parameters in init() functions. I noticed this has already happened in December in commit https://github.com/swift-aws/aws-sdk-swift/commit/0360367d8cb531a256cde7714cc0033b17fa4490.

I would suggest you force the order to be alphabetical. Then they won't change between builds of code generator and model changes.