### PR TITLE
Moved CodeGenerator files from AWSSDKSwiftCore

### DIFF
--- a/Sources/CodeGenerator/AWSService.swift
+++ b/Sources/CodeGenerator/AWSService.swift
@@ -19,7 +19,7 @@ struct AWSService {
     let docJSON: JSON
     let endpointJSON: JSON
     var shapes = [Shape]()
-    var operations: [AWSSDKSwiftCore.Operation] = []
+    var operations: [Operation] = []
     var errorShapeNames = [String]()
     var shapeDoc: [String: [String: String]] = [:]
 
@@ -248,8 +248,8 @@ struct AWSService {
         return shapes.sorted{ $0.name < $1.name }
     }
 
-    private func parseOperation(shapes: [Shape]) throws -> ([AWSSDKSwiftCore.Operation], [String])  {
-        var operations: [AWSSDKSwiftCore.Operation] = []
+    private func parseOperation(shapes: [Shape]) throws -> ([Operation], [String])  {
+        var operations: [Operation] = []
         var errorShapeNames: [String] = []
         for (_, json) in apiJSON["operations"].dictionaryValue {
             for json in json["errors"].arrayValue {
@@ -273,7 +273,7 @@ struct AWSService {
                 }
             }
 
-            let operation = AWSSDKSwiftCore.Operation(
+            let operation = Operation(
                 name: json["name"].stringValue,
                 httpMethod: json["http"]["method"].stringValue,
                 path: json["http"]["requestUri"].stringValue,

--- a/Sources/CodeGenerator/CodeGenerator.swift
+++ b/Sources/CodeGenerator/CodeGenerator.swift
@@ -62,7 +62,7 @@ extension ServiceProtocol {
     }
 }
 
-extension AWSSDKSwiftCore.Operation {
+extension Operation {
     func generateSwiftFunctionCode() -> String {
         var code = ""
 

--- a/Sources/CodeGenerator/Doc/Glob.swift
+++ b/Sources/CodeGenerator/Doc/Glob.swift
@@ -1,0 +1,37 @@
+//
+//  Glob.swift
+//  AWSSDKSwift
+//
+//  Created by Yuki Takei on 2017/03/19.
+//
+//
+
+import Foundation
+
+#if os(Linux)
+    import Glibc
+#else
+    import Darwin.C
+#endif
+
+public class Glob {
+    
+    public static func entries(pattern: String) -> [String] {
+        var files = [String]()
+        var gt: glob_t = glob_t()
+        let res = glob(pattern.cString(using: .utf8)!, 0, nil, &gt)
+        if res != 0 {
+            return files
+        }
+        
+        for i in (0..<gt.gl_pathc) {
+            let x = gt.gl_pathv[Int(i)]
+            let c = UnsafePointer<CChar>(x)!
+            let s = String.init(cString: c)
+            files.append(s)
+        }
+        
+        globfree(&gt)
+        return files
+    }
+}

--- a/Sources/CodeGenerator/Doc/Member.swift
+++ b/Sources/CodeGenerator/Doc/Member.swift
@@ -1,0 +1,29 @@
+//
+//  Member.swift
+//  AWSSDKSwift
+//
+//  Created by Yuki Takei on 2017/03/29.
+//
+//
+
+import Foundation
+
+public struct Member {
+    public let name: String
+    public let required: Bool
+    public let shape: Shape
+    public let location: Location?
+    public let locationName: String?
+    public let xmlNamespace: XMLNamespace?
+    public let isStreaming: Bool
+    
+    public init(name: String, required: Bool, shape: Shape, location: Location?, locationName: String?, xmlNamespace: XMLNamespace?, isStreaming: Bool){
+        self.name = name
+        self.required = required
+        self.shape = shape
+        self.location = location
+        self.locationName = locationName
+        self.xmlNamespace = xmlNamespace
+        self.isStreaming = isStreaming
+    }
+}

--- a/Sources/CodeGenerator/Doc/Operation.swift
+++ b/Sources/CodeGenerator/Doc/Operation.swift
@@ -1,0 +1,23 @@
+//
+//  Operation.swift
+//  AWSSDKSwift
+//
+//  Created by Yuki Takei on 2017/03/22.
+//
+//
+
+public struct Operation {
+    public let name: String
+    public let httpMethod: String
+    public let path: String
+    public let inputShape: Shape?
+    public let outputShape: Shape?
+    
+    public init(name: String, httpMethod: String, path: String, inputShape: Shape?, outputShape: Shape?){
+        self.name = name
+        self.httpMethod = httpMethod
+        self.path = path
+        self.inputShape = inputShape
+        self.outputShape = outputShape
+    }
+}

--- a/Sources/CodeGenerator/Doc/Shape.swift
+++ b/Sources/CodeGenerator/Doc/Shape.swift
@@ -1,0 +1,119 @@
+//
+//  Shape.swift
+//  AWSSDKSwift
+//
+//  Created by Yuki Takei on 2017/03/22.
+//
+//
+
+import Foundation
+
+public enum ShapeTypeError: Error {
+    case unsupported(String)
+}
+
+public struct Shape {
+    public let name: String
+    public let type: ShapeType
+    
+    public init(name: String, type: ShapeType){
+        self.name = name
+        self.type = type
+    }
+    
+    public var isStruct: Bool {
+        switch type {
+        case .structure(_):
+            return true
+        default:
+            return false
+        }
+    }
+    
+    public var isOutputType: Bool {
+        if name.count <= 6 {
+            return false
+        }
+        
+        let suffix = String(name[name.index(name.endIndex, offsetBy: -6)...])
+        return suffix.lowercased() == "output"
+    }
+}
+
+public struct StructureShape {
+    public let members: [Member]
+    public let payload: String?
+    public let xmlNamespace: String?
+    
+    public init(members: [Member], payload: String?, xmlNamespace: String? = nil){
+        self.members = members
+        self.payload = payload
+        self.xmlNamespace = xmlNamespace
+    }
+}
+
+public typealias XMLAttribute = [String: [String: String]] // ["elementName": ["key": "value", ...]]
+
+public struct XMLNamespace {
+    public let locationName: String
+    public let attributeMap: [String: Any]
+    
+    public var attributes: XMLAttribute {
+        var dict: [String: String] = [:]
+        attributeMap.forEach {
+            dict[$0.key] = "\($0.value)"
+        }
+        return [locationName: dict]
+    }
+    
+    public init?(dictionary: [String: Any]) {
+        if let attributeMap = dictionary["xmlNamespace"] as? [String: Any] {
+            self.attributeMap = attributeMap
+        }
+        else {
+            return nil
+        }
+        
+        guard let name = dictionary["locationName"] as? String else {
+            return nil
+        }
+        
+        self.locationName = name
+    }
+}
+
+public enum Location {
+    case uri(locationName: String)
+    case querystring(locationName: String)
+    case header(locationName: String)
+    case body(locationName: String)
+    
+    public var name: String {
+        switch self {
+        case .uri(locationName: let name):
+            return name
+        case .querystring(locationName: let name):
+            return name
+        case .header(locationName: let name):
+            return name
+        case .body(locationName: let name):
+            return name
+        }
+    }
+}
+
+public indirect enum ShapeType {
+    case string(max: Int?, min: Int?, pattern: String?)
+    case integer(max: Int?, min: Int?)
+    case structure(StructureShape)
+    case blob(max: Int?, min: Int?)
+    case list(Shape)
+    case map(key: Shape, value: Shape)
+    case long(max: Int?, min: Int?)
+    case double(max: Int?, min: Int?)
+    case float(max: Int?, min: Int?)
+    case boolean
+    case timestamp
+    case `enum`([String])
+    case unhandledType
+}

--- a/Sources/CodeGenerator/Util.swift
+++ b/Sources/CodeGenerator/Util.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import SwiftyJSON
-import AWSSDKSwiftCore
 
 let enableShowLog = ProcessInfo.processInfo.environment["Verbose"] == nil ? false : true
 

--- a/Sources/CodeGenerator/main.swift
+++ b/Sources/CodeGenerator/main.swift
@@ -1,7 +1,6 @@
 import Foundation
 import SwiftyJSON
 import Dispatch
-import AWSSDKSwiftCore
 
 
 let apis = try loadAPIJSONList()


### PR DESCRIPTION
Shape, Operation, Member and Glob are not used in AWSSDKSwiftCore. They are only used in the CodeGenerator. 

I'll remove them from AWSSDKSwiftCore when this goes in