### PR TITLE
Add ability to remove items in CodeGenerator patch

### DIFF
--- a/CodeGenerator/Sources/CodeGenerator/patch.swift
+++ b/CodeGenerator/Sources/CodeGenerator/patch.swift
@@ -12,36 +12,36 @@ import SwiftyJSON
 // Patch operations
 //
 let servicePatches : [String: [Patch]] = [
-    // Backup clashes with a macOS framework, so need to rename the framework
     "Backup" : [
-        Patch(operation:.replace, entry:["serviceName"], value:"AWSBackup", originalValue:"Backup")
+        // Backup clashes with a macOS framework, so need to rename the framework
+        Patch(.replace, entry:["serviceName"], value:"AWSBackup", originalValue:"Backup")
     ],
-    // DirectoryService clashes with a macOS framework, so need to rename the framework
     "DirectoryService" : [
-        Patch(operation:.replace, entry:["serviceName"], value:"AWSDirectoryService", originalValue:"DirectoryService")
+        // DirectoryService clashes with a macOS framework, so need to rename the framework
+        Patch(.replace, entry:["serviceName"], value:"AWSDirectoryService", originalValue:"DirectoryService")
     ],
     "ECS" : [
-        Patch(operation:.add, entry:["shapes", "PropagateTags", "enum"], value:"NONE")
+        Patch(.add, entry:["shapes", "PropagateTags", "enum"], value:"NONE")
     ],
     "EC2" : [
-        Patch(operation:.replace, entry:["shapes", "PlatformValues", "enum", 0], value:"windows", originalValue:"Windows")
+        Patch(.replace, entry:["shapes", "PlatformValues", "enum", 0], value:"windows", originalValue:"Windows")
     ],
     "ELB" : [
-        Patch(operation:.replace, entry:["shapes", "SecurityGroupOwnerAlias", "type"], value:"integer", originalValue:"string")
+        Patch(.replace, entry:["shapes", "SecurityGroupOwnerAlias", "type"], value:"integer", originalValue:"string")
     ],
     "S3": [
-        Patch(operation:.replace, entry:["shapes","ReplicationStatus","enum",0], value:"COMPLETED", originalValue:"COMPLETE"),
-        Patch(operation:.replace, entry:["shapes","Size","type"], value:"long", originalValue:"integer"),
-        Patch(operation:.add, entry:["shapes", "BucketLocationConstraint", "enum"], value:"us-east-2"),
-        Patch(operation:.add, entry:["shapes", "BucketLocationConstraint", "enum"], value:"eu-west-2"),
-        Patch(operation:.add, entry:["shapes", "BucketLocationConstraint", "enum"], value:"eu-west-3"),
-        Patch(operation:.add, entry:["shapes", "BucketLocationConstraint", "enum"], value:"eu-north-1"),
-        Patch(operation:.add, entry:["shapes", "BucketLocationConstraint", "enum"], value:"ap-east-1"),
-        Patch(operation:.add, entry:["shapes", "BucketLocationConstraint", "enum"], value:"ap-northeast-2"),
-        Patch(operation:.add, entry:["shapes", "BucketLocationConstraint", "enum"], value:"ap-northeast-3"),
-        Patch(operation:.add, entry:["shapes", "BucketLocationConstraint", "enum"], value:"ca-central-1"),
-        Patch(operation:.add, entry:["shapes", "BucketLocationConstraint", "enum"], value:"cn-northwest-1"),
-        Patch(operation:.add, entry:["shapes", "BucketLocationConstraint", "enum"], value:"me-south-1")
+        Patch(.replace, entry:["shapes","ReplicationStatus","enum",0], value:"COMPLETED", originalValue:"COMPLETE"),
+        Patch(.replace, entry:["shapes","Size","type"], value:"long", originalValue:"integer"),
+        Patch(.add, entry:["shapes", "BucketLocationConstraint", "enum"], value:"us-east-2"),
+        Patch(.add, entry:["shapes", "BucketLocationConstraint", "enum"], value:"eu-west-2"),
+        Patch(.add, entry:["shapes", "BucketLocationConstraint", "enum"], value:"eu-west-3"),
+        Patch(.add, entry:["shapes", "BucketLocationConstraint", "enum"], value:"eu-north-1"),
+        Patch(.add, entry:["shapes", "BucketLocationConstraint", "enum"], value:"ap-east-1"),
+        Patch(.add, entry:["shapes", "BucketLocationConstraint", "enum"], value:"ap-northeast-2"),
+        Patch(.add, entry:["shapes", "BucketLocationConstraint", "enum"], value:"ap-northeast-3"),
+        Patch(.add, entry:["shapes", "BucketLocationConstraint", "enum"], value:"ca-central-1"),
+        Patch(.add, entry:["shapes", "BucketLocationConstraint", "enum"], value:"cn-northwest-1"),
+        Patch(.add, entry:["shapes", "BucketLocationConstraint", "enum"], value:"me-south-1")
     ]
 ]
 
@@ -50,9 +50,10 @@ struct Patch {
     enum Operation {
         case replace
         case add
+        case remove
     }
 
-    init(operation: Operation, entry: [JSONSubscriptType], value: String, originalValue: String? = nil) {
+    init(_ operation: Operation, entry: [JSONSubscriptType], value: String, originalValue: String? = nil) {
         self.operation = operation
         self.entry = entry
         self.value = value
@@ -74,34 +75,52 @@ func patch(_ apiJSON: JSON) -> JSON {
     for patch in patches {
         let field = patchedJSON[patch.entry]
         guard field != JSON.null else {
-            print("Attempting to patch field \(patch.entry) that doesn't eixst")
-            exit(-1)
+            fatalError("Attempting to patch field \(patch.entry) that doesn't eixst")
         }
 
         switch patch.operation {
         case .replace:
             if let originalValue = patch.originalValue {
                 guard originalValue.description == field.stringValue else {
-                    print("Found an unexpected value while patching \(patch.entry). Expected \"\(originalValue)\", got \"\(field.stringValue)\"")
-                    exit(-1)
+                    fatalError("Found an unexpected value while patching \(patch.entry). Expected \"\(originalValue)\", got \"\(field.stringValue)\"")
                 }
             }
 
             patchedJSON[patch.entry].object = patch.value
+            
         case .add:
             guard let array = field.array else {
-                print("Attempting to add a field to \(patch.entry) that cannot be added to.")
-                exit(-1)
+                fatalError("Attempting to add a field to \(patch.entry) that cannot be added to.")
             }
 
             guard array.first(where:{$0.stringValue == patch.value.description}) == nil else {
-                print("Attempting to add field \"\(patch.value)\" to array \(patch.entry) that aleady exists.")
-                exit(-1)
+                fatalError("Attempting to add field \"\(patch.value)\" to array \(patch.entry) that aleady exists.")
             }
 
             var newArray = field.arrayObject!
             newArray.append(patch.value)
             patchedJSON[patch.entry].arrayObject = newArray
+
+        case .remove:
+            if let array = field.array {
+                guard let firstIndex = array.firstIndex(where:{$0.stringValue == patch.value.description}) else {
+                    fatalError("Attempting to remove field \"\(patch.value)\" from array \(patch.entry) that doesn't exists.")
+                }
+                
+                var newArray = field.arrayObject!
+                newArray.remove(at: firstIndex)
+                patchedJSON[patch.entry].arrayObject = newArray
+            } else if let dictionary = field.dictionary {
+                guard dictionary[patch.value.description] != nil else {
+                    fatalError("Attempting to remove field \"\(patch.value)\" from dictionary \(patch.entry) that doesn't exists.")
+                }
+                
+                var newDictionary = field.dictionaryObject!
+                newDictionary[patch.value.description] = nil
+                patchedJSON[patch.entry].dictionaryObject = newDictionary
+            } else {
+                fatalError("Attempting to remove a field from \(patch.entry) that cannot be removed from.")
+            }
         }
     }
     return patchedJSON

--- a/CodeGenerator/Sources/CodeGenerator/patch.swift
+++ b/CodeGenerator/Sources/CodeGenerator/patch.swift
@@ -29,6 +29,11 @@ let servicePatches : [String: [Patch]] = [
     "ELB" : [
         Patch(.replace, entry:["shapes", "SecurityGroupOwnerAlias", "type"], value:"integer", originalValue:"string")
     ],
+    "Route53": [
+        Patch(.remove, entry:["shapes", "ListHealthChecksResponse", "required"], value:"Marker"),
+        Patch(.remove, entry:["shapes", "ListHostedZonesResponse", "required"], value:"Marker"),
+        Patch(.remove, entry:["shapes", "ListReusableDelegationSetsResponse", "required"], value:"Marker")
+    ],
     "S3": [
         Patch(.replace, entry:["shapes","ReplicationStatus","enum",0], value:"COMPLETED", originalValue:"COMPLETE"),
         Patch(.replace, entry:["shapes","Size","type"], value:"long", originalValue:"integer"),

--- a/Sources/AWSSDKSwift/Services/Route53/Route53_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/Route53/Route53_Shapes.swift
@@ -2392,7 +2392,7 @@ extension Route53 {
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "HealthChecks", required: true, type: .list, encoding: .list(member:"HealthCheck")), 
             AWSShapeMember(label: "IsTruncated", required: true, type: .boolean), 
-            AWSShapeMember(label: "Marker", required: true, type: .string), 
+            AWSShapeMember(label: "Marker", required: false, type: .string), 
             AWSShapeMember(label: "MaxItems", required: true, type: .string), 
             AWSShapeMember(label: "NextMarker", required: false, type: .string)
         ]
@@ -2402,13 +2402,13 @@ extension Route53 {
         /// A flag that indicates whether there are more health checks to be listed. If the response was truncated, you can get the next group of health checks by submitting another ListHealthChecks request and specifying the value of NextMarker in the marker parameter.
         public let isTruncated: Bool
         /// For the second and subsequent calls to ListHealthChecks, Marker is the value that you specified for the marker parameter in the previous request.
-        public let marker: String
+        public let marker: String?
         /// The value that you specified for the maxitems parameter in the call to ListHealthChecks that produced the current response.
         public let maxItems: String
         /// If IsTruncated is true, the value of NextMarker identifies the first health check that Amazon Route 53 returns if you submit another ListHealthChecks request and specify the value of NextMarker in the marker parameter.
         public let nextMarker: String?
 
-        public init(healthChecks: [HealthCheck], isTruncated: Bool, marker: String, maxItems: String, nextMarker: String? = nil) {
+        public init(healthChecks: [HealthCheck], isTruncated: Bool, marker: String? = nil, maxItems: String, nextMarker: String? = nil) {
             self.healthChecks = healthChecks
             self.isTruncated = isTruncated
             self.marker = marker
@@ -2540,7 +2540,7 @@ extension Route53 {
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "HostedZones", required: true, type: .list, encoding: .list(member:"HostedZone")), 
             AWSShapeMember(label: "IsTruncated", required: true, type: .boolean), 
-            AWSShapeMember(label: "Marker", required: true, type: .string), 
+            AWSShapeMember(label: "Marker", required: false, type: .string), 
             AWSShapeMember(label: "MaxItems", required: true, type: .string), 
             AWSShapeMember(label: "NextMarker", required: false, type: .string)
         ]
@@ -2550,13 +2550,13 @@ extension Route53 {
         /// A flag indicating whether there are more hosted zones to be listed. If the response was truncated, you can get more hosted zones by submitting another ListHostedZones request and specifying the value of NextMarker in the marker parameter.
         public let isTruncated: Bool
         /// For the second and subsequent calls to ListHostedZones, Marker is the value that you specified for the marker parameter in the request that produced the current response.
-        public let marker: String
+        public let marker: String?
         /// The value that you specified for the maxitems parameter in the call to ListHostedZones that produced the current response.
         public let maxItems: String
         /// If IsTruncated is true, the value of NextMarker identifies the first hosted zone in the next group of hosted zones. Submit another ListHostedZones request, and specify the value of NextMarker from the response in the marker parameter. This element is present only if IsTruncated is true.
         public let nextMarker: String?
 
-        public init(hostedZones: [HostedZone], isTruncated: Bool, marker: String, maxItems: String, nextMarker: String? = nil) {
+        public init(hostedZones: [HostedZone], isTruncated: Bool, marker: String? = nil, maxItems: String, nextMarker: String? = nil) {
             self.hostedZones = hostedZones
             self.isTruncated = isTruncated
             self.marker = marker
@@ -2743,7 +2743,7 @@ extension Route53 {
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "DelegationSets", required: true, type: .list, encoding: .list(member:"DelegationSet")), 
             AWSShapeMember(label: "IsTruncated", required: true, type: .boolean), 
-            AWSShapeMember(label: "Marker", required: true, type: .string), 
+            AWSShapeMember(label: "Marker", required: false, type: .string), 
             AWSShapeMember(label: "MaxItems", required: true, type: .string), 
             AWSShapeMember(label: "NextMarker", required: false, type: .string)
         ]
@@ -2753,13 +2753,13 @@ extension Route53 {
         /// A flag that indicates whether there are more reusable delegation sets to be listed.
         public let isTruncated: Bool
         /// For the second and subsequent calls to ListReusableDelegationSets, Marker is the value that you specified for the marker parameter in the request that produced the current response.
-        public let marker: String
+        public let marker: String?
         /// The value that you specified for the maxitems parameter in the call to ListReusableDelegationSets that produced the current response.
         public let maxItems: String
         /// If IsTruncated is true, the value of NextMarker identifies the next reusable delegation set that Amazon Route 53 will return if you submit another ListReusableDelegationSets request and specify the value of NextMarker in the marker parameter.
         public let nextMarker: String?
 
-        public init(delegationSets: [DelegationSet], isTruncated: Bool, marker: String, maxItems: String, nextMarker: String? = nil) {
+        public init(delegationSets: [DelegationSet], isTruncated: Bool, marker: String? = nil, maxItems: String, nextMarker: String? = nil) {
             self.delegationSets = delegationSets
             self.isTruncated = isTruncated
             self.marker = marker


### PR DESCRIPTION
You can use it to remove items from arrays or dictionaries in the model files.
Use it to remove entries from required array of a number of response shapes in Route53