### PR TITLE
Codegenerator patching

### DIFF
--- a/Sources/AWSSDKSwift/Services/ECS/ECS_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/ECS/ECS_Shapes.swift
@@ -2398,6 +2398,7 @@ extension ECS {
     public enum PropagateTags: String, CustomStringConvertible, Codable {
         case taskDefinition = "TASK_DEFINITION"
         case service = "SERVICE"
+        case none = "NONE"
         public var description: String { return self.rawValue }
     }
 

--- a/Sources/AWSSDKSwift/Services/S3/S3_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/S3/S3_Shapes.swift
@@ -4932,18 +4932,18 @@ extension S3 {
             AWSShapeMember(label: "Key", required: false, type: .string), 
             AWSShapeMember(label: "LastModified", required: false, type: .timestamp), 
             AWSShapeMember(label: "Owner", required: false, type: .structure), 
-            AWSShapeMember(label: "Size", required: false, type: .integer), 
+            AWSShapeMember(label: "Size", required: false, type: .long), 
             AWSShapeMember(label: "StorageClass", required: false, type: .enum)
         ]
         public let eTag: String?
         public let key: String?
         public let lastModified: TimeStamp?
         public let owner: Owner?
-        public let size: Int32?
+        public let size: Int64?
         /// The class of storage used to store the object.
         public let storageClass: ObjectStorageClass?
 
-        public init(eTag: String? = nil, key: String? = nil, lastModified: TimeStamp? = nil, owner: Owner? = nil, size: Int32? = nil, storageClass: ObjectStorageClass? = nil) {
+        public init(eTag: String? = nil, key: String? = nil, lastModified: TimeStamp? = nil, owner: Owner? = nil, size: Int64? = nil, storageClass: ObjectStorageClass? = nil) {
             self.eTag = eTag
             self.key = key
             self.lastModified = lastModified
@@ -5108,7 +5108,7 @@ extension S3 {
             AWSShapeMember(label: "Key", required: false, type: .string), 
             AWSShapeMember(label: "LastModified", required: false, type: .timestamp), 
             AWSShapeMember(label: "Owner", required: false, type: .structure), 
-            AWSShapeMember(label: "Size", required: false, type: .integer), 
+            AWSShapeMember(label: "Size", required: false, type: .long), 
             AWSShapeMember(label: "StorageClass", required: false, type: .enum), 
             AWSShapeMember(label: "VersionId", required: false, type: .string)
         ]
@@ -5121,13 +5121,13 @@ extension S3 {
         public let lastModified: TimeStamp?
         public let owner: Owner?
         /// Size in bytes of the object.
-        public let size: Int32?
+        public let size: Int64?
         /// The class of storage used to store the object.
         public let storageClass: ObjectVersionStorageClass?
         /// Version ID of an object.
         public let versionId: String?
 
-        public init(eTag: String? = nil, isLatest: Bool? = nil, key: String? = nil, lastModified: TimeStamp? = nil, owner: Owner? = nil, size: Int32? = nil, storageClass: ObjectVersionStorageClass? = nil, versionId: String? = nil) {
+        public init(eTag: String? = nil, isLatest: Bool? = nil, key: String? = nil, lastModified: TimeStamp? = nil, owner: Owner? = nil, size: Int64? = nil, storageClass: ObjectVersionStorageClass? = nil, versionId: String? = nil) {
             self.eTag = eTag
             self.isLatest = isLatest
             self.key = key
@@ -5228,7 +5228,7 @@ extension S3 {
             AWSShapeMember(label: "ETag", required: false, type: .string), 
             AWSShapeMember(label: "LastModified", required: false, type: .timestamp), 
             AWSShapeMember(label: "PartNumber", required: false, type: .integer), 
-            AWSShapeMember(label: "Size", required: false, type: .integer)
+            AWSShapeMember(label: "Size", required: false, type: .long)
         ]
         /// Entity tag returned when the part was uploaded.
         public let eTag: String?
@@ -5237,9 +5237,9 @@ extension S3 {
         /// Part number identifying the part. This is a positive integer between 1 and 10,000.
         public let partNumber: Int32?
         /// Size in bytes of the uploaded part data.
-        public let size: Int32?
+        public let size: Int64?
 
-        public init(eTag: String? = nil, lastModified: TimeStamp? = nil, partNumber: Int32? = nil, size: Int32? = nil) {
+        public init(eTag: String? = nil, lastModified: TimeStamp? = nil, partNumber: Int32? = nil, size: Int64? = nil) {
             self.eTag = eTag
             self.lastModified = lastModified
             self.partNumber = partNumber

--- a/Sources/CodeGenerator/AWSService.swift
+++ b/Sources/CodeGenerator/AWSService.swift
@@ -78,7 +78,7 @@ struct AWSService {
     }
 
     init(fromAPIJSON apiJSON: JSON, docJSON: JSON, endpointJSON: JSON) throws {
-        self.apiJSON = apiJSON
+        self.apiJSON = patch(apiJSON)
         self.docJSON = docJSON
         self.endpointJSON = endpointJSON
         self.shapes = try parseShapes()

--- a/Sources/CodeGenerator/patch.swift
+++ b/Sources/CodeGenerator/patch.swift
@@ -16,10 +16,10 @@ let servicePatches : [String: [Patch]] = [
         Patch(operation:.add, entry:["shapes", "PropagateTags", "enum"], value:"NONE")
     ],
     "ELB" : [
-        //Patch(operation:.replace, entry:["shapes", "SecurityGroupOwnerAlias", "type"], value:"integer", originalValue:"string")
+        Patch(operation:.replace, entry:["shapes", "SecurityGroupOwnerAlias", "type"], value:"integer", originalValue:"string")
     ],
     "S3": [
-        //Patch(operation:.replace, entry:["shapes","ReplicationStatus","enum",0], value:"COMPLETED", originalValue:"COMPLETE"),
+        Patch(operation:.replace, entry:["shapes","ReplicationStatus","enum",0], value:"COMPLETED", originalValue:"COMPLETE"),
         Patch(operation:.replace, entry:["shapes","Size","type"], value:"long", originalValue:"integer")
     ]
 ]

--- a/Sources/CodeGenerator/patch.swift
+++ b/Sources/CodeGenerator/patch.swift
@@ -1,0 +1,89 @@
+//
+//  Patch.swift
+//  AWSSDKSwift - CodeGenerator
+//
+//  Created by Adam Fowler 2019/5/16
+//  Patches the JSON AWS model files as they are loaded into the CodeGenerator
+//
+import Foundation
+import SwiftyJSON
+
+//
+// Patch operations
+//
+let servicePatches : [String: [Patch]] = [
+    "ECS" : [
+        Patch(operation:.add, entry:["shapes", "PropagateTags", "enum"], value:"NONE")
+    ],
+    "ELB" : [
+        //Patch(operation:.replace, entry:["shapes", "SecurityGroupOwnerAlias", "type"], value:"integer", originalValue:"string")
+    ],
+    "S3": [
+        //Patch(operation:.replace, entry:["shapes","ReplicationStatus","enum",0], value:"COMPLETED", originalValue:"COMPLETE"),
+        Patch(operation:.replace, entry:["shapes","Size","type"], value:"long", originalValue:"integer")
+    ]
+]
+
+// structure defining a model patch
+struct Patch {
+    enum Operation {
+        case replace
+        case add
+    }
+    
+    init(operation: Operation, entry: [JSONSubscriptType], value: String, originalValue: String? = nil) {
+        self.operation = operation
+        self.entry = entry
+        self.value = value
+        self.originalValue = originalValue
+    }
+    
+    let operation : Operation
+    let entry : [JSONSubscriptType]
+    let value : CustomStringConvertible
+    let originalValue : CustomStringConvertible?
+}
+
+/// patch model JSON
+func patch(_ apiJSON: JSON) -> JSON {
+    let service = apiJSON["serviceName"].stringValue.toSwiftClassCase()
+    guard let patches = servicePatches[service] else {return apiJSON}
+    var patchedJSON = apiJSON
+    
+    for patch in patches {
+        let field = patchedJSON[patch.entry]
+        guard field != JSON.null else {
+            print("Attempting to patch field \(patch.entry) that doesn't eixst")
+            exit(-1)
+        }
+
+        switch patch.operation {
+        case .replace:
+            if let originalValue = patch.originalValue {
+                guard originalValue.description == field.stringValue else {
+                    print("Found an unexpected value while patching \(patch.entry). Expected \"\(originalValue)\", got \"\(field.stringValue)\"")
+                    exit(-1)
+                }
+            }
+            
+            patchedJSON[patch.entry].object = patch.value
+        case .add:
+            guard let array = field.array else {
+                print("Attempting to add a field to \(patch.entry) that cannot be added to.")
+                exit(-1)
+            }
+
+            guard array.first(where:{$0.stringValue == patch.value.description}) == nil else {
+                print("Attempting to add field \"\(patch.value)\" to array \(patch.entry) that aleady exists.")
+                exit(-1)
+            }
+            
+            var newArray = field.arrayObject!
+            newArray.append(patch.value)
+            patchedJSON[patch.entry].arrayObject = newArray
+        }
+    }
+    return patchedJSON
+}
+
+

--- a/Tests/AWSSDKSwiftTests/Services/S3/S3Tests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/S3/S3Tests.swift
@@ -82,7 +82,7 @@ class S3Tests: XCTestCase {
         let output = try client.listObjects(S3.ListObjectsRequest(bucket: TestData.shared.bucket))
         XCTAssertEqual(output.maxKeys, 1000)
         XCTAssertEqual(output.contents?.first?.key, TestData.shared.key)
-        XCTAssertEqual(output.contents?.first?.size, Int32(TestData.shared.bodyData.count))
+        XCTAssertEqual(output.contents?.first?.size, Int64(TestData.shared.bodyData.count))
         XCTAssertEqual(output.contents?.first?.eTag, putResult.eTag?.replacingOccurrences(of: "\"", with: ""))
     }
 

--- a/models/README.md
+++ b/models/README.md
@@ -3,7 +3,7 @@
 In order to keep up with rapidly updating AWS APIs, we use [the JSON model files utilized by the Go AWS SDK](https://github.com/aws/aws-sdk-go/tree/master/models).
 
 IMPORTANT - There are a few known bugs in certain services api.json
-
+These are now fixed up by the model patcher when loaded into the CodeGenerator, so there is no need to edit the models when you bring them across
 1. s3 - ReplicationStatus enum should be `COMPLETED` past tense. (_not_ `COMPLETE` present tense)
 2. elasticloadbalancing (not v2) - ensure ``"SecurityGroupOwnerAlias":{"type":"integer"}`` (_not_ "string")
 

--- a/models/apis/elasticloadbalancing/2012-06-01/api-2.json
+++ b/models/apis/elasticloadbalancing/2012-06-01/api-2.json
@@ -1458,7 +1458,7 @@
     "SSLCertificateId":{"type":"string"},
     "SecurityGroupId":{"type":"string"},
     "SecurityGroupName":{"type":"string"},
-    "SecurityGroupOwnerAlias":{"type":"integer"},
+    "SecurityGroupOwnerAlias":{"type":"string"},
     "SecurityGroups":{
       "type":"list",
       "member":{"shape":"SecurityGroupId"}

--- a/models/apis/s3/2006-03-01/api-2.json
+++ b/models/apis/s3/2006-03-01/api-2.json
@@ -5744,7 +5744,7 @@
     "ReplicationStatus":{
       "type":"string",
       "enum":[
-        "COMPLETED",
+        "COMPLETE",
         "PENDING",
         "FAILED",
         "REPLICA"


### PR DESCRIPTION
There seems to be a growing number of errors being found in the aws-sdk-go model files. I thought instead of adding to the list of edits needed to be made everytime we could patch them in the code generator.

The patch code fixes up the two already known about in S3 and ELB, the one mentioned in #109 and another I found in S3. It is relatively easy to add new patches. There are two patch operations available: replace and add. Currently they only work on leaf nodes of the json but that should suffice.