### PR TITLE
Supply Content-MD5 header for all S3 operations with a body

### DIFF
--- a/Sources/AWSSDKSwift/Middlewares/S3/S3RequestMiddleware.swift
+++ b/Sources/AWSSDKSwift/Middlewares/S3/S3RequestMiddleware.swift
@@ -44,6 +44,11 @@ public struct S3RequestMiddleware: AWSRequestMiddleware {
             }
         }
 
+        if let data = try request.body.asData() {
+            let encoded = Data(md5(data)).base64EncodedString()
+            request.addValue(encoded, forHTTPHeaderField: "Content-MD5")
+        }
+        
         switch request.operation {
         case "CreateBucket":
             var xml = ""
@@ -54,11 +59,6 @@ public struct S3RequestMiddleware: AWSRequestMiddleware {
             xml += "</CreateBucketConfiguration>"
             request.body = .text(xml)
 
-        case "PutObject":
-            if let data = try request.body.asData() {
-                let encoded = Data(bytes: md5(data)).base64EncodedString()
-                request.addValue(encoded, forHTTPHeaderField: "Content-MD5")
-            }
         default:
             break
         }


### PR DESCRIPTION
Minor change, ensure we supply a Content-MD5 for all S3 operations with a body. Found another S3 operation that required one. Instead of continuing to update the list of operations that require them I thought adding to all operations would be preferable. Amazon recommend it is there for all S3 operations. 