### PR TITLE
Moved MD5 calculation below setting of body for CreateBucket

### DIFF
--- a/Sources/AWSSDKSwift/Middlewares/S3/S3RequestMiddleware.swift
+++ b/Sources/AWSSDKSwift/Middlewares/S3/S3RequestMiddleware.swift
@@ -42,11 +42,6 @@ public struct S3RequestMiddleware: AWSRequestMiddleware {
                 }
                 request.url = URL(string: urlString)!
             }
-
-            if let data = try request.body.asData() {
-                let encoded = Data(md5(data)).base64EncodedString()
-                request.addValue(encoded, forHTTPHeaderField: "Content-MD5")
-            }
         }
 
         switch request.operation {
@@ -61,6 +56,11 @@ public struct S3RequestMiddleware: AWSRequestMiddleware {
 
         default:
             break
+        }
+
+        if let data = try request.body.asData() {
+            let encoded = Data(md5(data)).base64EncodedString()
+            request.addValue(encoded, forHTTPHeaderField: "Content-MD5")
         }
 
         return request


### PR DESCRIPTION
We are calculating an MD5 for the body of S3.CreateBucket(), and then changing the body almost straight away after. This moves the MD5 calculation to after the CreateBucket body has been altered.

It also now outside the check for whether we are running a GET operation, but with other code changes GET operations never have a body now, so this should be ok.