### PR TITLE
Fix S3.GetBucketLocation by editing response body

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -193,7 +193,7 @@ let package = Package(
         .library(name: "XRay", targets: ["XRay"])
     ],
     dependencies: [
-        .package(url: "https://github.com/swift-aws/aws-sdk-swift-core.git", .upToNextMinor(from: "3.1.1"))
+        .package(url: "https://github.com/swift-aws/aws-sdk-swift-core.git", .upToNextMinor(from: "3.2.0"))
     ],
     targets: [
         .target(name: "ACM", dependencies: ["AWSSDKSwiftCore"], path: "./Sources/AWSSDKSwift/Services/ACM"),

--- a/Sources/AWSSDKSwift/Middlewares/Glacier/GlacierRequestMiddleware.swift
+++ b/Sources/AWSSDKSwift/Middlewares/Glacier/GlacierRequestMiddleware.swift
@@ -3,7 +3,7 @@ import AWSSDKSwiftCore
 
 let MEGA_BYTE = 1024 * 1024
 
-public struct GlacierRequestMiddleware: AWSRequestMiddleware {
+public struct GlacierRequestMiddleware: AWSServiceMiddleware {
 
     let apiVersion: String
 

--- a/Sources/AWSSDKSwift/Middlewares/S3/S3RequestMiddleware.swift
+++ b/Sources/AWSSDKSwift/Middlewares/S3/S3RequestMiddleware.swift
@@ -1,7 +1,7 @@
 import Foundation
 import AWSSDKSwiftCore
 
-public struct S3RequestMiddleware: AWSRequestMiddleware {
+public struct S3RequestMiddleware: AWSServiceMiddleware {
 
     public init () {}
 
@@ -66,5 +66,20 @@ public struct S3RequestMiddleware: AWSRequestMiddleware {
         }
 
         return request
+    }
+    
+    
+    public func chain(responseBody: Body) throws -> Body {
+        switch responseBody {
+        case .xml(let element):
+            if element.name == "LocationConstraint" {
+                let parentElement = XML.Element(name: "BucketLocation")
+                parentElement.addChild(element)
+                return .xml(parentElement)
+            }
+        default:
+            break
+        }
+        return responseBody
     }
 }


### PR DESCRIPTION
Fixes https://github.com/swift-aws/aws-sdk-swift/issues/157
This pull request needs https://github.com/swift-aws/aws-sdk-swift-core/pull/106

Also
- renamed AWSRequestMiddleware to AWSServiceMiddleware
- S3 GET requests don't mangle the hostname if it isn't amazonaws.com as is done for all other requests