### PR TITLE
AWSErrorType conforms with CustomStringConvertible

### DIFF
--- a/CodeGenerator/Templates/error.stencil
+++ b/CodeGenerator/Templates/error.stencil
@@ -24,3 +24,14 @@ extension {{errorName}} {
         }
     }
 }
+
+extension {{errorName}} : CustomStringConvertible {
+    public var description : String {
+        switch self {
+{%for error in errors %}
+        case .{{error.enum}}(let message):
+            return "{{error.string}}: \(message ?? "")"
+{% endfor %}
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/ACM/ACM_Error.swift
+++ b/Sources/AWSSDKSwift/Services/ACM/ACM_Error.swift
@@ -48,3 +48,30 @@ extension ACMErrorType {
         }
     }
 }
+
+extension ACMErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .invalidArgsException(let message):
+            return "InvalidArgsException: \(message ?? "")"
+        case .invalidArnException(let message):
+            return "InvalidArnException: \(message ?? "")"
+        case .invalidDomainValidationOptionsException(let message):
+            return "InvalidDomainValidationOptionsException: \(message ?? "")"
+        case .invalidStateException(let message):
+            return "InvalidStateException: \(message ?? "")"
+        case .invalidTagException(let message):
+            return "InvalidTagException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .requestInProgressException(let message):
+            return "RequestInProgressException: \(message ?? "")"
+        case .resourceInUseException(let message):
+            return "ResourceInUseException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .tooManyTagsException(let message):
+            return "TooManyTagsException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/ACMPCA/ACMPCA_Error.swift
+++ b/Sources/AWSSDKSwift/Services/ACMPCA/ACMPCA_Error.swift
@@ -72,3 +72,46 @@ extension ACMPCAErrorType {
         }
     }
 }
+
+extension ACMPCAErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .certificateMismatchException(let message):
+            return "CertificateMismatchException: \(message ?? "")"
+        case .concurrentModificationException(let message):
+            return "ConcurrentModificationException: \(message ?? "")"
+        case .invalidArgsException(let message):
+            return "InvalidArgsException: \(message ?? "")"
+        case .invalidArnException(let message):
+            return "InvalidArnException: \(message ?? "")"
+        case .invalidNextTokenException(let message):
+            return "InvalidNextTokenException: \(message ?? "")"
+        case .invalidPolicyException(let message):
+            return "InvalidPolicyException: \(message ?? "")"
+        case .invalidRequestException(let message):
+            return "InvalidRequestException: \(message ?? "")"
+        case .invalidStateException(let message):
+            return "InvalidStateException: \(message ?? "")"
+        case .invalidTagException(let message):
+            return "InvalidTagException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .malformedCSRException(let message):
+            return "MalformedCSRException: \(message ?? "")"
+        case .malformedCertificateException(let message):
+            return "MalformedCertificateException: \(message ?? "")"
+        case .permissionAlreadyExistsException(let message):
+            return "PermissionAlreadyExistsException: \(message ?? "")"
+        case .requestAlreadyProcessedException(let message):
+            return "RequestAlreadyProcessedException: \(message ?? "")"
+        case .requestFailedException(let message):
+            return "RequestFailedException: \(message ?? "")"
+        case .requestInProgressException(let message):
+            return "RequestInProgressException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .tooManyTagsException(let message):
+            return "TooManyTagsException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/APIGateway/APIGateway_Error.swift
+++ b/Sources/AWSSDKSwift/Services/APIGateway/APIGateway_Error.swift
@@ -39,3 +39,24 @@ extension APIGatewayErrorType {
         }
     }
 }
+
+extension APIGatewayErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .badRequestException(let message):
+            return "BadRequestException: \(message ?? "")"
+        case .conflictException(let message):
+            return "ConflictException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .notFoundException(let message):
+            return "NotFoundException: \(message ?? "")"
+        case .serviceUnavailableException(let message):
+            return "ServiceUnavailableException: \(message ?? "")"
+        case .tooManyRequestsException(let message):
+            return "TooManyRequestsException: \(message ?? "")"
+        case .unauthorizedException(let message):
+            return "UnauthorizedException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/AWSBackup/AWSBackup_Error.swift
+++ b/Sources/AWSSDKSwift/Services/AWSBackup/AWSBackup_Error.swift
@@ -42,3 +42,26 @@ extension AWSBackupErrorType {
         }
     }
 }
+
+extension AWSBackupErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .alreadyExistsException(let message):
+            return "AlreadyExistsException: \(message ?? "")"
+        case .dependencyFailureException(let message):
+            return "DependencyFailureException: \(message ?? "")"
+        case .invalidParameterValueException(let message):
+            return "InvalidParameterValueException: \(message ?? "")"
+        case .invalidRequestException(let message):
+            return "InvalidRequestException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .missingParameterValueException(let message):
+            return "MissingParameterValueException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .serviceUnavailableException(let message):
+            return "ServiceUnavailableException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/AWSDirectoryService/AWSDirectoryService_Error.swift
+++ b/Sources/AWSSDKSwift/Services/AWSDirectoryService/AWSDirectoryService_Error.swift
@@ -87,3 +87,56 @@ extension AWSDirectoryServiceErrorType {
         }
     }
 }
+
+extension AWSDirectoryServiceErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .accessDeniedException(let message):
+            return "AccessDeniedException: \(message ?? "")"
+        case .authenticationFailedException(let message):
+            return "AuthenticationFailedException: \(message ?? "")"
+        case .clientException(let message):
+            return "ClientException: \(message ?? "")"
+        case .directoryAlreadySharedException(let message):
+            return "DirectoryAlreadySharedException: \(message ?? "")"
+        case .directoryLimitExceededException(let message):
+            return "DirectoryLimitExceededException: \(message ?? "")"
+        case .directoryNotSharedException(let message):
+            return "DirectoryNotSharedException: \(message ?? "")"
+        case .directoryUnavailableException(let message):
+            return "DirectoryUnavailableException: \(message ?? "")"
+        case .domainControllerLimitExceededException(let message):
+            return "DomainControllerLimitExceededException: \(message ?? "")"
+        case .entityAlreadyExistsException(let message):
+            return "EntityAlreadyExistsException: \(message ?? "")"
+        case .entityDoesNotExistException(let message):
+            return "EntityDoesNotExistException: \(message ?? "")"
+        case .insufficientPermissionsException(let message):
+            return "InsufficientPermissionsException: \(message ?? "")"
+        case .invalidNextTokenException(let message):
+            return "InvalidNextTokenException: \(message ?? "")"
+        case .invalidParameterException(let message):
+            return "InvalidParameterException: \(message ?? "")"
+        case .invalidPasswordException(let message):
+            return "InvalidPasswordException: \(message ?? "")"
+        case .invalidTargetException(let message):
+            return "InvalidTargetException: \(message ?? "")"
+        case .ipRouteLimitExceededException(let message):
+            return "IpRouteLimitExceededException: \(message ?? "")"
+        case .organizationsException(let message):
+            return "OrganizationsException: \(message ?? "")"
+        case .serviceException(let message):
+            return "ServiceException: \(message ?? "")"
+        case .shareLimitExceededException(let message):
+            return "ShareLimitExceededException: \(message ?? "")"
+        case .snapshotLimitExceededException(let message):
+            return "SnapshotLimitExceededException: \(message ?? "")"
+        case .tagLimitExceededException(let message):
+            return "TagLimitExceededException: \(message ?? "")"
+        case .unsupportedOperationException(let message):
+            return "UnsupportedOperationException: \(message ?? "")"
+        case .userDoesNotExistException(let message):
+            return "UserDoesNotExistException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/AlexaForBusiness/AlexaForBusiness_Error.swift
+++ b/Sources/AWSSDKSwift/Services/AlexaForBusiness/AlexaForBusiness_Error.swift
@@ -63,3 +63,40 @@ extension AlexaForBusinessErrorType {
         }
     }
 }
+
+extension AlexaForBusinessErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .alreadyExistsException(let message):
+            return "AlreadyExistsException: \(message ?? "")"
+        case .concurrentModificationException(let message):
+            return "ConcurrentModificationException: \(message ?? "")"
+        case .deviceNotRegisteredException(let message):
+            return "DeviceNotRegisteredException: \(message ?? "")"
+        case .invalidCertificateAuthorityException(let message):
+            return "InvalidCertificateAuthorityException: \(message ?? "")"
+        case .invalidDeviceException(let message):
+            return "InvalidDeviceException: \(message ?? "")"
+        case .invalidSecretsManagerResourceException(let message):
+            return "InvalidSecretsManagerResourceException: \(message ?? "")"
+        case .invalidServiceLinkedRoleStateException(let message):
+            return "InvalidServiceLinkedRoleStateException: \(message ?? "")"
+        case .invalidUserStatusException(let message):
+            return "InvalidUserStatusException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .nameInUseException(let message):
+            return "NameInUseException: \(message ?? "")"
+        case .notFoundException(let message):
+            return "NotFoundException: \(message ?? "")"
+        case .resourceAssociatedException(let message):
+            return "ResourceAssociatedException: \(message ?? "")"
+        case .resourceInUseException(let message):
+            return "ResourceInUseException: \(message ?? "")"
+        case .skillNotLinkedException(let message):
+            return "SkillNotLinkedException: \(message ?? "")"
+        case .unauthorizedException(let message):
+            return "UnauthorizedException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Amplify/Amplify_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Amplify/Amplify_Error.swift
@@ -39,3 +39,24 @@ extension AmplifyErrorType {
         }
     }
 }
+
+extension AmplifyErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .badRequestException(let message):
+            return "BadRequestException: \(message ?? "")"
+        case .dependentServiceFailureException(let message):
+            return "DependentServiceFailureException: \(message ?? "")"
+        case .internalFailureException(let message):
+            return "InternalFailureException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .notFoundException(let message):
+            return "NotFoundException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .unauthorizedException(let message):
+            return "UnauthorizedException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/ApiGatewayManagementApi/ApiGatewayManagementApi_Error.swift
+++ b/Sources/AWSSDKSwift/Services/ApiGatewayManagementApi/ApiGatewayManagementApi_Error.swift
@@ -30,3 +30,18 @@ extension ApiGatewayManagementApiErrorType {
         }
     }
 }
+
+extension ApiGatewayManagementApiErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .forbiddenException(let message):
+            return "ForbiddenException: \(message ?? "")"
+        case .goneException(let message):
+            return "GoneException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .payloadTooLargeException(let message):
+            return "PayloadTooLargeException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/ApiGatewayV2/ApiGatewayV2_Error.swift
+++ b/Sources/AWSSDKSwift/Services/ApiGatewayV2/ApiGatewayV2_Error.swift
@@ -30,3 +30,18 @@ extension ApiGatewayV2ErrorType {
         }
     }
 }
+
+extension ApiGatewayV2ErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .badRequestException(let message):
+            return "BadRequestException: \(message ?? "")"
+        case .conflictException(let message):
+            return "ConflictException: \(message ?? "")"
+        case .notFoundException(let message):
+            return "NotFoundException: \(message ?? "")"
+        case .tooManyRequestsException(let message):
+            return "TooManyRequestsException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/AppMesh/AppMesh_Error.swift
+++ b/Sources/AWSSDKSwift/Services/AppMesh/AppMesh_Error.swift
@@ -48,3 +48,30 @@ extension AppMeshErrorType {
         }
     }
 }
+
+extension AppMeshErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .badRequestException(let message):
+            return "BadRequestException: \(message ?? "")"
+        case .conflictException(let message):
+            return "ConflictException: \(message ?? "")"
+        case .forbiddenException(let message):
+            return "ForbiddenException: \(message ?? "")"
+        case .internalServerErrorException(let message):
+            return "InternalServerErrorException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .notFoundException(let message):
+            return "NotFoundException: \(message ?? "")"
+        case .resourceInUseException(let message):
+            return "ResourceInUseException: \(message ?? "")"
+        case .serviceUnavailableException(let message):
+            return "ServiceUnavailableException: \(message ?? "")"
+        case .tooManyRequestsException(let message):
+            return "TooManyRequestsException: \(message ?? "")"
+        case .tooManyTagsException(let message):
+            return "TooManyTagsException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/AppStream/AppStream_Error.swift
+++ b/Sources/AWSSDKSwift/Services/AppStream/AppStream_Error.swift
@@ -51,3 +51,32 @@ extension AppStreamErrorType {
         }
     }
 }
+
+extension AppStreamErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .concurrentModificationException(let message):
+            return "ConcurrentModificationException: \(message ?? "")"
+        case .incompatibleImageException(let message):
+            return "IncompatibleImageException: \(message ?? "")"
+        case .invalidAccountStatusException(let message):
+            return "InvalidAccountStatusException: \(message ?? "")"
+        case .invalidParameterCombinationException(let message):
+            return "InvalidParameterCombinationException: \(message ?? "")"
+        case .invalidRoleException(let message):
+            return "InvalidRoleException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .operationNotPermittedException(let message):
+            return "OperationNotPermittedException: \(message ?? "")"
+        case .resourceAlreadyExistsException(let message):
+            return "ResourceAlreadyExistsException: \(message ?? "")"
+        case .resourceInUseException(let message):
+            return "ResourceInUseException: \(message ?? "")"
+        case .resourceNotAvailableException(let message):
+            return "ResourceNotAvailableException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/AppSync/AppSync_Error.swift
+++ b/Sources/AWSSDKSwift/Services/AppSync/AppSync_Error.swift
@@ -51,3 +51,32 @@ extension AppSyncErrorType {
         }
     }
 }
+
+extension AppSyncErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .accessDeniedException(let message):
+            return "AccessDeniedException: \(message ?? "")"
+        case .apiKeyLimitExceededException(let message):
+            return "ApiKeyLimitExceededException: \(message ?? "")"
+        case .apiKeyValidityOutOfBoundsException(let message):
+            return "ApiKeyValidityOutOfBoundsException: \(message ?? "")"
+        case .apiLimitExceededException(let message):
+            return "ApiLimitExceededException: \(message ?? "")"
+        case .badRequestException(let message):
+            return "BadRequestException: \(message ?? "")"
+        case .concurrentModificationException(let message):
+            return "ConcurrentModificationException: \(message ?? "")"
+        case .graphQLSchemaException(let message):
+            return "GraphQLSchemaException: \(message ?? "")"
+        case .internalFailureException(let message):
+            return "InternalFailureException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .notFoundException(let message):
+            return "NotFoundException: \(message ?? "")"
+        case .unauthorizedException(let message):
+            return "UnauthorizedException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/ApplicationAutoScaling/ApplicationAutoScaling_Error.swift
+++ b/Sources/AWSSDKSwift/Services/ApplicationAutoScaling/ApplicationAutoScaling_Error.swift
@@ -39,3 +39,24 @@ extension ApplicationAutoScalingErrorType {
         }
     }
 }
+
+extension ApplicationAutoScalingErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .concurrentUpdateException(let message):
+            return "ConcurrentUpdateException: \(message ?? "")"
+        case .failedResourceAccessException(let message):
+            return "FailedResourceAccessException: \(message ?? "")"
+        case .internalServiceException(let message):
+            return "InternalServiceException: \(message ?? "")"
+        case .invalidNextTokenException(let message):
+            return "InvalidNextTokenException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .objectNotFoundException(let message):
+            return "ObjectNotFoundException: \(message ?? "")"
+        case .validationException(let message):
+            return "ValidationException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/ApplicationDiscoveryService/ApplicationDiscoveryService_Error.swift
+++ b/Sources/AWSSDKSwift/Services/ApplicationDiscoveryService/ApplicationDiscoveryService_Error.swift
@@ -42,3 +42,26 @@ extension ApplicationDiscoveryServiceErrorType {
         }
     }
 }
+
+extension ApplicationDiscoveryServiceErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .authorizationErrorException(let message):
+            return "AuthorizationErrorException: \(message ?? "")"
+        case .conflictErrorException(let message):
+            return "ConflictErrorException: \(message ?? "")"
+        case .invalidParameterException(let message):
+            return "InvalidParameterException: \(message ?? "")"
+        case .invalidParameterValueException(let message):
+            return "InvalidParameterValueException: \(message ?? "")"
+        case .operationNotPermittedException(let message):
+            return "OperationNotPermittedException: \(message ?? "")"
+        case .resourceInUseException(let message):
+            return "ResourceInUseException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .serverInternalErrorException(let message):
+            return "ServerInternalErrorException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/ApplicationInsights/ApplicationInsights_Error.swift
+++ b/Sources/AWSSDKSwift/Services/ApplicationInsights/ApplicationInsights_Error.swift
@@ -33,3 +33,20 @@ extension ApplicationInsightsErrorType {
         }
     }
 }
+
+extension ApplicationInsightsErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .badRequestException(let message):
+            return "BadRequestException: \(message ?? "")"
+        case .internalServerException(let message):
+            return "InternalServerException: \(message ?? "")"
+        case .resourceInUseException(let message):
+            return "ResourceInUseException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .validationException(let message):
+            return "ValidationException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Athena/Athena_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Athena/Athena_Error.swift
@@ -30,3 +30,18 @@ extension AthenaErrorType {
         }
     }
 }
+
+extension AthenaErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .internalServerException(let message):
+            return "InternalServerException: \(message ?? "")"
+        case .invalidRequestException(let message):
+            return "InvalidRequestException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .tooManyRequestsException(let message):
+            return "TooManyRequestsException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/AutoScaling/AutoScaling_Error.swift
+++ b/Sources/AWSSDKSwift/Services/AutoScaling/AutoScaling_Error.swift
@@ -39,3 +39,24 @@ extension AutoScalingErrorType {
         }
     }
 }
+
+extension AutoScalingErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .alreadyExistsFault(let message):
+            return "AlreadyExistsFault: \(message ?? "")"
+        case .invalidNextToken(let message):
+            return "InvalidNextToken: \(message ?? "")"
+        case .limitExceededFault(let message):
+            return "LimitExceededFault: \(message ?? "")"
+        case .resourceContentionFault(let message):
+            return "ResourceContentionFault: \(message ?? "")"
+        case .resourceInUseFault(let message):
+            return "ResourceInUseFault: \(message ?? "")"
+        case .scalingActivityInProgressFault(let message):
+            return "ScalingActivityInProgressFault: \(message ?? "")"
+        case .serviceLinkedRoleFailure(let message):
+            return "ServiceLinkedRoleFailure: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/AutoScalingPlans/AutoScalingPlans_Error.swift
+++ b/Sources/AWSSDKSwift/Services/AutoScalingPlans/AutoScalingPlans_Error.swift
@@ -36,3 +36,22 @@ extension AutoScalingPlansErrorType {
         }
     }
 }
+
+extension AutoScalingPlansErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .concurrentUpdateException(let message):
+            return "ConcurrentUpdateException: \(message ?? "")"
+        case .internalServiceException(let message):
+            return "InternalServiceException: \(message ?? "")"
+        case .invalidNextTokenException(let message):
+            return "InvalidNextTokenException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .objectNotFoundException(let message):
+            return "ObjectNotFoundException: \(message ?? "")"
+        case .validationException(let message):
+            return "ValidationException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Batch/Batch_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Batch/Batch_Error.swift
@@ -24,3 +24,14 @@ extension BatchErrorType {
         }
     }
 }
+
+extension BatchErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .clientException(let message):
+            return "ClientException: \(message ?? "")"
+        case .serverException(let message):
+            return "ServerException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Budgets/Budgets_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Budgets/Budgets_Error.swift
@@ -39,3 +39,24 @@ extension BudgetsErrorType {
         }
     }
 }
+
+extension BudgetsErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .creationLimitExceededException(let message):
+            return "CreationLimitExceededException: \(message ?? "")"
+        case .duplicateRecordException(let message):
+            return "DuplicateRecordException: \(message ?? "")"
+        case .expiredNextTokenException(let message):
+            return "ExpiredNextTokenException: \(message ?? "")"
+        case .internalErrorException(let message):
+            return "InternalErrorException: \(message ?? "")"
+        case .invalidNextTokenException(let message):
+            return "InvalidNextTokenException: \(message ?? "")"
+        case .invalidParameterException(let message):
+            return "InvalidParameterException: \(message ?? "")"
+        case .notFoundException(let message):
+            return "NotFoundException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Chime/Chime_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Chime/Chime_Error.swift
@@ -48,3 +48,30 @@ extension ChimeErrorType {
         }
     }
 }
+
+extension ChimeErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .badRequestException(let message):
+            return "BadRequestException: \(message ?? "")"
+        case .conflictException(let message):
+            return "ConflictException: \(message ?? "")"
+        case .forbiddenException(let message):
+            return "ForbiddenException: \(message ?? "")"
+        case .notFoundException(let message):
+            return "NotFoundException: \(message ?? "")"
+        case .resourceLimitExceededException(let message):
+            return "ResourceLimitExceededException: \(message ?? "")"
+        case .serviceFailureException(let message):
+            return "ServiceFailureException: \(message ?? "")"
+        case .serviceUnavailableException(let message):
+            return "ServiceUnavailableException: \(message ?? "")"
+        case .throttledClientException(let message):
+            return "ThrottledClientException: \(message ?? "")"
+        case .unauthorizedClientException(let message):
+            return "UnauthorizedClientException: \(message ?? "")"
+        case .unprocessableEntityException(let message):
+            return "UnprocessableEntityException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Cloud9/Cloud9_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Cloud9/Cloud9_Error.swift
@@ -39,3 +39,24 @@ extension Cloud9ErrorType {
         }
     }
 }
+
+extension Cloud9ErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .badRequestException(let message):
+            return "BadRequestException: \(message ?? "")"
+        case .conflictException(let message):
+            return "ConflictException: \(message ?? "")"
+        case .forbiddenException(let message):
+            return "ForbiddenException: \(message ?? "")"
+        case .internalServerErrorException(let message):
+            return "InternalServerErrorException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .notFoundException(let message):
+            return "NotFoundException: \(message ?? "")"
+        case .tooManyRequestsException(let message):
+            return "TooManyRequestsException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/CloudDirectory/CloudDirectory_Error.swift
+++ b/Sources/AWSSDKSwift/Services/CloudDirectory/CloudDirectory_Error.swift
@@ -123,3 +123,80 @@ extension CloudDirectoryErrorType {
         }
     }
 }
+
+extension CloudDirectoryErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .accessDeniedException(let message):
+            return "AccessDeniedException: \(message ?? "")"
+        case .batchWriteException(let message):
+            return "BatchWriteException: \(message ?? "")"
+        case .cannotListParentOfRootException(let message):
+            return "CannotListParentOfRootException: \(message ?? "")"
+        case .directoryAlreadyExistsException(let message):
+            return "DirectoryAlreadyExistsException: \(message ?? "")"
+        case .directoryDeletedException(let message):
+            return "DirectoryDeletedException: \(message ?? "")"
+        case .directoryNotDisabledException(let message):
+            return "DirectoryNotDisabledException: \(message ?? "")"
+        case .directoryNotEnabledException(let message):
+            return "DirectoryNotEnabledException: \(message ?? "")"
+        case .facetAlreadyExistsException(let message):
+            return "FacetAlreadyExistsException: \(message ?? "")"
+        case .facetInUseException(let message):
+            return "FacetInUseException: \(message ?? "")"
+        case .facetNotFoundException(let message):
+            return "FacetNotFoundException: \(message ?? "")"
+        case .facetValidationException(let message):
+            return "FacetValidationException: \(message ?? "")"
+        case .incompatibleSchemaException(let message):
+            return "IncompatibleSchemaException: \(message ?? "")"
+        case .indexedAttributeMissingException(let message):
+            return "IndexedAttributeMissingException: \(message ?? "")"
+        case .internalServiceException(let message):
+            return "InternalServiceException: \(message ?? "")"
+        case .invalidArnException(let message):
+            return "InvalidArnException: \(message ?? "")"
+        case .invalidAttachmentException(let message):
+            return "InvalidAttachmentException: \(message ?? "")"
+        case .invalidFacetUpdateException(let message):
+            return "InvalidFacetUpdateException: \(message ?? "")"
+        case .invalidNextTokenException(let message):
+            return "InvalidNextTokenException: \(message ?? "")"
+        case .invalidRuleException(let message):
+            return "InvalidRuleException: \(message ?? "")"
+        case .invalidSchemaDocException(let message):
+            return "InvalidSchemaDocException: \(message ?? "")"
+        case .invalidTaggingRequestException(let message):
+            return "InvalidTaggingRequestException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .linkNameAlreadyInUseException(let message):
+            return "LinkNameAlreadyInUseException: \(message ?? "")"
+        case .notIndexException(let message):
+            return "NotIndexException: \(message ?? "")"
+        case .notNodeException(let message):
+            return "NotNodeException: \(message ?? "")"
+        case .notPolicyException(let message):
+            return "NotPolicyException: \(message ?? "")"
+        case .objectAlreadyDetachedException(let message):
+            return "ObjectAlreadyDetachedException: \(message ?? "")"
+        case .objectNotDetachedException(let message):
+            return "ObjectNotDetachedException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .retryableConflictException(let message):
+            return "RetryableConflictException: \(message ?? "")"
+        case .schemaAlreadyExistsException(let message):
+            return "SchemaAlreadyExistsException: \(message ?? "")"
+        case .schemaAlreadyPublishedException(let message):
+            return "SchemaAlreadyPublishedException: \(message ?? "")"
+        case .stillContainsLinksException(let message):
+            return "StillContainsLinksException: \(message ?? "")"
+        case .unsupportedIndexTypeException(let message):
+            return "UnsupportedIndexTypeException: \(message ?? "")"
+        case .validationException(let message):
+            return "ValidationException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/CloudFormation/CloudFormation_Error.swift
+++ b/Sources/AWSSDKSwift/Services/CloudFormation/CloudFormation_Error.swift
@@ -66,3 +66,42 @@ extension CloudFormationErrorType {
         }
     }
 }
+
+extension CloudFormationErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .alreadyExistsException(let message):
+            return "AlreadyExistsException: \(message ?? "")"
+        case .changeSetNotFoundException(let message):
+            return "ChangeSetNotFoundException: \(message ?? "")"
+        case .createdButModifiedException(let message):
+            return "CreatedButModifiedException: \(message ?? "")"
+        case .insufficientCapabilitiesException(let message):
+            return "InsufficientCapabilitiesException: \(message ?? "")"
+        case .invalidChangeSetStatusException(let message):
+            return "InvalidChangeSetStatusException: \(message ?? "")"
+        case .invalidOperationException(let message):
+            return "InvalidOperationException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .nameAlreadyExistsException(let message):
+            return "NameAlreadyExistsException: \(message ?? "")"
+        case .operationIdAlreadyExistsException(let message):
+            return "OperationIdAlreadyExistsException: \(message ?? "")"
+        case .operationInProgressException(let message):
+            return "OperationInProgressException: \(message ?? "")"
+        case .operationNotFoundException(let message):
+            return "OperationNotFoundException: \(message ?? "")"
+        case .stackInstanceNotFoundException(let message):
+            return "StackInstanceNotFoundException: \(message ?? "")"
+        case .stackSetNotEmptyException(let message):
+            return "StackSetNotEmptyException: \(message ?? "")"
+        case .stackSetNotFoundException(let message):
+            return "StackSetNotFoundException: \(message ?? "")"
+        case .staleRequestException(let message):
+            return "StaleRequestException: \(message ?? "")"
+        case .tokenAlreadyExistsException(let message):
+            return "TokenAlreadyExistsException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/CloudFront/CloudFront_Error.swift
+++ b/Sources/AWSSDKSwift/Services/CloudFront/CloudFront_Error.swift
@@ -261,3 +261,172 @@ extension CloudFrontErrorType {
         }
     }
 }
+
+extension CloudFrontErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .accessDenied(let message):
+            return "AccessDenied: \(message ?? "")"
+        case .batchTooLarge(let message):
+            return "BatchTooLarge: \(message ?? "")"
+        case .cNAMEAlreadyExists(let message):
+            return "CNAMEAlreadyExists: \(message ?? "")"
+        case .cannotChangeImmutablePublicKeyFields(let message):
+            return "CannotChangeImmutablePublicKeyFields: \(message ?? "")"
+        case .cloudFrontOriginAccessIdentityAlreadyExists(let message):
+            return "CloudFrontOriginAccessIdentityAlreadyExists: \(message ?? "")"
+        case .cloudFrontOriginAccessIdentityInUse(let message):
+            return "CloudFrontOriginAccessIdentityInUse: \(message ?? "")"
+        case .distributionAlreadyExists(let message):
+            return "DistributionAlreadyExists: \(message ?? "")"
+        case .distributionNotDisabled(let message):
+            return "DistributionNotDisabled: \(message ?? "")"
+        case .fieldLevelEncryptionConfigAlreadyExists(let message):
+            return "FieldLevelEncryptionConfigAlreadyExists: \(message ?? "")"
+        case .fieldLevelEncryptionConfigInUse(let message):
+            return "FieldLevelEncryptionConfigInUse: \(message ?? "")"
+        case .fieldLevelEncryptionProfileAlreadyExists(let message):
+            return "FieldLevelEncryptionProfileAlreadyExists: \(message ?? "")"
+        case .fieldLevelEncryptionProfileInUse(let message):
+            return "FieldLevelEncryptionProfileInUse: \(message ?? "")"
+        case .fieldLevelEncryptionProfileSizeExceeded(let message):
+            return "FieldLevelEncryptionProfileSizeExceeded: \(message ?? "")"
+        case .illegalFieldLevelEncryptionConfigAssociationWithCacheBehavior(let message):
+            return "IllegalFieldLevelEncryptionConfigAssociationWithCacheBehavior: \(message ?? "")"
+        case .illegalUpdate(let message):
+            return "IllegalUpdate: \(message ?? "")"
+        case .inconsistentQuantities(let message):
+            return "InconsistentQuantities: \(message ?? "")"
+        case .invalidArgument(let message):
+            return "InvalidArgument: \(message ?? "")"
+        case .invalidDefaultRootObject(let message):
+            return "InvalidDefaultRootObject: \(message ?? "")"
+        case .invalidErrorCode(let message):
+            return "InvalidErrorCode: \(message ?? "")"
+        case .invalidForwardCookies(let message):
+            return "InvalidForwardCookies: \(message ?? "")"
+        case .invalidGeoRestrictionParameter(let message):
+            return "InvalidGeoRestrictionParameter: \(message ?? "")"
+        case .invalidHeadersForS3Origin(let message):
+            return "InvalidHeadersForS3Origin: \(message ?? "")"
+        case .invalidIfMatchVersion(let message):
+            return "InvalidIfMatchVersion: \(message ?? "")"
+        case .invalidLambdaFunctionAssociation(let message):
+            return "InvalidLambdaFunctionAssociation: \(message ?? "")"
+        case .invalidLocationCode(let message):
+            return "InvalidLocationCode: \(message ?? "")"
+        case .invalidMinimumProtocolVersion(let message):
+            return "InvalidMinimumProtocolVersion: \(message ?? "")"
+        case .invalidOrigin(let message):
+            return "InvalidOrigin: \(message ?? "")"
+        case .invalidOriginAccessIdentity(let message):
+            return "InvalidOriginAccessIdentity: \(message ?? "")"
+        case .invalidOriginKeepaliveTimeout(let message):
+            return "InvalidOriginKeepaliveTimeout: \(message ?? "")"
+        case .invalidOriginReadTimeout(let message):
+            return "InvalidOriginReadTimeout: \(message ?? "")"
+        case .invalidProtocolSettings(let message):
+            return "InvalidProtocolSettings: \(message ?? "")"
+        case .invalidQueryStringParameters(let message):
+            return "InvalidQueryStringParameters: \(message ?? "")"
+        case .invalidRelativePath(let message):
+            return "InvalidRelativePath: \(message ?? "")"
+        case .invalidRequiredProtocol(let message):
+            return "InvalidRequiredProtocol: \(message ?? "")"
+        case .invalidResponseCode(let message):
+            return "InvalidResponseCode: \(message ?? "")"
+        case .invalidTTLOrder(let message):
+            return "InvalidTTLOrder: \(message ?? "")"
+        case .invalidTagging(let message):
+            return "InvalidTagging: \(message ?? "")"
+        case .invalidViewerCertificate(let message):
+            return "InvalidViewerCertificate: \(message ?? "")"
+        case .invalidWebACLId(let message):
+            return "InvalidWebACLId: \(message ?? "")"
+        case .missingBody(let message):
+            return "MissingBody: \(message ?? "")"
+        case .noSuchCloudFrontOriginAccessIdentity(let message):
+            return "NoSuchCloudFrontOriginAccessIdentity: \(message ?? "")"
+        case .noSuchDistribution(let message):
+            return "NoSuchDistribution: \(message ?? "")"
+        case .noSuchFieldLevelEncryptionConfig(let message):
+            return "NoSuchFieldLevelEncryptionConfig: \(message ?? "")"
+        case .noSuchFieldLevelEncryptionProfile(let message):
+            return "NoSuchFieldLevelEncryptionProfile: \(message ?? "")"
+        case .noSuchInvalidation(let message):
+            return "NoSuchInvalidation: \(message ?? "")"
+        case .noSuchOrigin(let message):
+            return "NoSuchOrigin: \(message ?? "")"
+        case .noSuchPublicKey(let message):
+            return "NoSuchPublicKey: \(message ?? "")"
+        case .noSuchResource(let message):
+            return "NoSuchResource: \(message ?? "")"
+        case .noSuchStreamingDistribution(let message):
+            return "NoSuchStreamingDistribution: \(message ?? "")"
+        case .preconditionFailed(let message):
+            return "PreconditionFailed: \(message ?? "")"
+        case .publicKeyAlreadyExists(let message):
+            return "PublicKeyAlreadyExists: \(message ?? "")"
+        case .publicKeyInUse(let message):
+            return "PublicKeyInUse: \(message ?? "")"
+        case .queryArgProfileEmpty(let message):
+            return "QueryArgProfileEmpty: \(message ?? "")"
+        case .streamingDistributionAlreadyExists(let message):
+            return "StreamingDistributionAlreadyExists: \(message ?? "")"
+        case .streamingDistributionNotDisabled(let message):
+            return "StreamingDistributionNotDisabled: \(message ?? "")"
+        case .tooManyCacheBehaviors(let message):
+            return "TooManyCacheBehaviors: \(message ?? "")"
+        case .tooManyCertificates(let message):
+            return "TooManyCertificates: \(message ?? "")"
+        case .tooManyCloudFrontOriginAccessIdentities(let message):
+            return "TooManyCloudFrontOriginAccessIdentities: \(message ?? "")"
+        case .tooManyCookieNamesInWhiteList(let message):
+            return "TooManyCookieNamesInWhiteList: \(message ?? "")"
+        case .tooManyDistributionCNAMEs(let message):
+            return "TooManyDistributionCNAMEs: \(message ?? "")"
+        case .tooManyDistributions(let message):
+            return "TooManyDistributions: \(message ?? "")"
+        case .tooManyDistributionsAssociatedToFieldLevelEncryptionConfig(let message):
+            return "TooManyDistributionsAssociatedToFieldLevelEncryptionConfig: \(message ?? "")"
+        case .tooManyDistributionsWithLambdaAssociations(let message):
+            return "TooManyDistributionsWithLambdaAssociations: \(message ?? "")"
+        case .tooManyFieldLevelEncryptionConfigs(let message):
+            return "TooManyFieldLevelEncryptionConfigs: \(message ?? "")"
+        case .tooManyFieldLevelEncryptionContentTypeProfiles(let message):
+            return "TooManyFieldLevelEncryptionContentTypeProfiles: \(message ?? "")"
+        case .tooManyFieldLevelEncryptionEncryptionEntities(let message):
+            return "TooManyFieldLevelEncryptionEncryptionEntities: \(message ?? "")"
+        case .tooManyFieldLevelEncryptionFieldPatterns(let message):
+            return "TooManyFieldLevelEncryptionFieldPatterns: \(message ?? "")"
+        case .tooManyFieldLevelEncryptionProfiles(let message):
+            return "TooManyFieldLevelEncryptionProfiles: \(message ?? "")"
+        case .tooManyFieldLevelEncryptionQueryArgProfiles(let message):
+            return "TooManyFieldLevelEncryptionQueryArgProfiles: \(message ?? "")"
+        case .tooManyHeadersInForwardedValues(let message):
+            return "TooManyHeadersInForwardedValues: \(message ?? "")"
+        case .tooManyInvalidationsInProgress(let message):
+            return "TooManyInvalidationsInProgress: \(message ?? "")"
+        case .tooManyLambdaFunctionAssociations(let message):
+            return "TooManyLambdaFunctionAssociations: \(message ?? "")"
+        case .tooManyOriginCustomHeaders(let message):
+            return "TooManyOriginCustomHeaders: \(message ?? "")"
+        case .tooManyOriginGroupsPerDistribution(let message):
+            return "TooManyOriginGroupsPerDistribution: \(message ?? "")"
+        case .tooManyOrigins(let message):
+            return "TooManyOrigins: \(message ?? "")"
+        case .tooManyPublicKeys(let message):
+            return "TooManyPublicKeys: \(message ?? "")"
+        case .tooManyQueryStringParameters(let message):
+            return "TooManyQueryStringParameters: \(message ?? "")"
+        case .tooManyStreamingDistributionCNAMEs(let message):
+            return "TooManyStreamingDistributionCNAMEs: \(message ?? "")"
+        case .tooManyStreamingDistributions(let message):
+            return "TooManyStreamingDistributions: \(message ?? "")"
+        case .tooManyTrustedSigners(let message):
+            return "TooManyTrustedSigners: \(message ?? "")"
+        case .trustedSignerDoesNotExist(let message):
+            return "TrustedSignerDoesNotExist: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/CloudHSM/CloudHSM_Error.swift
+++ b/Sources/AWSSDKSwift/Services/CloudHSM/CloudHSM_Error.swift
@@ -27,3 +27,16 @@ extension CloudHSMErrorType {
         }
     }
 }
+
+extension CloudHSMErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .cloudHsmInternalException(let message):
+            return "CloudHsmInternalException: \(message ?? "")"
+        case .cloudHsmServiceException(let message):
+            return "CloudHsmServiceException: \(message ?? "")"
+        case .invalidRequestException(let message):
+            return "InvalidRequestException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/CloudHSMV2/CloudHSMV2_Error.swift
+++ b/Sources/AWSSDKSwift/Services/CloudHSMV2/CloudHSMV2_Error.swift
@@ -33,3 +33,20 @@ extension CloudHSMV2ErrorType {
         }
     }
 }
+
+extension CloudHSMV2ErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .cloudHsmAccessDeniedException(let message):
+            return "CloudHsmAccessDeniedException: \(message ?? "")"
+        case .cloudHsmInternalFailureException(let message):
+            return "CloudHsmInternalFailureException: \(message ?? "")"
+        case .cloudHsmInvalidRequestException(let message):
+            return "CloudHsmInvalidRequestException: \(message ?? "")"
+        case .cloudHsmResourceNotFoundException(let message):
+            return "CloudHsmResourceNotFoundException: \(message ?? "")"
+        case .cloudHsmServiceException(let message):
+            return "CloudHsmServiceException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/CloudSearch/CloudSearch_Error.swift
+++ b/Sources/AWSSDKSwift/Services/CloudSearch/CloudSearch_Error.swift
@@ -36,3 +36,22 @@ extension CloudSearchErrorType {
         }
     }
 }
+
+extension CloudSearchErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .baseException(let message):
+            return "BaseException: \(message ?? "")"
+        case .disabledOperationException(let message):
+            return "DisabledOperationException: \(message ?? "")"
+        case .internalException(let message):
+            return "InternalException: \(message ?? "")"
+        case .invalidTypeException(let message):
+            return "InvalidTypeException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/CloudSearchDomain/CloudSearchDomain_Error.swift
+++ b/Sources/AWSSDKSwift/Services/CloudSearchDomain/CloudSearchDomain_Error.swift
@@ -24,3 +24,14 @@ extension CloudSearchDomainErrorType {
         }
     }
 }
+
+extension CloudSearchDomainErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .documentServiceException(let message):
+            return "DocumentServiceException: \(message ?? "")"
+        case .searchException(let message):
+            return "SearchException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/CloudTrail/CloudTrail_Error.swift
+++ b/Sources/AWSSDKSwift/Services/CloudTrail/CloudTrail_Error.swift
@@ -135,3 +135,88 @@ extension CloudTrailErrorType {
         }
     }
 }
+
+extension CloudTrailErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .cloudTrailARNInvalidException(let message):
+            return "CloudTrailARNInvalidException: \(message ?? "")"
+        case .cloudTrailAccessNotEnabledException(let message):
+            return "CloudTrailAccessNotEnabledException: \(message ?? "")"
+        case .cloudWatchLogsDeliveryUnavailableException(let message):
+            return "CloudWatchLogsDeliveryUnavailableException: \(message ?? "")"
+        case .insufficientDependencyServiceAccessPermissionException(let message):
+            return "InsufficientDependencyServiceAccessPermissionException: \(message ?? "")"
+        case .insufficientEncryptionPolicyException(let message):
+            return "InsufficientEncryptionPolicyException: \(message ?? "")"
+        case .insufficientS3BucketPolicyException(let message):
+            return "InsufficientS3BucketPolicyException: \(message ?? "")"
+        case .insufficientSnsTopicPolicyException(let message):
+            return "InsufficientSnsTopicPolicyException: \(message ?? "")"
+        case .invalidCloudWatchLogsLogGroupArnException(let message):
+            return "InvalidCloudWatchLogsLogGroupArnException: \(message ?? "")"
+        case .invalidCloudWatchLogsRoleArnException(let message):
+            return "InvalidCloudWatchLogsRoleArnException: \(message ?? "")"
+        case .invalidEventSelectorsException(let message):
+            return "InvalidEventSelectorsException: \(message ?? "")"
+        case .invalidHomeRegionException(let message):
+            return "InvalidHomeRegionException: \(message ?? "")"
+        case .invalidKmsKeyIdException(let message):
+            return "InvalidKmsKeyIdException: \(message ?? "")"
+        case .invalidLookupAttributesException(let message):
+            return "InvalidLookupAttributesException: \(message ?? "")"
+        case .invalidMaxResultsException(let message):
+            return "InvalidMaxResultsException: \(message ?? "")"
+        case .invalidNextTokenException(let message):
+            return "InvalidNextTokenException: \(message ?? "")"
+        case .invalidParameterCombinationException(let message):
+            return "InvalidParameterCombinationException: \(message ?? "")"
+        case .invalidS3BucketNameException(let message):
+            return "InvalidS3BucketNameException: \(message ?? "")"
+        case .invalidS3PrefixException(let message):
+            return "InvalidS3PrefixException: \(message ?? "")"
+        case .invalidSnsTopicNameException(let message):
+            return "InvalidSnsTopicNameException: \(message ?? "")"
+        case .invalidTagParameterException(let message):
+            return "InvalidTagParameterException: \(message ?? "")"
+        case .invalidTimeRangeException(let message):
+            return "InvalidTimeRangeException: \(message ?? "")"
+        case .invalidTokenException(let message):
+            return "InvalidTokenException: \(message ?? "")"
+        case .invalidTrailNameException(let message):
+            return "InvalidTrailNameException: \(message ?? "")"
+        case .kmsException(let message):
+            return "KmsException: \(message ?? "")"
+        case .kmsKeyDisabledException(let message):
+            return "KmsKeyDisabledException: \(message ?? "")"
+        case .kmsKeyNotFoundException(let message):
+            return "KmsKeyNotFoundException: \(message ?? "")"
+        case .maximumNumberOfTrailsExceededException(let message):
+            return "MaximumNumberOfTrailsExceededException: \(message ?? "")"
+        case .notOrganizationMasterAccountException(let message):
+            return "NotOrganizationMasterAccountException: \(message ?? "")"
+        case .operationNotPermittedException(let message):
+            return "OperationNotPermittedException: \(message ?? "")"
+        case .organizationNotInAllFeaturesModeException(let message):
+            return "OrganizationNotInAllFeaturesModeException: \(message ?? "")"
+        case .organizationsNotInUseException(let message):
+            return "OrganizationsNotInUseException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .resourceTypeNotSupportedException(let message):
+            return "ResourceTypeNotSupportedException: \(message ?? "")"
+        case .s3BucketDoesNotExistException(let message):
+            return "S3BucketDoesNotExistException: \(message ?? "")"
+        case .tagsLimitExceededException(let message):
+            return "TagsLimitExceededException: \(message ?? "")"
+        case .trailAlreadyExistsException(let message):
+            return "TrailAlreadyExistsException: \(message ?? "")"
+        case .trailNotFoundException(let message):
+            return "TrailNotFoundException: \(message ?? "")"
+        case .trailNotProvidedException(let message):
+            return "TrailNotProvidedException: \(message ?? "")"
+        case .unsupportedOperationException(let message):
+            return "UnsupportedOperationException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/CloudWatch/CloudWatch_Error.swift
+++ b/Sources/AWSSDKSwift/Services/CloudWatch/CloudWatch_Error.swift
@@ -57,3 +57,36 @@ extension CloudWatchErrorType {
         }
     }
 }
+
+extension CloudWatchErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .concurrentModificationException(let message):
+            return "ConcurrentModificationException: \(message ?? "")"
+        case .dashboardInvalidInputError(let message):
+            return "DashboardInvalidInputError: \(message ?? "")"
+        case .dashboardNotFoundError(let message):
+            return "DashboardNotFoundError: \(message ?? "")"
+        case .internalServiceFault(let message):
+            return "InternalServiceFault: \(message ?? "")"
+        case .invalidFormatFault(let message):
+            return "InvalidFormatFault: \(message ?? "")"
+        case .invalidNextToken(let message):
+            return "InvalidNextToken: \(message ?? "")"
+        case .invalidParameterCombinationException(let message):
+            return "InvalidParameterCombinationException: \(message ?? "")"
+        case .invalidParameterValueException(let message):
+            return "InvalidParameterValueException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .limitExceededFault(let message):
+            return "LimitExceededFault: \(message ?? "")"
+        case .missingRequiredParameterException(let message):
+            return "MissingRequiredParameterException: \(message ?? "")"
+        case .resourceNotFound(let message):
+            return "ResourceNotFound: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/CloudWatchEvents/CloudWatchEvents_Error.swift
+++ b/Sources/AWSSDKSwift/Services/CloudWatchEvents/CloudWatchEvents_Error.swift
@@ -39,3 +39,24 @@ extension CloudWatchEventsErrorType {
         }
     }
 }
+
+extension CloudWatchEventsErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .concurrentModificationException(let message):
+            return "ConcurrentModificationException: \(message ?? "")"
+        case .internalException(let message):
+            return "InternalException: \(message ?? "")"
+        case .invalidEventPatternException(let message):
+            return "InvalidEventPatternException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .managedRuleException(let message):
+            return "ManagedRuleException: \(message ?? "")"
+        case .policyLengthExceededException(let message):
+            return "PolicyLengthExceededException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/CloudWatchLogs/CloudWatchLogs_Error.swift
+++ b/Sources/AWSSDKSwift/Services/CloudWatchLogs/CloudWatchLogs_Error.swift
@@ -51,3 +51,32 @@ extension CloudWatchLogsErrorType {
         }
     }
 }
+
+extension CloudWatchLogsErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .dataAlreadyAcceptedException(let message):
+            return "DataAlreadyAcceptedException: \(message ?? "")"
+        case .invalidOperationException(let message):
+            return "InvalidOperationException: \(message ?? "")"
+        case .invalidParameterException(let message):
+            return "InvalidParameterException: \(message ?? "")"
+        case .invalidSequenceTokenException(let message):
+            return "InvalidSequenceTokenException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .malformedQueryException(let message):
+            return "MalformedQueryException: \(message ?? "")"
+        case .operationAbortedException(let message):
+            return "OperationAbortedException: \(message ?? "")"
+        case .resourceAlreadyExistsException(let message):
+            return "ResourceAlreadyExistsException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .serviceUnavailableException(let message):
+            return "ServiceUnavailableException: \(message ?? "")"
+        case .unrecognizedClientException(let message):
+            return "UnrecognizedClientException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/CodeBuild/CodeBuild_Error.swift
+++ b/Sources/AWSSDKSwift/Services/CodeBuild/CodeBuild_Error.swift
@@ -33,3 +33,20 @@ extension CodeBuildErrorType {
         }
     }
 }
+
+extension CodeBuildErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .accountLimitExceededException(let message):
+            return "AccountLimitExceededException: \(message ?? "")"
+        case .invalidInputException(let message):
+            return "InvalidInputException: \(message ?? "")"
+        case .oAuthProviderException(let message):
+            return "OAuthProviderException: \(message ?? "")"
+        case .resourceAlreadyExistsException(let message):
+            return "ResourceAlreadyExistsException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/CodeCommit/CodeCommit_Error.swift
+++ b/Sources/AWSSDKSwift/Services/CodeCommit/CodeCommit_Error.swift
@@ -459,3 +459,304 @@ extension CodeCommitErrorType {
         }
     }
 }
+
+extension CodeCommitErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .actorDoesNotExistException(let message):
+            return "ActorDoesNotExistException: \(message ?? "")"
+        case .authorDoesNotExistException(let message):
+            return "AuthorDoesNotExistException: \(message ?? "")"
+        case .beforeCommitIdAndAfterCommitIdAreSameException(let message):
+            return "BeforeCommitIdAndAfterCommitIdAreSameException: \(message ?? "")"
+        case .blobIdDoesNotExistException(let message):
+            return "BlobIdDoesNotExistException: \(message ?? "")"
+        case .blobIdRequiredException(let message):
+            return "BlobIdRequiredException: \(message ?? "")"
+        case .branchDoesNotExistException(let message):
+            return "BranchDoesNotExistException: \(message ?? "")"
+        case .branchNameExistsException(let message):
+            return "BranchNameExistsException: \(message ?? "")"
+        case .branchNameIsTagNameException(let message):
+            return "BranchNameIsTagNameException: \(message ?? "")"
+        case .branchNameRequiredException(let message):
+            return "BranchNameRequiredException: \(message ?? "")"
+        case .clientRequestTokenRequiredException(let message):
+            return "ClientRequestTokenRequiredException: \(message ?? "")"
+        case .commentContentRequiredException(let message):
+            return "CommentContentRequiredException: \(message ?? "")"
+        case .commentContentSizeLimitExceededException(let message):
+            return "CommentContentSizeLimitExceededException: \(message ?? "")"
+        case .commentDeletedException(let message):
+            return "CommentDeletedException: \(message ?? "")"
+        case .commentDoesNotExistException(let message):
+            return "CommentDoesNotExistException: \(message ?? "")"
+        case .commentIdRequiredException(let message):
+            return "CommentIdRequiredException: \(message ?? "")"
+        case .commentNotCreatedByCallerException(let message):
+            return "CommentNotCreatedByCallerException: \(message ?? "")"
+        case .commitDoesNotExistException(let message):
+            return "CommitDoesNotExistException: \(message ?? "")"
+        case .commitIdDoesNotExistException(let message):
+            return "CommitIdDoesNotExistException: \(message ?? "")"
+        case .commitIdRequiredException(let message):
+            return "CommitIdRequiredException: \(message ?? "")"
+        case .commitMessageLengthExceededException(let message):
+            return "CommitMessageLengthExceededException: \(message ?? "")"
+        case .commitRequiredException(let message):
+            return "CommitRequiredException: \(message ?? "")"
+        case .defaultBranchCannotBeDeletedException(let message):
+            return "DefaultBranchCannotBeDeletedException: \(message ?? "")"
+        case .directoryNameConflictsWithFileNameException(let message):
+            return "DirectoryNameConflictsWithFileNameException: \(message ?? "")"
+        case .encryptionIntegrityChecksFailedException(let message):
+            return "EncryptionIntegrityChecksFailedException: \(message ?? "")"
+        case .encryptionKeyAccessDeniedException(let message):
+            return "EncryptionKeyAccessDeniedException: \(message ?? "")"
+        case .encryptionKeyDisabledException(let message):
+            return "EncryptionKeyDisabledException: \(message ?? "")"
+        case .encryptionKeyNotFoundException(let message):
+            return "EncryptionKeyNotFoundException: \(message ?? "")"
+        case .encryptionKeyUnavailableException(let message):
+            return "EncryptionKeyUnavailableException: \(message ?? "")"
+        case .fileContentAndSourceFileSpecifiedException(let message):
+            return "FileContentAndSourceFileSpecifiedException: \(message ?? "")"
+        case .fileContentRequiredException(let message):
+            return "FileContentRequiredException: \(message ?? "")"
+        case .fileContentSizeLimitExceededException(let message):
+            return "FileContentSizeLimitExceededException: \(message ?? "")"
+        case .fileDoesNotExistException(let message):
+            return "FileDoesNotExistException: \(message ?? "")"
+        case .fileEntryRequiredException(let message):
+            return "FileEntryRequiredException: \(message ?? "")"
+        case .fileModeRequiredException(let message):
+            return "FileModeRequiredException: \(message ?? "")"
+        case .fileNameConflictsWithDirectoryNameException(let message):
+            return "FileNameConflictsWithDirectoryNameException: \(message ?? "")"
+        case .filePathConflictsWithSubmodulePathException(let message):
+            return "FilePathConflictsWithSubmodulePathException: \(message ?? "")"
+        case .fileTooLargeException(let message):
+            return "FileTooLargeException: \(message ?? "")"
+        case .folderContentSizeLimitExceededException(let message):
+            return "FolderContentSizeLimitExceededException: \(message ?? "")"
+        case .folderDoesNotExistException(let message):
+            return "FolderDoesNotExistException: \(message ?? "")"
+        case .idempotencyParameterMismatchException(let message):
+            return "IdempotencyParameterMismatchException: \(message ?? "")"
+        case .invalidActorArnException(let message):
+            return "InvalidActorArnException: \(message ?? "")"
+        case .invalidAuthorArnException(let message):
+            return "InvalidAuthorArnException: \(message ?? "")"
+        case .invalidBlobIdException(let message):
+            return "InvalidBlobIdException: \(message ?? "")"
+        case .invalidBranchNameException(let message):
+            return "InvalidBranchNameException: \(message ?? "")"
+        case .invalidClientRequestTokenException(let message):
+            return "InvalidClientRequestTokenException: \(message ?? "")"
+        case .invalidCommentIdException(let message):
+            return "InvalidCommentIdException: \(message ?? "")"
+        case .invalidCommitException(let message):
+            return "InvalidCommitException: \(message ?? "")"
+        case .invalidCommitIdException(let message):
+            return "InvalidCommitIdException: \(message ?? "")"
+        case .invalidConflictDetailLevelException(let message):
+            return "InvalidConflictDetailLevelException: \(message ?? "")"
+        case .invalidConflictResolutionException(let message):
+            return "InvalidConflictResolutionException: \(message ?? "")"
+        case .invalidConflictResolutionStrategyException(let message):
+            return "InvalidConflictResolutionStrategyException: \(message ?? "")"
+        case .invalidContinuationTokenException(let message):
+            return "InvalidContinuationTokenException: \(message ?? "")"
+        case .invalidDeletionParameterException(let message):
+            return "InvalidDeletionParameterException: \(message ?? "")"
+        case .invalidDescriptionException(let message):
+            return "InvalidDescriptionException: \(message ?? "")"
+        case .invalidDestinationCommitSpecifierException(let message):
+            return "InvalidDestinationCommitSpecifierException: \(message ?? "")"
+        case .invalidEmailException(let message):
+            return "InvalidEmailException: \(message ?? "")"
+        case .invalidFileLocationException(let message):
+            return "InvalidFileLocationException: \(message ?? "")"
+        case .invalidFileModeException(let message):
+            return "InvalidFileModeException: \(message ?? "")"
+        case .invalidFilePositionException(let message):
+            return "InvalidFilePositionException: \(message ?? "")"
+        case .invalidMaxConflictFilesException(let message):
+            return "InvalidMaxConflictFilesException: \(message ?? "")"
+        case .invalidMaxMergeHunksException(let message):
+            return "InvalidMaxMergeHunksException: \(message ?? "")"
+        case .invalidMaxResultsException(let message):
+            return "InvalidMaxResultsException: \(message ?? "")"
+        case .invalidMergeOptionException(let message):
+            return "InvalidMergeOptionException: \(message ?? "")"
+        case .invalidOrderException(let message):
+            return "InvalidOrderException: \(message ?? "")"
+        case .invalidParentCommitIdException(let message):
+            return "InvalidParentCommitIdException: \(message ?? "")"
+        case .invalidPathException(let message):
+            return "InvalidPathException: \(message ?? "")"
+        case .invalidPullRequestEventTypeException(let message):
+            return "InvalidPullRequestEventTypeException: \(message ?? "")"
+        case .invalidPullRequestIdException(let message):
+            return "InvalidPullRequestIdException: \(message ?? "")"
+        case .invalidPullRequestStatusException(let message):
+            return "InvalidPullRequestStatusException: \(message ?? "")"
+        case .invalidPullRequestStatusUpdateException(let message):
+            return "InvalidPullRequestStatusUpdateException: \(message ?? "")"
+        case .invalidReferenceNameException(let message):
+            return "InvalidReferenceNameException: \(message ?? "")"
+        case .invalidRelativeFileVersionEnumException(let message):
+            return "InvalidRelativeFileVersionEnumException: \(message ?? "")"
+        case .invalidReplacementContentException(let message):
+            return "InvalidReplacementContentException: \(message ?? "")"
+        case .invalidReplacementTypeException(let message):
+            return "InvalidReplacementTypeException: \(message ?? "")"
+        case .invalidRepositoryDescriptionException(let message):
+            return "InvalidRepositoryDescriptionException: \(message ?? "")"
+        case .invalidRepositoryNameException(let message):
+            return "InvalidRepositoryNameException: \(message ?? "")"
+        case .invalidRepositoryTriggerBranchNameException(let message):
+            return "InvalidRepositoryTriggerBranchNameException: \(message ?? "")"
+        case .invalidRepositoryTriggerCustomDataException(let message):
+            return "InvalidRepositoryTriggerCustomDataException: \(message ?? "")"
+        case .invalidRepositoryTriggerDestinationArnException(let message):
+            return "InvalidRepositoryTriggerDestinationArnException: \(message ?? "")"
+        case .invalidRepositoryTriggerEventsException(let message):
+            return "InvalidRepositoryTriggerEventsException: \(message ?? "")"
+        case .invalidRepositoryTriggerNameException(let message):
+            return "InvalidRepositoryTriggerNameException: \(message ?? "")"
+        case .invalidRepositoryTriggerRegionException(let message):
+            return "InvalidRepositoryTriggerRegionException: \(message ?? "")"
+        case .invalidResourceArnException(let message):
+            return "InvalidResourceArnException: \(message ?? "")"
+        case .invalidSortByException(let message):
+            return "InvalidSortByException: \(message ?? "")"
+        case .invalidSourceCommitSpecifierException(let message):
+            return "InvalidSourceCommitSpecifierException: \(message ?? "")"
+        case .invalidSystemTagUsageException(let message):
+            return "InvalidSystemTagUsageException: \(message ?? "")"
+        case .invalidTagKeysListException(let message):
+            return "InvalidTagKeysListException: \(message ?? "")"
+        case .invalidTagsMapException(let message):
+            return "InvalidTagsMapException: \(message ?? "")"
+        case .invalidTargetBranchException(let message):
+            return "InvalidTargetBranchException: \(message ?? "")"
+        case .invalidTargetException(let message):
+            return "InvalidTargetException: \(message ?? "")"
+        case .invalidTargetsException(let message):
+            return "InvalidTargetsException: \(message ?? "")"
+        case .invalidTitleException(let message):
+            return "InvalidTitleException: \(message ?? "")"
+        case .manualMergeRequiredException(let message):
+            return "ManualMergeRequiredException: \(message ?? "")"
+        case .maximumBranchesExceededException(let message):
+            return "MaximumBranchesExceededException: \(message ?? "")"
+        case .maximumConflictResolutionEntriesExceededException(let message):
+            return "MaximumConflictResolutionEntriesExceededException: \(message ?? "")"
+        case .maximumFileContentToLoadExceededException(let message):
+            return "MaximumFileContentToLoadExceededException: \(message ?? "")"
+        case .maximumFileEntriesExceededException(let message):
+            return "MaximumFileEntriesExceededException: \(message ?? "")"
+        case .maximumItemsToCompareExceededException(let message):
+            return "MaximumItemsToCompareExceededException: \(message ?? "")"
+        case .maximumOpenPullRequestsExceededException(let message):
+            return "MaximumOpenPullRequestsExceededException: \(message ?? "")"
+        case .maximumRepositoryNamesExceededException(let message):
+            return "MaximumRepositoryNamesExceededException: \(message ?? "")"
+        case .maximumRepositoryTriggersExceededException(let message):
+            return "MaximumRepositoryTriggersExceededException: \(message ?? "")"
+        case .mergeOptionRequiredException(let message):
+            return "MergeOptionRequiredException: \(message ?? "")"
+        case .multipleConflictResolutionEntriesException(let message):
+            return "MultipleConflictResolutionEntriesException: \(message ?? "")"
+        case .multipleRepositoriesInPullRequestException(let message):
+            return "MultipleRepositoriesInPullRequestException: \(message ?? "")"
+        case .nameLengthExceededException(let message):
+            return "NameLengthExceededException: \(message ?? "")"
+        case .noChangeException(let message):
+            return "NoChangeException: \(message ?? "")"
+        case .parentCommitDoesNotExistException(let message):
+            return "ParentCommitDoesNotExistException: \(message ?? "")"
+        case .parentCommitIdOutdatedException(let message):
+            return "ParentCommitIdOutdatedException: \(message ?? "")"
+        case .parentCommitIdRequiredException(let message):
+            return "ParentCommitIdRequiredException: \(message ?? "")"
+        case .pathDoesNotExistException(let message):
+            return "PathDoesNotExistException: \(message ?? "")"
+        case .pathRequiredException(let message):
+            return "PathRequiredException: \(message ?? "")"
+        case .pullRequestAlreadyClosedException(let message):
+            return "PullRequestAlreadyClosedException: \(message ?? "")"
+        case .pullRequestDoesNotExistException(let message):
+            return "PullRequestDoesNotExistException: \(message ?? "")"
+        case .pullRequestIdRequiredException(let message):
+            return "PullRequestIdRequiredException: \(message ?? "")"
+        case .pullRequestStatusRequiredException(let message):
+            return "PullRequestStatusRequiredException: \(message ?? "")"
+        case .putFileEntryConflictException(let message):
+            return "PutFileEntryConflictException: \(message ?? "")"
+        case .referenceDoesNotExistException(let message):
+            return "ReferenceDoesNotExistException: \(message ?? "")"
+        case .referenceNameRequiredException(let message):
+            return "ReferenceNameRequiredException: \(message ?? "")"
+        case .referenceTypeNotSupportedException(let message):
+            return "ReferenceTypeNotSupportedException: \(message ?? "")"
+        case .replacementContentRequiredException(let message):
+            return "ReplacementContentRequiredException: \(message ?? "")"
+        case .replacementTypeRequiredException(let message):
+            return "ReplacementTypeRequiredException: \(message ?? "")"
+        case .repositoryDoesNotExistException(let message):
+            return "RepositoryDoesNotExistException: \(message ?? "")"
+        case .repositoryLimitExceededException(let message):
+            return "RepositoryLimitExceededException: \(message ?? "")"
+        case .repositoryNameExistsException(let message):
+            return "RepositoryNameExistsException: \(message ?? "")"
+        case .repositoryNameRequiredException(let message):
+            return "RepositoryNameRequiredException: \(message ?? "")"
+        case .repositoryNamesRequiredException(let message):
+            return "RepositoryNamesRequiredException: \(message ?? "")"
+        case .repositoryNotAssociatedWithPullRequestException(let message):
+            return "RepositoryNotAssociatedWithPullRequestException: \(message ?? "")"
+        case .repositoryTriggerBranchNameListRequiredException(let message):
+            return "RepositoryTriggerBranchNameListRequiredException: \(message ?? "")"
+        case .repositoryTriggerDestinationArnRequiredException(let message):
+            return "RepositoryTriggerDestinationArnRequiredException: \(message ?? "")"
+        case .repositoryTriggerEventsListRequiredException(let message):
+            return "RepositoryTriggerEventsListRequiredException: \(message ?? "")"
+        case .repositoryTriggerNameRequiredException(let message):
+            return "RepositoryTriggerNameRequiredException: \(message ?? "")"
+        case .repositoryTriggersListRequiredException(let message):
+            return "RepositoryTriggersListRequiredException: \(message ?? "")"
+        case .resourceArnRequiredException(let message):
+            return "ResourceArnRequiredException: \(message ?? "")"
+        case .restrictedSourceFileException(let message):
+            return "RestrictedSourceFileException: \(message ?? "")"
+        case .sameFileContentException(let message):
+            return "SameFileContentException: \(message ?? "")"
+        case .samePathRequestException(let message):
+            return "SamePathRequestException: \(message ?? "")"
+        case .sourceAndDestinationAreSameException(let message):
+            return "SourceAndDestinationAreSameException: \(message ?? "")"
+        case .sourceFileOrContentRequiredException(let message):
+            return "SourceFileOrContentRequiredException: \(message ?? "")"
+        case .tagKeysListRequiredException(let message):
+            return "TagKeysListRequiredException: \(message ?? "")"
+        case .tagPolicyException(let message):
+            return "TagPolicyException: \(message ?? "")"
+        case .tagsMapRequiredException(let message):
+            return "TagsMapRequiredException: \(message ?? "")"
+        case .targetRequiredException(let message):
+            return "TargetRequiredException: \(message ?? "")"
+        case .targetsRequiredException(let message):
+            return "TargetsRequiredException: \(message ?? "")"
+        case .tipOfSourceReferenceIsDifferentException(let message):
+            return "TipOfSourceReferenceIsDifferentException: \(message ?? "")"
+        case .tipsDivergenceExceededException(let message):
+            return "TipsDivergenceExceededException: \(message ?? "")"
+        case .titleRequiredException(let message):
+            return "TitleRequiredException: \(message ?? "")"
+        case .tooManyTagsException(let message):
+            return "TooManyTagsException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/CodeDeploy/CodeDeploy_Error.swift
+++ b/Sources/AWSSDKSwift/Services/CodeDeploy/CodeDeploy_Error.swift
@@ -342,3 +342,226 @@ extension CodeDeployErrorType {
         }
     }
 }
+
+extension CodeDeployErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .alarmsLimitExceededException(let message):
+            return "AlarmsLimitExceededException: \(message ?? "")"
+        case .applicationAlreadyExistsException(let message):
+            return "ApplicationAlreadyExistsException: \(message ?? "")"
+        case .applicationDoesNotExistException(let message):
+            return "ApplicationDoesNotExistException: \(message ?? "")"
+        case .applicationLimitExceededException(let message):
+            return "ApplicationLimitExceededException: \(message ?? "")"
+        case .applicationNameRequiredException(let message):
+            return "ApplicationNameRequiredException: \(message ?? "")"
+        case .arnNotSupportedException(let message):
+            return "ArnNotSupportedException: \(message ?? "")"
+        case .batchLimitExceededException(let message):
+            return "BatchLimitExceededException: \(message ?? "")"
+        case .bucketNameFilterRequiredException(let message):
+            return "BucketNameFilterRequiredException: \(message ?? "")"
+        case .deploymentAlreadyCompletedException(let message):
+            return "DeploymentAlreadyCompletedException: \(message ?? "")"
+        case .deploymentConfigAlreadyExistsException(let message):
+            return "DeploymentConfigAlreadyExistsException: \(message ?? "")"
+        case .deploymentConfigDoesNotExistException(let message):
+            return "DeploymentConfigDoesNotExistException: \(message ?? "")"
+        case .deploymentConfigInUseException(let message):
+            return "DeploymentConfigInUseException: \(message ?? "")"
+        case .deploymentConfigLimitExceededException(let message):
+            return "DeploymentConfigLimitExceededException: \(message ?? "")"
+        case .deploymentConfigNameRequiredException(let message):
+            return "DeploymentConfigNameRequiredException: \(message ?? "")"
+        case .deploymentDoesNotExistException(let message):
+            return "DeploymentDoesNotExistException: \(message ?? "")"
+        case .deploymentGroupAlreadyExistsException(let message):
+            return "DeploymentGroupAlreadyExistsException: \(message ?? "")"
+        case .deploymentGroupDoesNotExistException(let message):
+            return "DeploymentGroupDoesNotExistException: \(message ?? "")"
+        case .deploymentGroupLimitExceededException(let message):
+            return "DeploymentGroupLimitExceededException: \(message ?? "")"
+        case .deploymentGroupNameRequiredException(let message):
+            return "DeploymentGroupNameRequiredException: \(message ?? "")"
+        case .deploymentIdRequiredException(let message):
+            return "DeploymentIdRequiredException: \(message ?? "")"
+        case .deploymentIsNotInReadyStateException(let message):
+            return "DeploymentIsNotInReadyStateException: \(message ?? "")"
+        case .deploymentLimitExceededException(let message):
+            return "DeploymentLimitExceededException: \(message ?? "")"
+        case .deploymentNotStartedException(let message):
+            return "DeploymentNotStartedException: \(message ?? "")"
+        case .deploymentTargetDoesNotExistException(let message):
+            return "DeploymentTargetDoesNotExistException: \(message ?? "")"
+        case .deploymentTargetIdRequiredException(let message):
+            return "DeploymentTargetIdRequiredException: \(message ?? "")"
+        case .deploymentTargetListSizeExceededException(let message):
+            return "DeploymentTargetListSizeExceededException: \(message ?? "")"
+        case .descriptionTooLongException(let message):
+            return "DescriptionTooLongException: \(message ?? "")"
+        case .eCSServiceMappingLimitExceededException(let message):
+            return "ECSServiceMappingLimitExceededException: \(message ?? "")"
+        case .gitHubAccountTokenDoesNotExistException(let message):
+            return "GitHubAccountTokenDoesNotExistException: \(message ?? "")"
+        case .gitHubAccountTokenNameRequiredException(let message):
+            return "GitHubAccountTokenNameRequiredException: \(message ?? "")"
+        case .iamArnRequiredException(let message):
+            return "IamArnRequiredException: \(message ?? "")"
+        case .iamSessionArnAlreadyRegisteredException(let message):
+            return "IamSessionArnAlreadyRegisteredException: \(message ?? "")"
+        case .iamUserArnAlreadyRegisteredException(let message):
+            return "IamUserArnAlreadyRegisteredException: \(message ?? "")"
+        case .iamUserArnRequiredException(let message):
+            return "IamUserArnRequiredException: \(message ?? "")"
+        case .instanceDoesNotExistException(let message):
+            return "InstanceDoesNotExistException: \(message ?? "")"
+        case .instanceIdRequiredException(let message):
+            return "InstanceIdRequiredException: \(message ?? "")"
+        case .instanceLimitExceededException(let message):
+            return "InstanceLimitExceededException: \(message ?? "")"
+        case .instanceNameAlreadyRegisteredException(let message):
+            return "InstanceNameAlreadyRegisteredException: \(message ?? "")"
+        case .instanceNameRequiredException(let message):
+            return "InstanceNameRequiredException: \(message ?? "")"
+        case .instanceNotRegisteredException(let message):
+            return "InstanceNotRegisteredException: \(message ?? "")"
+        case .invalidAlarmConfigException(let message):
+            return "InvalidAlarmConfigException: \(message ?? "")"
+        case .invalidApplicationNameException(let message):
+            return "InvalidApplicationNameException: \(message ?? "")"
+        case .invalidArnException(let message):
+            return "InvalidArnException: \(message ?? "")"
+        case .invalidAutoRollbackConfigException(let message):
+            return "InvalidAutoRollbackConfigException: \(message ?? "")"
+        case .invalidAutoScalingGroupException(let message):
+            return "InvalidAutoScalingGroupException: \(message ?? "")"
+        case .invalidBlueGreenDeploymentConfigurationException(let message):
+            return "InvalidBlueGreenDeploymentConfigurationException: \(message ?? "")"
+        case .invalidBucketNameFilterException(let message):
+            return "InvalidBucketNameFilterException: \(message ?? "")"
+        case .invalidComputePlatformException(let message):
+            return "InvalidComputePlatformException: \(message ?? "")"
+        case .invalidDeployedStateFilterException(let message):
+            return "InvalidDeployedStateFilterException: \(message ?? "")"
+        case .invalidDeploymentConfigNameException(let message):
+            return "InvalidDeploymentConfigNameException: \(message ?? "")"
+        case .invalidDeploymentGroupNameException(let message):
+            return "InvalidDeploymentGroupNameException: \(message ?? "")"
+        case .invalidDeploymentIdException(let message):
+            return "InvalidDeploymentIdException: \(message ?? "")"
+        case .invalidDeploymentInstanceTypeException(let message):
+            return "InvalidDeploymentInstanceTypeException: \(message ?? "")"
+        case .invalidDeploymentStatusException(let message):
+            return "InvalidDeploymentStatusException: \(message ?? "")"
+        case .invalidDeploymentStyleException(let message):
+            return "InvalidDeploymentStyleException: \(message ?? "")"
+        case .invalidDeploymentTargetIdException(let message):
+            return "InvalidDeploymentTargetIdException: \(message ?? "")"
+        case .invalidDeploymentWaitTypeException(let message):
+            return "InvalidDeploymentWaitTypeException: \(message ?? "")"
+        case .invalidEC2TagCombinationException(let message):
+            return "InvalidEC2TagCombinationException: \(message ?? "")"
+        case .invalidEC2TagException(let message):
+            return "InvalidEC2TagException: \(message ?? "")"
+        case .invalidECSServiceException(let message):
+            return "InvalidECSServiceException: \(message ?? "")"
+        case .invalidFileExistsBehaviorException(let message):
+            return "InvalidFileExistsBehaviorException: \(message ?? "")"
+        case .invalidGitHubAccountTokenException(let message):
+            return "InvalidGitHubAccountTokenException: \(message ?? "")"
+        case .invalidGitHubAccountTokenNameException(let message):
+            return "InvalidGitHubAccountTokenNameException: \(message ?? "")"
+        case .invalidIamSessionArnException(let message):
+            return "InvalidIamSessionArnException: \(message ?? "")"
+        case .invalidIamUserArnException(let message):
+            return "InvalidIamUserArnException: \(message ?? "")"
+        case .invalidIgnoreApplicationStopFailuresValueException(let message):
+            return "InvalidIgnoreApplicationStopFailuresValueException: \(message ?? "")"
+        case .invalidInputException(let message):
+            return "InvalidInputException: \(message ?? "")"
+        case .invalidInstanceNameException(let message):
+            return "InvalidInstanceNameException: \(message ?? "")"
+        case .invalidInstanceStatusException(let message):
+            return "InvalidInstanceStatusException: \(message ?? "")"
+        case .invalidInstanceTypeException(let message):
+            return "InvalidInstanceTypeException: \(message ?? "")"
+        case .invalidKeyPrefixFilterException(let message):
+            return "InvalidKeyPrefixFilterException: \(message ?? "")"
+        case .invalidLifecycleEventHookExecutionIdException(let message):
+            return "InvalidLifecycleEventHookExecutionIdException: \(message ?? "")"
+        case .invalidLifecycleEventHookExecutionStatusException(let message):
+            return "InvalidLifecycleEventHookExecutionStatusException: \(message ?? "")"
+        case .invalidLoadBalancerInfoException(let message):
+            return "InvalidLoadBalancerInfoException: \(message ?? "")"
+        case .invalidMinimumHealthyHostValueException(let message):
+            return "InvalidMinimumHealthyHostValueException: \(message ?? "")"
+        case .invalidNextTokenException(let message):
+            return "InvalidNextTokenException: \(message ?? "")"
+        case .invalidOnPremisesTagCombinationException(let message):
+            return "InvalidOnPremisesTagCombinationException: \(message ?? "")"
+        case .invalidOperationException(let message):
+            return "InvalidOperationException: \(message ?? "")"
+        case .invalidRegistrationStatusException(let message):
+            return "InvalidRegistrationStatusException: \(message ?? "")"
+        case .invalidRevisionException(let message):
+            return "InvalidRevisionException: \(message ?? "")"
+        case .invalidRoleException(let message):
+            return "InvalidRoleException: \(message ?? "")"
+        case .invalidSortByException(let message):
+            return "InvalidSortByException: \(message ?? "")"
+        case .invalidSortOrderException(let message):
+            return "InvalidSortOrderException: \(message ?? "")"
+        case .invalidTagException(let message):
+            return "InvalidTagException: \(message ?? "")"
+        case .invalidTagFilterException(let message):
+            return "InvalidTagFilterException: \(message ?? "")"
+        case .invalidTagsToAddException(let message):
+            return "InvalidTagsToAddException: \(message ?? "")"
+        case .invalidTargetFilterNameException(let message):
+            return "InvalidTargetFilterNameException: \(message ?? "")"
+        case .invalidTargetGroupPairException(let message):
+            return "InvalidTargetGroupPairException: \(message ?? "")"
+        case .invalidTargetInstancesException(let message):
+            return "InvalidTargetInstancesException: \(message ?? "")"
+        case .invalidTimeRangeException(let message):
+            return "InvalidTimeRangeException: \(message ?? "")"
+        case .invalidTrafficRoutingConfigurationException(let message):
+            return "InvalidTrafficRoutingConfigurationException: \(message ?? "")"
+        case .invalidTriggerConfigException(let message):
+            return "InvalidTriggerConfigException: \(message ?? "")"
+        case .invalidUpdateOutdatedInstancesOnlyValueException(let message):
+            return "InvalidUpdateOutdatedInstancesOnlyValueException: \(message ?? "")"
+        case .lifecycleEventAlreadyCompletedException(let message):
+            return "LifecycleEventAlreadyCompletedException: \(message ?? "")"
+        case .lifecycleHookLimitExceededException(let message):
+            return "LifecycleHookLimitExceededException: \(message ?? "")"
+        case .multipleIamArnsProvidedException(let message):
+            return "MultipleIamArnsProvidedException: \(message ?? "")"
+        case .operationNotSupportedException(let message):
+            return "OperationNotSupportedException: \(message ?? "")"
+        case .resourceArnRequiredException(let message):
+            return "ResourceArnRequiredException: \(message ?? "")"
+        case .resourceValidationException(let message):
+            return "ResourceValidationException: \(message ?? "")"
+        case .revisionDoesNotExistException(let message):
+            return "RevisionDoesNotExistException: \(message ?? "")"
+        case .revisionRequiredException(let message):
+            return "RevisionRequiredException: \(message ?? "")"
+        case .roleRequiredException(let message):
+            return "RoleRequiredException: \(message ?? "")"
+        case .tagLimitExceededException(let message):
+            return "TagLimitExceededException: \(message ?? "")"
+        case .tagRequiredException(let message):
+            return "TagRequiredException: \(message ?? "")"
+        case .tagSetListLimitExceededException(let message):
+            return "TagSetListLimitExceededException: \(message ?? "")"
+        case .throttlingException(let message):
+            return "ThrottlingException: \(message ?? "")"
+        case .triggerTargetsLimitExceededException(let message):
+            return "TriggerTargetsLimitExceededException: \(message ?? "")"
+        case .unsupportedActionForDeploymentTypeException(let message):
+            return "UnsupportedActionForDeploymentTypeException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/CodePipeline/CodePipeline_Error.swift
+++ b/Sources/AWSSDKSwift/Services/CodePipeline/CodePipeline_Error.swift
@@ -111,3 +111,72 @@ extension CodePipelineErrorType {
         }
     }
 }
+
+extension CodePipelineErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .actionNotFoundException(let message):
+            return "ActionNotFoundException: \(message ?? "")"
+        case .actionTypeNotFoundException(let message):
+            return "ActionTypeNotFoundException: \(message ?? "")"
+        case .approvalAlreadyCompletedException(let message):
+            return "ApprovalAlreadyCompletedException: \(message ?? "")"
+        case .concurrentModificationException(let message):
+            return "ConcurrentModificationException: \(message ?? "")"
+        case .invalidActionDeclarationException(let message):
+            return "InvalidActionDeclarationException: \(message ?? "")"
+        case .invalidApprovalTokenException(let message):
+            return "InvalidApprovalTokenException: \(message ?? "")"
+        case .invalidArnException(let message):
+            return "InvalidArnException: \(message ?? "")"
+        case .invalidBlockerDeclarationException(let message):
+            return "InvalidBlockerDeclarationException: \(message ?? "")"
+        case .invalidClientTokenException(let message):
+            return "InvalidClientTokenException: \(message ?? "")"
+        case .invalidJobException(let message):
+            return "InvalidJobException: \(message ?? "")"
+        case .invalidJobStateException(let message):
+            return "InvalidJobStateException: \(message ?? "")"
+        case .invalidNextTokenException(let message):
+            return "InvalidNextTokenException: \(message ?? "")"
+        case .invalidNonceException(let message):
+            return "InvalidNonceException: \(message ?? "")"
+        case .invalidStageDeclarationException(let message):
+            return "InvalidStageDeclarationException: \(message ?? "")"
+        case .invalidStructureException(let message):
+            return "InvalidStructureException: \(message ?? "")"
+        case .invalidTagsException(let message):
+            return "InvalidTagsException: \(message ?? "")"
+        case .invalidWebhookAuthenticationParametersException(let message):
+            return "InvalidWebhookAuthenticationParametersException: \(message ?? "")"
+        case .invalidWebhookFilterPatternException(let message):
+            return "InvalidWebhookFilterPatternException: \(message ?? "")"
+        case .jobNotFoundException(let message):
+            return "JobNotFoundException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .notLatestPipelineExecutionException(let message):
+            return "NotLatestPipelineExecutionException: \(message ?? "")"
+        case .pipelineExecutionNotFoundException(let message):
+            return "PipelineExecutionNotFoundException: \(message ?? "")"
+        case .pipelineNameInUseException(let message):
+            return "PipelineNameInUseException: \(message ?? "")"
+        case .pipelineNotFoundException(let message):
+            return "PipelineNotFoundException: \(message ?? "")"
+        case .pipelineVersionNotFoundException(let message):
+            return "PipelineVersionNotFoundException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .stageNotFoundException(let message):
+            return "StageNotFoundException: \(message ?? "")"
+        case .stageNotRetryableException(let message):
+            return "StageNotRetryableException: \(message ?? "")"
+        case .tooManyTagsException(let message):
+            return "TooManyTagsException: \(message ?? "")"
+        case .validationException(let message):
+            return "ValidationException: \(message ?? "")"
+        case .webhookNotFoundException(let message):
+            return "WebhookNotFoundException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/CodeStar/CodeStar_Error.swift
+++ b/Sources/AWSSDKSwift/Services/CodeStar/CodeStar_Error.swift
@@ -57,3 +57,36 @@ extension CodeStarErrorType {
         }
     }
 }
+
+extension CodeStarErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .concurrentModificationException(let message):
+            return "ConcurrentModificationException: \(message ?? "")"
+        case .invalidNextTokenException(let message):
+            return "InvalidNextTokenException: \(message ?? "")"
+        case .invalidServiceRoleException(let message):
+            return "InvalidServiceRoleException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .projectAlreadyExistsException(let message):
+            return "ProjectAlreadyExistsException: \(message ?? "")"
+        case .projectConfigurationException(let message):
+            return "ProjectConfigurationException: \(message ?? "")"
+        case .projectCreationFailedException(let message):
+            return "ProjectCreationFailedException: \(message ?? "")"
+        case .projectNotFoundException(let message):
+            return "ProjectNotFoundException: \(message ?? "")"
+        case .teamMemberAlreadyAssociatedException(let message):
+            return "TeamMemberAlreadyAssociatedException: \(message ?? "")"
+        case .teamMemberNotFoundException(let message):
+            return "TeamMemberNotFoundException: \(message ?? "")"
+        case .userProfileAlreadyExistsException(let message):
+            return "UserProfileAlreadyExistsException: \(message ?? "")"
+        case .userProfileNotFoundException(let message):
+            return "UserProfileNotFoundException: \(message ?? "")"
+        case .validationException(let message):
+            return "ValidationException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/CognitoIdentity/CognitoIdentity_Error.swift
+++ b/Sources/AWSSDKSwift/Services/CognitoIdentity/CognitoIdentity_Error.swift
@@ -51,3 +51,32 @@ extension CognitoIdentityErrorType {
         }
     }
 }
+
+extension CognitoIdentityErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .concurrentModificationException(let message):
+            return "ConcurrentModificationException: \(message ?? "")"
+        case .developerUserAlreadyRegisteredException(let message):
+            return "DeveloperUserAlreadyRegisteredException: \(message ?? "")"
+        case .externalServiceException(let message):
+            return "ExternalServiceException: \(message ?? "")"
+        case .internalErrorException(let message):
+            return "InternalErrorException: \(message ?? "")"
+        case .invalidIdentityPoolConfigurationException(let message):
+            return "InvalidIdentityPoolConfigurationException: \(message ?? "")"
+        case .invalidParameterException(let message):
+            return "InvalidParameterException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .notAuthorizedException(let message):
+            return "NotAuthorizedException: \(message ?? "")"
+        case .resourceConflictException(let message):
+            return "ResourceConflictException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .tooManyRequestsException(let message):
+            return "TooManyRequestsException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/CognitoIdentityProvider/CognitoIdentityProvider_Error.swift
+++ b/Sources/AWSSDKSwift/Services/CognitoIdentityProvider/CognitoIdentityProvider_Error.swift
@@ -129,3 +129,84 @@ extension CognitoIdentityProviderErrorType {
         }
     }
 }
+
+extension CognitoIdentityProviderErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .aliasExistsException(let message):
+            return "AliasExistsException: \(message ?? "")"
+        case .codeDeliveryFailureException(let message):
+            return "CodeDeliveryFailureException: \(message ?? "")"
+        case .codeMismatchException(let message):
+            return "CodeMismatchException: \(message ?? "")"
+        case .concurrentModificationException(let message):
+            return "ConcurrentModificationException: \(message ?? "")"
+        case .duplicateProviderException(let message):
+            return "DuplicateProviderException: \(message ?? "")"
+        case .enableSoftwareTokenMFAException(let message):
+            return "EnableSoftwareTokenMFAException: \(message ?? "")"
+        case .expiredCodeException(let message):
+            return "ExpiredCodeException: \(message ?? "")"
+        case .groupExistsException(let message):
+            return "GroupExistsException: \(message ?? "")"
+        case .internalErrorException(let message):
+            return "InternalErrorException: \(message ?? "")"
+        case .invalidEmailRoleAccessPolicyException(let message):
+            return "InvalidEmailRoleAccessPolicyException: \(message ?? "")"
+        case .invalidLambdaResponseException(let message):
+            return "InvalidLambdaResponseException: \(message ?? "")"
+        case .invalidOAuthFlowException(let message):
+            return "InvalidOAuthFlowException: \(message ?? "")"
+        case .invalidParameterException(let message):
+            return "InvalidParameterException: \(message ?? "")"
+        case .invalidPasswordException(let message):
+            return "InvalidPasswordException: \(message ?? "")"
+        case .invalidSmsRoleAccessPolicyException(let message):
+            return "InvalidSmsRoleAccessPolicyException: \(message ?? "")"
+        case .invalidSmsRoleTrustRelationshipException(let message):
+            return "InvalidSmsRoleTrustRelationshipException: \(message ?? "")"
+        case .invalidUserPoolConfigurationException(let message):
+            return "InvalidUserPoolConfigurationException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .mFAMethodNotFoundException(let message):
+            return "MFAMethodNotFoundException: \(message ?? "")"
+        case .notAuthorizedException(let message):
+            return "NotAuthorizedException: \(message ?? "")"
+        case .passwordResetRequiredException(let message):
+            return "PasswordResetRequiredException: \(message ?? "")"
+        case .preconditionNotMetException(let message):
+            return "PreconditionNotMetException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .scopeDoesNotExistException(let message):
+            return "ScopeDoesNotExistException: \(message ?? "")"
+        case .softwareTokenMFANotFoundException(let message):
+            return "SoftwareTokenMFANotFoundException: \(message ?? "")"
+        case .tooManyFailedAttemptsException(let message):
+            return "TooManyFailedAttemptsException: \(message ?? "")"
+        case .tooManyRequestsException(let message):
+            return "TooManyRequestsException: \(message ?? "")"
+        case .unexpectedLambdaException(let message):
+            return "UnexpectedLambdaException: \(message ?? "")"
+        case .unsupportedIdentityProviderException(let message):
+            return "UnsupportedIdentityProviderException: \(message ?? "")"
+        case .unsupportedUserStateException(let message):
+            return "UnsupportedUserStateException: \(message ?? "")"
+        case .userImportInProgressException(let message):
+            return "UserImportInProgressException: \(message ?? "")"
+        case .userLambdaValidationException(let message):
+            return "UserLambdaValidationException: \(message ?? "")"
+        case .userNotConfirmedException(let message):
+            return "UserNotConfirmedException: \(message ?? "")"
+        case .userNotFoundException(let message):
+            return "UserNotFoundException: \(message ?? "")"
+        case .userPoolAddOnNotEnabledException(let message):
+            return "UserPoolAddOnNotEnabledException: \(message ?? "")"
+        case .userPoolTaggingException(let message):
+            return "UserPoolTaggingException: \(message ?? "")"
+        case .usernameExistsException(let message):
+            return "UsernameExistsException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/CognitoSync/CognitoSync_Error.swift
+++ b/Sources/AWSSDKSwift/Services/CognitoSync/CognitoSync_Error.swift
@@ -57,3 +57,36 @@ extension CognitoSyncErrorType {
         }
     }
 }
+
+extension CognitoSyncErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .alreadyStreamedException(let message):
+            return "AlreadyStreamedException: \(message ?? "")"
+        case .concurrentModificationException(let message):
+            return "ConcurrentModificationException: \(message ?? "")"
+        case .duplicateRequestException(let message):
+            return "DuplicateRequestException: \(message ?? "")"
+        case .internalErrorException(let message):
+            return "InternalErrorException: \(message ?? "")"
+        case .invalidConfigurationException(let message):
+            return "InvalidConfigurationException: \(message ?? "")"
+        case .invalidLambdaFunctionOutputException(let message):
+            return "InvalidLambdaFunctionOutputException: \(message ?? "")"
+        case .invalidParameterException(let message):
+            return "InvalidParameterException: \(message ?? "")"
+        case .lambdaThrottledException(let message):
+            return "LambdaThrottledException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .notAuthorizedException(let message):
+            return "NotAuthorizedException: \(message ?? "")"
+        case .resourceConflictException(let message):
+            return "ResourceConflictException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .tooManyRequestsException(let message):
+            return "TooManyRequestsException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Comprehend/Comprehend_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Comprehend/Comprehend_Error.swift
@@ -66,3 +66,42 @@ extension ComprehendErrorType {
         }
     }
 }
+
+extension ComprehendErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .batchSizeLimitExceededException(let message):
+            return "BatchSizeLimitExceededException: \(message ?? "")"
+        case .concurrentModificationException(let message):
+            return "ConcurrentModificationException: \(message ?? "")"
+        case .internalServerException(let message):
+            return "InternalServerException: \(message ?? "")"
+        case .invalidFilterException(let message):
+            return "InvalidFilterException: \(message ?? "")"
+        case .invalidRequestException(let message):
+            return "InvalidRequestException: \(message ?? "")"
+        case .jobNotFoundException(let message):
+            return "JobNotFoundException: \(message ?? "")"
+        case .kmsKeyValidationException(let message):
+            return "KmsKeyValidationException: \(message ?? "")"
+        case .resourceInUseException(let message):
+            return "ResourceInUseException: \(message ?? "")"
+        case .resourceLimitExceededException(let message):
+            return "ResourceLimitExceededException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .resourceUnavailableException(let message):
+            return "ResourceUnavailableException: \(message ?? "")"
+        case .textSizeLimitExceededException(let message):
+            return "TextSizeLimitExceededException: \(message ?? "")"
+        case .tooManyRequestsException(let message):
+            return "TooManyRequestsException: \(message ?? "")"
+        case .tooManyTagKeysException(let message):
+            return "TooManyTagKeysException: \(message ?? "")"
+        case .tooManyTagsException(let message):
+            return "TooManyTagsException: \(message ?? "")"
+        case .unsupportedLanguageException(let message):
+            return "UnsupportedLanguageException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/ComprehendMedical/ComprehendMedical_Error.swift
+++ b/Sources/AWSSDKSwift/Services/ComprehendMedical/ComprehendMedical_Error.swift
@@ -36,3 +36,22 @@ extension ComprehendMedicalErrorType {
         }
     }
 }
+
+extension ComprehendMedicalErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .internalServerException(let message):
+            return "InternalServerException: \(message ?? "")"
+        case .invalidEncodingException(let message):
+            return "InvalidEncodingException: \(message ?? "")"
+        case .invalidRequestException(let message):
+            return "InvalidRequestException: \(message ?? "")"
+        case .serviceUnavailableException(let message):
+            return "ServiceUnavailableException: \(message ?? "")"
+        case .textSizeLimitExceededException(let message):
+            return "TextSizeLimitExceededException: \(message ?? "")"
+        case .tooManyRequestsException(let message):
+            return "TooManyRequestsException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/ConfigService/ConfigService_Error.swift
+++ b/Sources/AWSSDKSwift/Services/ConfigService/ConfigService_Error.swift
@@ -144,3 +144,94 @@ extension ConfigServiceErrorType {
         }
     }
 }
+
+extension ConfigServiceErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .insufficientDeliveryPolicyException(let message):
+            return "InsufficientDeliveryPolicyException: \(message ?? "")"
+        case .insufficientPermissionsException(let message):
+            return "InsufficientPermissionsException: \(message ?? "")"
+        case .invalidConfigurationRecorderNameException(let message):
+            return "InvalidConfigurationRecorderNameException: \(message ?? "")"
+        case .invalidDeliveryChannelNameException(let message):
+            return "InvalidDeliveryChannelNameException: \(message ?? "")"
+        case .invalidExpressionException(let message):
+            return "InvalidExpressionException: \(message ?? "")"
+        case .invalidLimitException(let message):
+            return "InvalidLimitException: \(message ?? "")"
+        case .invalidNextTokenException(let message):
+            return "InvalidNextTokenException: \(message ?? "")"
+        case .invalidParameterValueException(let message):
+            return "InvalidParameterValueException: \(message ?? "")"
+        case .invalidRecordingGroupException(let message):
+            return "InvalidRecordingGroupException: \(message ?? "")"
+        case .invalidResultTokenException(let message):
+            return "InvalidResultTokenException: \(message ?? "")"
+        case .invalidRoleException(let message):
+            return "InvalidRoleException: \(message ?? "")"
+        case .invalidS3KeyPrefixException(let message):
+            return "InvalidS3KeyPrefixException: \(message ?? "")"
+        case .invalidSNSTopicARNException(let message):
+            return "InvalidSNSTopicARNException: \(message ?? "")"
+        case .invalidTimeRangeException(let message):
+            return "InvalidTimeRangeException: \(message ?? "")"
+        case .lastDeliveryChannelDeleteFailedException(let message):
+            return "LastDeliveryChannelDeleteFailedException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .maxNumberOfConfigRulesExceededException(let message):
+            return "MaxNumberOfConfigRulesExceededException: \(message ?? "")"
+        case .maxNumberOfConfigurationRecordersExceededException(let message):
+            return "MaxNumberOfConfigurationRecordersExceededException: \(message ?? "")"
+        case .maxNumberOfDeliveryChannelsExceededException(let message):
+            return "MaxNumberOfDeliveryChannelsExceededException: \(message ?? "")"
+        case .maxNumberOfOrganizationConfigRulesExceededException(let message):
+            return "MaxNumberOfOrganizationConfigRulesExceededException: \(message ?? "")"
+        case .maxNumberOfRetentionConfigurationsExceededException(let message):
+            return "MaxNumberOfRetentionConfigurationsExceededException: \(message ?? "")"
+        case .noAvailableConfigurationRecorderException(let message):
+            return "NoAvailableConfigurationRecorderException: \(message ?? "")"
+        case .noAvailableDeliveryChannelException(let message):
+            return "NoAvailableDeliveryChannelException: \(message ?? "")"
+        case .noAvailableOrganizationException(let message):
+            return "NoAvailableOrganizationException: \(message ?? "")"
+        case .noRunningConfigurationRecorderException(let message):
+            return "NoRunningConfigurationRecorderException: \(message ?? "")"
+        case .noSuchBucketException(let message):
+            return "NoSuchBucketException: \(message ?? "")"
+        case .noSuchConfigRuleException(let message):
+            return "NoSuchConfigRuleException: \(message ?? "")"
+        case .noSuchConfigurationAggregatorException(let message):
+            return "NoSuchConfigurationAggregatorException: \(message ?? "")"
+        case .noSuchConfigurationRecorderException(let message):
+            return "NoSuchConfigurationRecorderException: \(message ?? "")"
+        case .noSuchDeliveryChannelException(let message):
+            return "NoSuchDeliveryChannelException: \(message ?? "")"
+        case .noSuchOrganizationConfigRuleException(let message):
+            return "NoSuchOrganizationConfigRuleException: \(message ?? "")"
+        case .noSuchRemediationConfigurationException(let message):
+            return "NoSuchRemediationConfigurationException: \(message ?? "")"
+        case .noSuchRetentionConfigurationException(let message):
+            return "NoSuchRetentionConfigurationException: \(message ?? "")"
+        case .organizationAccessDeniedException(let message):
+            return "OrganizationAccessDeniedException: \(message ?? "")"
+        case .organizationAllFeaturesNotEnabledException(let message):
+            return "OrganizationAllFeaturesNotEnabledException: \(message ?? "")"
+        case .oversizedConfigurationItemException(let message):
+            return "OversizedConfigurationItemException: \(message ?? "")"
+        case .remediationInProgressException(let message):
+            return "RemediationInProgressException: \(message ?? "")"
+        case .resourceInUseException(let message):
+            return "ResourceInUseException: \(message ?? "")"
+        case .resourceNotDiscoveredException(let message):
+            return "ResourceNotDiscoveredException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .tooManyTagsException(let message):
+            return "TooManyTagsException: \(message ?? "")"
+        case .validationException(let message):
+            return "ValidationException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Connect/Connect_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Connect/Connect_Error.swift
@@ -51,3 +51,32 @@ extension ConnectErrorType {
         }
     }
 }
+
+extension ConnectErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .contactNotFoundException(let message):
+            return "ContactNotFoundException: \(message ?? "")"
+        case .destinationNotAllowedException(let message):
+            return "DestinationNotAllowedException: \(message ?? "")"
+        case .duplicateResourceException(let message):
+            return "DuplicateResourceException: \(message ?? "")"
+        case .internalServiceException(let message):
+            return "InternalServiceException: \(message ?? "")"
+        case .invalidParameterException(let message):
+            return "InvalidParameterException: \(message ?? "")"
+        case .invalidRequestException(let message):
+            return "InvalidRequestException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .outboundContactNotPermittedException(let message):
+            return "OutboundContactNotPermittedException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .throttlingException(let message):
+            return "ThrottlingException: \(message ?? "")"
+        case .userNotFoundException(let message):
+            return "UserNotFoundException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/CostExplorer/CostExplorer_Error.swift
+++ b/Sources/AWSSDKSwift/Services/CostExplorer/CostExplorer_Error.swift
@@ -36,3 +36,22 @@ extension CostExplorerErrorType {
         }
     }
 }
+
+extension CostExplorerErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .billExpirationException(let message):
+            return "BillExpirationException: \(message ?? "")"
+        case .dataUnavailableException(let message):
+            return "DataUnavailableException: \(message ?? "")"
+        case .invalidNextTokenException(let message):
+            return "InvalidNextTokenException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .requestChangedException(let message):
+            return "RequestChangedException: \(message ?? "")"
+        case .unresolvableUsageUnitException(let message):
+            return "UnresolvableUsageUnitException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/CostandUsageReportService/CostandUsageReportService_Error.swift
+++ b/Sources/AWSSDKSwift/Services/CostandUsageReportService/CostandUsageReportService_Error.swift
@@ -30,3 +30,18 @@ extension CostandUsageReportServiceErrorType {
         }
     }
 }
+
+extension CostandUsageReportServiceErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .duplicateReportNameException(let message):
+            return "DuplicateReportNameException: \(message ?? "")"
+        case .internalErrorException(let message):
+            return "InternalErrorException: \(message ?? "")"
+        case .reportLimitReachedException(let message):
+            return "ReportLimitReachedException: \(message ?? "")"
+        case .validationException(let message):
+            return "ValidationException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/DAX/DAX_Error.swift
+++ b/Sources/AWSSDKSwift/Services/DAX/DAX_Error.swift
@@ -96,3 +96,62 @@ extension DAXErrorType {
         }
     }
 }
+
+extension DAXErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .clusterAlreadyExistsFault(let message):
+            return "ClusterAlreadyExistsFault: \(message ?? "")"
+        case .clusterNotFoundFault(let message):
+            return "ClusterNotFoundFault: \(message ?? "")"
+        case .clusterQuotaForCustomerExceededFault(let message):
+            return "ClusterQuotaForCustomerExceededFault: \(message ?? "")"
+        case .insufficientClusterCapacityFault(let message):
+            return "InsufficientClusterCapacityFault: \(message ?? "")"
+        case .invalidARNFault(let message):
+            return "InvalidARNFault: \(message ?? "")"
+        case .invalidClusterStateFault(let message):
+            return "InvalidClusterStateFault: \(message ?? "")"
+        case .invalidParameterCombinationException(let message):
+            return "InvalidParameterCombinationException: \(message ?? "")"
+        case .invalidParameterGroupStateFault(let message):
+            return "InvalidParameterGroupStateFault: \(message ?? "")"
+        case .invalidParameterValueException(let message):
+            return "InvalidParameterValueException: \(message ?? "")"
+        case .invalidSubnet(let message):
+            return "InvalidSubnet: \(message ?? "")"
+        case .invalidVPCNetworkStateFault(let message):
+            return "InvalidVPCNetworkStateFault: \(message ?? "")"
+        case .nodeNotFoundFault(let message):
+            return "NodeNotFoundFault: \(message ?? "")"
+        case .nodeQuotaForClusterExceededFault(let message):
+            return "NodeQuotaForClusterExceededFault: \(message ?? "")"
+        case .nodeQuotaForCustomerExceededFault(let message):
+            return "NodeQuotaForCustomerExceededFault: \(message ?? "")"
+        case .parameterGroupAlreadyExistsFault(let message):
+            return "ParameterGroupAlreadyExistsFault: \(message ?? "")"
+        case .parameterGroupNotFoundFault(let message):
+            return "ParameterGroupNotFoundFault: \(message ?? "")"
+        case .parameterGroupQuotaExceededFault(let message):
+            return "ParameterGroupQuotaExceededFault: \(message ?? "")"
+        case .serviceLinkedRoleNotFoundFault(let message):
+            return "ServiceLinkedRoleNotFoundFault: \(message ?? "")"
+        case .subnetGroupAlreadyExistsFault(let message):
+            return "SubnetGroupAlreadyExistsFault: \(message ?? "")"
+        case .subnetGroupInUseFault(let message):
+            return "SubnetGroupInUseFault: \(message ?? "")"
+        case .subnetGroupNotFoundFault(let message):
+            return "SubnetGroupNotFoundFault: \(message ?? "")"
+        case .subnetGroupQuotaExceededFault(let message):
+            return "SubnetGroupQuotaExceededFault: \(message ?? "")"
+        case .subnetInUse(let message):
+            return "SubnetInUse: \(message ?? "")"
+        case .subnetQuotaExceededFault(let message):
+            return "SubnetQuotaExceededFault: \(message ?? "")"
+        case .tagNotFoundFault(let message):
+            return "TagNotFoundFault: \(message ?? "")"
+        case .tagQuotaPerResourceExceeded(let message):
+            return "TagQuotaPerResourceExceeded: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/DLM/DLM_Error.swift
+++ b/Sources/AWSSDKSwift/Services/DLM/DLM_Error.swift
@@ -30,3 +30,18 @@ extension DLMErrorType {
         }
     }
 }
+
+extension DLMErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .internalServerException(let message):
+            return "InternalServerException: \(message ?? "")"
+        case .invalidRequestException(let message):
+            return "InvalidRequestException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/DataPipeline/DataPipeline_Error.swift
+++ b/Sources/AWSSDKSwift/Services/DataPipeline/DataPipeline_Error.swift
@@ -33,3 +33,20 @@ extension DataPipelineErrorType {
         }
     }
 }
+
+extension DataPipelineErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .internalServiceError(let message):
+            return "InternalServiceError: \(message ?? "")"
+        case .invalidRequestException(let message):
+            return "InvalidRequestException: \(message ?? "")"
+        case .pipelineDeletedException(let message):
+            return "PipelineDeletedException: \(message ?? "")"
+        case .pipelineNotFoundException(let message):
+            return "PipelineNotFoundException: \(message ?? "")"
+        case .taskNotFoundException(let message):
+            return "TaskNotFoundException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/DataSync/DataSync_Error.swift
+++ b/Sources/AWSSDKSwift/Services/DataSync/DataSync_Error.swift
@@ -24,3 +24,14 @@ extension DataSyncErrorType {
         }
     }
 }
+
+extension DataSyncErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .internalException(let message):
+            return "InternalException: \(message ?? "")"
+        case .invalidRequestException(let message):
+            return "InvalidRequestException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/DatabaseMigrationService/DatabaseMigrationService_Error.swift
+++ b/Sources/AWSSDKSwift/Services/DatabaseMigrationService/DatabaseMigrationService_Error.swift
@@ -78,3 +78,50 @@ extension DatabaseMigrationServiceErrorType {
         }
     }
 }
+
+extension DatabaseMigrationServiceErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .accessDeniedFault(let message):
+            return "AccessDeniedFault: \(message ?? "")"
+        case .insufficientResourceCapacityFault(let message):
+            return "InsufficientResourceCapacityFault: \(message ?? "")"
+        case .invalidCertificateFault(let message):
+            return "InvalidCertificateFault: \(message ?? "")"
+        case .invalidResourceStateFault(let message):
+            return "InvalidResourceStateFault: \(message ?? "")"
+        case .invalidSubnet(let message):
+            return "InvalidSubnet: \(message ?? "")"
+        case .kMSAccessDeniedFault(let message):
+            return "KMSAccessDeniedFault: \(message ?? "")"
+        case .kMSDisabledFault(let message):
+            return "KMSDisabledFault: \(message ?? "")"
+        case .kMSInvalidStateFault(let message):
+            return "KMSInvalidStateFault: \(message ?? "")"
+        case .kMSKeyNotAccessibleFault(let message):
+            return "KMSKeyNotAccessibleFault: \(message ?? "")"
+        case .kMSNotFoundFault(let message):
+            return "KMSNotFoundFault: \(message ?? "")"
+        case .kMSThrottlingFault(let message):
+            return "KMSThrottlingFault: \(message ?? "")"
+        case .replicationSubnetGroupDoesNotCoverEnoughAZs(let message):
+            return "ReplicationSubnetGroupDoesNotCoverEnoughAZs: \(message ?? "")"
+        case .resourceAlreadyExistsFault(let message):
+            return "ResourceAlreadyExistsFault: \(message ?? "")"
+        case .resourceNotFoundFault(let message):
+            return "ResourceNotFoundFault: \(message ?? "")"
+        case .resourceQuotaExceededFault(let message):
+            return "ResourceQuotaExceededFault: \(message ?? "")"
+        case .sNSInvalidTopicFault(let message):
+            return "SNSInvalidTopicFault: \(message ?? "")"
+        case .sNSNoAuthorizationFault(let message):
+            return "SNSNoAuthorizationFault: \(message ?? "")"
+        case .storageQuotaExceededFault(let message):
+            return "StorageQuotaExceededFault: \(message ?? "")"
+        case .subnetAlreadyInUse(let message):
+            return "SubnetAlreadyInUse: \(message ?? "")"
+        case .upgradeDependencyFailureFault(let message):
+            return "UpgradeDependencyFailureFault: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/DeviceFarm/DeviceFarm_Error.swift
+++ b/Sources/AWSSDKSwift/Services/DeviceFarm/DeviceFarm_Error.swift
@@ -48,3 +48,30 @@ extension DeviceFarmErrorType {
         }
     }
 }
+
+extension DeviceFarmErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .argumentException(let message):
+            return "ArgumentException: \(message ?? "")"
+        case .idempotencyException(let message):
+            return "IdempotencyException: \(message ?? "")"
+        case .invalidOperationException(let message):
+            return "InvalidOperationException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .notEligibleException(let message):
+            return "NotEligibleException: \(message ?? "")"
+        case .notFoundException(let message):
+            return "NotFoundException: \(message ?? "")"
+        case .serviceAccountException(let message):
+            return "ServiceAccountException: \(message ?? "")"
+        case .tagOperationException(let message):
+            return "TagOperationException: \(message ?? "")"
+        case .tagPolicyException(let message):
+            return "TagPolicyException: \(message ?? "")"
+        case .tooManyTagsException(let message):
+            return "TooManyTagsException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/DirectConnect/DirectConnect_Error.swift
+++ b/Sources/AWSSDKSwift/Services/DirectConnect/DirectConnect_Error.swift
@@ -30,3 +30,18 @@ extension DirectConnectErrorType {
         }
     }
 }
+
+extension DirectConnectErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .directConnectClientException(let message):
+            return "DirectConnectClientException: \(message ?? "")"
+        case .directConnectServerException(let message):
+            return "DirectConnectServerException: \(message ?? "")"
+        case .duplicateTagKeysException(let message):
+            return "DuplicateTagKeysException: \(message ?? "")"
+        case .tooManyTagsException(let message):
+            return "TooManyTagsException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/DocDB/DocDB_Error.swift
+++ b/Sources/AWSSDKSwift/Services/DocDB/DocDB_Error.swift
@@ -150,3 +150,98 @@ extension DocDBErrorType {
         }
     }
 }
+
+extension DocDBErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .authorizationNotFoundFault(let message):
+            return "AuthorizationNotFoundFault: \(message ?? "")"
+        case .certificateNotFoundFault(let message):
+            return "CertificateNotFoundFault: \(message ?? "")"
+        case .dBClusterAlreadyExistsFault(let message):
+            return "DBClusterAlreadyExistsFault: \(message ?? "")"
+        case .dBClusterNotFoundFault(let message):
+            return "DBClusterNotFoundFault: \(message ?? "")"
+        case .dBClusterParameterGroupNotFoundFault(let message):
+            return "DBClusterParameterGroupNotFoundFault: \(message ?? "")"
+        case .dBClusterQuotaExceededFault(let message):
+            return "DBClusterQuotaExceededFault: \(message ?? "")"
+        case .dBClusterSnapshotAlreadyExistsFault(let message):
+            return "DBClusterSnapshotAlreadyExistsFault: \(message ?? "")"
+        case .dBClusterSnapshotNotFoundFault(let message):
+            return "DBClusterSnapshotNotFoundFault: \(message ?? "")"
+        case .dBInstanceAlreadyExistsFault(let message):
+            return "DBInstanceAlreadyExistsFault: \(message ?? "")"
+        case .dBInstanceNotFoundFault(let message):
+            return "DBInstanceNotFoundFault: \(message ?? "")"
+        case .dBParameterGroupAlreadyExistsFault(let message):
+            return "DBParameterGroupAlreadyExistsFault: \(message ?? "")"
+        case .dBParameterGroupNotFoundFault(let message):
+            return "DBParameterGroupNotFoundFault: \(message ?? "")"
+        case .dBParameterGroupQuotaExceededFault(let message):
+            return "DBParameterGroupQuotaExceededFault: \(message ?? "")"
+        case .dBSecurityGroupNotFoundFault(let message):
+            return "DBSecurityGroupNotFoundFault: \(message ?? "")"
+        case .dBSnapshotAlreadyExistsFault(let message):
+            return "DBSnapshotAlreadyExistsFault: \(message ?? "")"
+        case .dBSnapshotNotFoundFault(let message):
+            return "DBSnapshotNotFoundFault: \(message ?? "")"
+        case .dBSubnetGroupAlreadyExistsFault(let message):
+            return "DBSubnetGroupAlreadyExistsFault: \(message ?? "")"
+        case .dBSubnetGroupDoesNotCoverEnoughAZs(let message):
+            return "DBSubnetGroupDoesNotCoverEnoughAZs: \(message ?? "")"
+        case .dBSubnetGroupNotFoundFault(let message):
+            return "DBSubnetGroupNotFoundFault: \(message ?? "")"
+        case .dBSubnetGroupQuotaExceededFault(let message):
+            return "DBSubnetGroupQuotaExceededFault: \(message ?? "")"
+        case .dBSubnetQuotaExceededFault(let message):
+            return "DBSubnetQuotaExceededFault: \(message ?? "")"
+        case .dBUpgradeDependencyFailureFault(let message):
+            return "DBUpgradeDependencyFailureFault: \(message ?? "")"
+        case .instanceQuotaExceededFault(let message):
+            return "InstanceQuotaExceededFault: \(message ?? "")"
+        case .insufficientDBClusterCapacityFault(let message):
+            return "InsufficientDBClusterCapacityFault: \(message ?? "")"
+        case .insufficientDBInstanceCapacityFault(let message):
+            return "InsufficientDBInstanceCapacityFault: \(message ?? "")"
+        case .insufficientStorageClusterCapacityFault(let message):
+            return "InsufficientStorageClusterCapacityFault: \(message ?? "")"
+        case .invalidDBClusterSnapshotStateFault(let message):
+            return "InvalidDBClusterSnapshotStateFault: \(message ?? "")"
+        case .invalidDBClusterStateFault(let message):
+            return "InvalidDBClusterStateFault: \(message ?? "")"
+        case .invalidDBInstanceStateFault(let message):
+            return "InvalidDBInstanceStateFault: \(message ?? "")"
+        case .invalidDBParameterGroupStateFault(let message):
+            return "InvalidDBParameterGroupStateFault: \(message ?? "")"
+        case .invalidDBSecurityGroupStateFault(let message):
+            return "InvalidDBSecurityGroupStateFault: \(message ?? "")"
+        case .invalidDBSnapshotStateFault(let message):
+            return "InvalidDBSnapshotStateFault: \(message ?? "")"
+        case .invalidDBSubnetGroupStateFault(let message):
+            return "InvalidDBSubnetGroupStateFault: \(message ?? "")"
+        case .invalidDBSubnetStateFault(let message):
+            return "InvalidDBSubnetStateFault: \(message ?? "")"
+        case .invalidRestoreFault(let message):
+            return "InvalidRestoreFault: \(message ?? "")"
+        case .invalidSubnet(let message):
+            return "InvalidSubnet: \(message ?? "")"
+        case .invalidVPCNetworkStateFault(let message):
+            return "InvalidVPCNetworkStateFault: \(message ?? "")"
+        case .kMSKeyNotAccessibleFault(let message):
+            return "KMSKeyNotAccessibleFault: \(message ?? "")"
+        case .resourceNotFoundFault(let message):
+            return "ResourceNotFoundFault: \(message ?? "")"
+        case .sharedSnapshotQuotaExceededFault(let message):
+            return "SharedSnapshotQuotaExceededFault: \(message ?? "")"
+        case .snapshotQuotaExceededFault(let message):
+            return "SnapshotQuotaExceededFault: \(message ?? "")"
+        case .storageQuotaExceededFault(let message):
+            return "StorageQuotaExceededFault: \(message ?? "")"
+        case .storageTypeNotSupportedFault(let message):
+            return "StorageTypeNotSupportedFault: \(message ?? "")"
+        case .subnetAlreadyInUse(let message):
+            return "SubnetAlreadyInUse: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/DynamoDB/DynamoDB_Error.swift
+++ b/Sources/AWSSDKSwift/Services/DynamoDB/DynamoDB_Error.swift
@@ -93,3 +93,60 @@ extension DynamoDBErrorType {
         }
     }
 }
+
+extension DynamoDBErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .backupInUseException(let message):
+            return "BackupInUseException: \(message ?? "")"
+        case .backupNotFoundException(let message):
+            return "BackupNotFoundException: \(message ?? "")"
+        case .conditionalCheckFailedException(let message):
+            return "ConditionalCheckFailedException: \(message ?? "")"
+        case .continuousBackupsUnavailableException(let message):
+            return "ContinuousBackupsUnavailableException: \(message ?? "")"
+        case .globalTableAlreadyExistsException(let message):
+            return "GlobalTableAlreadyExistsException: \(message ?? "")"
+        case .globalTableNotFoundException(let message):
+            return "GlobalTableNotFoundException: \(message ?? "")"
+        case .idempotentParameterMismatchException(let message):
+            return "IdempotentParameterMismatchException: \(message ?? "")"
+        case .indexNotFoundException(let message):
+            return "IndexNotFoundException: \(message ?? "")"
+        case .internalServerError(let message):
+            return "InternalServerError: \(message ?? "")"
+        case .invalidRestoreTimeException(let message):
+            return "InvalidRestoreTimeException: \(message ?? "")"
+        case .itemCollectionSizeLimitExceededException(let message):
+            return "ItemCollectionSizeLimitExceededException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .pointInTimeRecoveryUnavailableException(let message):
+            return "PointInTimeRecoveryUnavailableException: \(message ?? "")"
+        case .provisionedThroughputExceededException(let message):
+            return "ProvisionedThroughputExceededException: \(message ?? "")"
+        case .replicaAlreadyExistsException(let message):
+            return "ReplicaAlreadyExistsException: \(message ?? "")"
+        case .replicaNotFoundException(let message):
+            return "ReplicaNotFoundException: \(message ?? "")"
+        case .requestLimitExceeded(let message):
+            return "RequestLimitExceeded: \(message ?? "")"
+        case .resourceInUseException(let message):
+            return "ResourceInUseException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .tableAlreadyExistsException(let message):
+            return "TableAlreadyExistsException: \(message ?? "")"
+        case .tableInUseException(let message):
+            return "TableInUseException: \(message ?? "")"
+        case .tableNotFoundException(let message):
+            return "TableNotFoundException: \(message ?? "")"
+        case .transactionCanceledException(let message):
+            return "TransactionCanceledException: \(message ?? "")"
+        case .transactionConflictException(let message):
+            return "TransactionConflictException: \(message ?? "")"
+        case .transactionInProgressException(let message):
+            return "TransactionInProgressException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/DynamoDBStreams/DynamoDBStreams_Error.swift
+++ b/Sources/AWSSDKSwift/Services/DynamoDBStreams/DynamoDBStreams_Error.swift
@@ -33,3 +33,20 @@ extension DynamoDBStreamsErrorType {
         }
     }
 }
+
+extension DynamoDBStreamsErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .expiredIteratorException(let message):
+            return "ExpiredIteratorException: \(message ?? "")"
+        case .internalServerError(let message):
+            return "InternalServerError: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .trimmedDataAccessException(let message):
+            return "TrimmedDataAccessException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/EC2InstanceConnect/EC2InstanceConnect_Error.swift
+++ b/Sources/AWSSDKSwift/Services/EC2InstanceConnect/EC2InstanceConnect_Error.swift
@@ -33,3 +33,20 @@ extension EC2InstanceConnectErrorType {
         }
     }
 }
+
+extension EC2InstanceConnectErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .authException(let message):
+            return "AuthException: \(message ?? "")"
+        case .eC2InstanceNotFoundException(let message):
+            return "EC2InstanceNotFoundException: \(message ?? "")"
+        case .invalidArgsException(let message):
+            return "InvalidArgsException: \(message ?? "")"
+        case .serviceException(let message):
+            return "ServiceException: \(message ?? "")"
+        case .throttlingException(let message):
+            return "ThrottlingException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/ECR/ECR_Error.swift
+++ b/Sources/AWSSDKSwift/Services/ECR/ECR_Error.swift
@@ -84,3 +84,54 @@ extension ECRErrorType {
         }
     }
 }
+
+extension ECRErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .emptyUploadException(let message):
+            return "EmptyUploadException: \(message ?? "")"
+        case .imageAlreadyExistsException(let message):
+            return "ImageAlreadyExistsException: \(message ?? "")"
+        case .imageNotFoundException(let message):
+            return "ImageNotFoundException: \(message ?? "")"
+        case .invalidLayerException(let message):
+            return "InvalidLayerException: \(message ?? "")"
+        case .invalidLayerPartException(let message):
+            return "InvalidLayerPartException: \(message ?? "")"
+        case .invalidParameterException(let message):
+            return "InvalidParameterException: \(message ?? "")"
+        case .invalidTagParameterException(let message):
+            return "InvalidTagParameterException: \(message ?? "")"
+        case .layerAlreadyExistsException(let message):
+            return "LayerAlreadyExistsException: \(message ?? "")"
+        case .layerInaccessibleException(let message):
+            return "LayerInaccessibleException: \(message ?? "")"
+        case .layerPartTooSmallException(let message):
+            return "LayerPartTooSmallException: \(message ?? "")"
+        case .layersNotFoundException(let message):
+            return "LayersNotFoundException: \(message ?? "")"
+        case .lifecyclePolicyNotFoundException(let message):
+            return "LifecyclePolicyNotFoundException: \(message ?? "")"
+        case .lifecyclePolicyPreviewInProgressException(let message):
+            return "LifecyclePolicyPreviewInProgressException: \(message ?? "")"
+        case .lifecyclePolicyPreviewNotFoundException(let message):
+            return "LifecyclePolicyPreviewNotFoundException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .repositoryAlreadyExistsException(let message):
+            return "RepositoryAlreadyExistsException: \(message ?? "")"
+        case .repositoryNotEmptyException(let message):
+            return "RepositoryNotEmptyException: \(message ?? "")"
+        case .repositoryNotFoundException(let message):
+            return "RepositoryNotFoundException: \(message ?? "")"
+        case .repositoryPolicyNotFoundException(let message):
+            return "RepositoryPolicyNotFoundException: \(message ?? "")"
+        case .serverException(let message):
+            return "ServerException: \(message ?? "")"
+        case .tooManyTagsException(let message):
+            return "TooManyTagsException: \(message ?? "")"
+        case .uploadNotFoundException(let message):
+            return "UploadNotFoundException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/ECS/ECS_Error.swift
+++ b/Sources/AWSSDKSwift/Services/ECS/ECS_Error.swift
@@ -81,3 +81,52 @@ extension ECSErrorType {
         }
     }
 }
+
+extension ECSErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .accessDeniedException(let message):
+            return "AccessDeniedException: \(message ?? "")"
+        case .attributeLimitExceededException(let message):
+            return "AttributeLimitExceededException: \(message ?? "")"
+        case .blockedException(let message):
+            return "BlockedException: \(message ?? "")"
+        case .clientException(let message):
+            return "ClientException: \(message ?? "")"
+        case .clusterContainsContainerInstancesException(let message):
+            return "ClusterContainsContainerInstancesException: \(message ?? "")"
+        case .clusterContainsServicesException(let message):
+            return "ClusterContainsServicesException: \(message ?? "")"
+        case .clusterContainsTasksException(let message):
+            return "ClusterContainsTasksException: \(message ?? "")"
+        case .clusterNotFoundException(let message):
+            return "ClusterNotFoundException: \(message ?? "")"
+        case .invalidParameterException(let message):
+            return "InvalidParameterException: \(message ?? "")"
+        case .missingVersionException(let message):
+            return "MissingVersionException: \(message ?? "")"
+        case .noUpdateAvailableException(let message):
+            return "NoUpdateAvailableException: \(message ?? "")"
+        case .platformTaskDefinitionIncompatibilityException(let message):
+            return "PlatformTaskDefinitionIncompatibilityException: \(message ?? "")"
+        case .platformUnknownException(let message):
+            return "PlatformUnknownException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .serverException(let message):
+            return "ServerException: \(message ?? "")"
+        case .serviceNotActiveException(let message):
+            return "ServiceNotActiveException: \(message ?? "")"
+        case .serviceNotFoundException(let message):
+            return "ServiceNotFoundException: \(message ?? "")"
+        case .targetNotFoundException(let message):
+            return "TargetNotFoundException: \(message ?? "")"
+        case .taskSetNotFoundException(let message):
+            return "TaskSetNotFoundException: \(message ?? "")"
+        case .unsupportedFeatureException(let message):
+            return "UnsupportedFeatureException: \(message ?? "")"
+        case .updateInProgressException(let message):
+            return "UpdateInProgressException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/EFS/EFS_Error.swift
+++ b/Sources/AWSSDKSwift/Services/EFS/EFS_Error.swift
@@ -81,3 +81,52 @@ extension EFSErrorType {
         }
     }
 }
+
+extension EFSErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .badRequest(let message):
+            return "BadRequest: \(message ?? "")"
+        case .dependencyTimeout(let message):
+            return "DependencyTimeout: \(message ?? "")"
+        case .fileSystemAlreadyExists(let message):
+            return "FileSystemAlreadyExists: \(message ?? "")"
+        case .fileSystemInUse(let message):
+            return "FileSystemInUse: \(message ?? "")"
+        case .fileSystemLimitExceeded(let message):
+            return "FileSystemLimitExceeded: \(message ?? "")"
+        case .fileSystemNotFound(let message):
+            return "FileSystemNotFound: \(message ?? "")"
+        case .incorrectFileSystemLifeCycleState(let message):
+            return "IncorrectFileSystemLifeCycleState: \(message ?? "")"
+        case .incorrectMountTargetState(let message):
+            return "IncorrectMountTargetState: \(message ?? "")"
+        case .insufficientThroughputCapacity(let message):
+            return "InsufficientThroughputCapacity: \(message ?? "")"
+        case .internalServerError(let message):
+            return "InternalServerError: \(message ?? "")"
+        case .ipAddressInUse(let message):
+            return "IpAddressInUse: \(message ?? "")"
+        case .mountTargetConflict(let message):
+            return "MountTargetConflict: \(message ?? "")"
+        case .mountTargetNotFound(let message):
+            return "MountTargetNotFound: \(message ?? "")"
+        case .networkInterfaceLimitExceeded(let message):
+            return "NetworkInterfaceLimitExceeded: \(message ?? "")"
+        case .noFreeAddressesInSubnet(let message):
+            return "NoFreeAddressesInSubnet: \(message ?? "")"
+        case .securityGroupLimitExceeded(let message):
+            return "SecurityGroupLimitExceeded: \(message ?? "")"
+        case .securityGroupNotFound(let message):
+            return "SecurityGroupNotFound: \(message ?? "")"
+        case .subnetNotFound(let message):
+            return "SubnetNotFound: \(message ?? "")"
+        case .throughputLimitExceeded(let message):
+            return "ThroughputLimitExceeded: \(message ?? "")"
+        case .tooManyRequests(let message):
+            return "TooManyRequests: \(message ?? "")"
+        case .unsupportedAvailabilityZone(let message):
+            return "UnsupportedAvailabilityZone: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/EKS/EKS_Error.swift
+++ b/Sources/AWSSDKSwift/Services/EKS/EKS_Error.swift
@@ -45,3 +45,28 @@ extension EKSErrorType {
         }
     }
 }
+
+extension EKSErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .clientException(let message):
+            return "ClientException: \(message ?? "")"
+        case .invalidParameterException(let message):
+            return "InvalidParameterException: \(message ?? "")"
+        case .invalidRequestException(let message):
+            return "InvalidRequestException: \(message ?? "")"
+        case .resourceInUseException(let message):
+            return "ResourceInUseException: \(message ?? "")"
+        case .resourceLimitExceededException(let message):
+            return "ResourceLimitExceededException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .serverException(let message):
+            return "ServerException: \(message ?? "")"
+        case .serviceUnavailableException(let message):
+            return "ServiceUnavailableException: \(message ?? "")"
+        case .unsupportedAvailabilityZoneException(let message):
+            return "UnsupportedAvailabilityZoneException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/ELB/ELB_Error.swift
+++ b/Sources/AWSSDKSwift/Services/ELB/ELB_Error.swift
@@ -84,3 +84,54 @@ extension ELBErrorType {
         }
     }
 }
+
+extension ELBErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .accessPointNotFoundException(let message):
+            return "AccessPointNotFoundException: \(message ?? "")"
+        case .certificateNotFoundException(let message):
+            return "CertificateNotFoundException: \(message ?? "")"
+        case .dependencyThrottleException(let message):
+            return "DependencyThrottleException: \(message ?? "")"
+        case .duplicateAccessPointNameException(let message):
+            return "DuplicateAccessPointNameException: \(message ?? "")"
+        case .duplicateListenerException(let message):
+            return "DuplicateListenerException: \(message ?? "")"
+        case .duplicatePolicyNameException(let message):
+            return "DuplicatePolicyNameException: \(message ?? "")"
+        case .duplicateTagKeysException(let message):
+            return "DuplicateTagKeysException: \(message ?? "")"
+        case .invalidConfigurationRequestException(let message):
+            return "InvalidConfigurationRequestException: \(message ?? "")"
+        case .invalidEndPointException(let message):
+            return "InvalidEndPointException: \(message ?? "")"
+        case .invalidSchemeException(let message):
+            return "InvalidSchemeException: \(message ?? "")"
+        case .invalidSecurityGroupException(let message):
+            return "InvalidSecurityGroupException: \(message ?? "")"
+        case .invalidSubnetException(let message):
+            return "InvalidSubnetException: \(message ?? "")"
+        case .listenerNotFoundException(let message):
+            return "ListenerNotFoundException: \(message ?? "")"
+        case .loadBalancerAttributeNotFoundException(let message):
+            return "LoadBalancerAttributeNotFoundException: \(message ?? "")"
+        case .operationNotPermittedException(let message):
+            return "OperationNotPermittedException: \(message ?? "")"
+        case .policyNotFoundException(let message):
+            return "PolicyNotFoundException: \(message ?? "")"
+        case .policyTypeNotFoundException(let message):
+            return "PolicyTypeNotFoundException: \(message ?? "")"
+        case .subnetNotFoundException(let message):
+            return "SubnetNotFoundException: \(message ?? "")"
+        case .tooManyAccessPointsException(let message):
+            return "TooManyAccessPointsException: \(message ?? "")"
+        case .tooManyPoliciesException(let message):
+            return "TooManyPoliciesException: \(message ?? "")"
+        case .tooManyTagsException(let message):
+            return "TooManyTagsException: \(message ?? "")"
+        case .unsupportedProtocolException(let message):
+            return "UnsupportedProtocolException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/ELBV2/ELBV2_Error.swift
+++ b/Sources/AWSSDKSwift/Services/ELBV2/ELBV2_Error.swift
@@ -123,3 +123,80 @@ extension ELBV2ErrorType {
         }
     }
 }
+
+extension ELBV2ErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .allocationIdNotFoundException(let message):
+            return "AllocationIdNotFoundException: \(message ?? "")"
+        case .availabilityZoneNotSupportedException(let message):
+            return "AvailabilityZoneNotSupportedException: \(message ?? "")"
+        case .certificateNotFoundException(let message):
+            return "CertificateNotFoundException: \(message ?? "")"
+        case .duplicateListenerException(let message):
+            return "DuplicateListenerException: \(message ?? "")"
+        case .duplicateLoadBalancerNameException(let message):
+            return "DuplicateLoadBalancerNameException: \(message ?? "")"
+        case .duplicateTagKeysException(let message):
+            return "DuplicateTagKeysException: \(message ?? "")"
+        case .duplicateTargetGroupNameException(let message):
+            return "DuplicateTargetGroupNameException: \(message ?? "")"
+        case .healthUnavailableException(let message):
+            return "HealthUnavailableException: \(message ?? "")"
+        case .incompatibleProtocolsException(let message):
+            return "IncompatibleProtocolsException: \(message ?? "")"
+        case .invalidConfigurationRequestException(let message):
+            return "InvalidConfigurationRequestException: \(message ?? "")"
+        case .invalidLoadBalancerActionException(let message):
+            return "InvalidLoadBalancerActionException: \(message ?? "")"
+        case .invalidSchemeException(let message):
+            return "InvalidSchemeException: \(message ?? "")"
+        case .invalidSecurityGroupException(let message):
+            return "InvalidSecurityGroupException: \(message ?? "")"
+        case .invalidSubnetException(let message):
+            return "InvalidSubnetException: \(message ?? "")"
+        case .invalidTargetException(let message):
+            return "InvalidTargetException: \(message ?? "")"
+        case .listenerNotFoundException(let message):
+            return "ListenerNotFoundException: \(message ?? "")"
+        case .loadBalancerNotFoundException(let message):
+            return "LoadBalancerNotFoundException: \(message ?? "")"
+        case .operationNotPermittedException(let message):
+            return "OperationNotPermittedException: \(message ?? "")"
+        case .priorityInUseException(let message):
+            return "PriorityInUseException: \(message ?? "")"
+        case .resourceInUseException(let message):
+            return "ResourceInUseException: \(message ?? "")"
+        case .ruleNotFoundException(let message):
+            return "RuleNotFoundException: \(message ?? "")"
+        case .sSLPolicyNotFoundException(let message):
+            return "SSLPolicyNotFoundException: \(message ?? "")"
+        case .subnetNotFoundException(let message):
+            return "SubnetNotFoundException: \(message ?? "")"
+        case .targetGroupAssociationLimitException(let message):
+            return "TargetGroupAssociationLimitException: \(message ?? "")"
+        case .targetGroupNotFoundException(let message):
+            return "TargetGroupNotFoundException: \(message ?? "")"
+        case .tooManyActionsException(let message):
+            return "TooManyActionsException: \(message ?? "")"
+        case .tooManyCertificatesException(let message):
+            return "TooManyCertificatesException: \(message ?? "")"
+        case .tooManyListenersException(let message):
+            return "TooManyListenersException: \(message ?? "")"
+        case .tooManyLoadBalancersException(let message):
+            return "TooManyLoadBalancersException: \(message ?? "")"
+        case .tooManyRegistrationsForTargetIdException(let message):
+            return "TooManyRegistrationsForTargetIdException: \(message ?? "")"
+        case .tooManyRulesException(let message):
+            return "TooManyRulesException: \(message ?? "")"
+        case .tooManyTagsException(let message):
+            return "TooManyTagsException: \(message ?? "")"
+        case .tooManyTargetGroupsException(let message):
+            return "TooManyTargetGroupsException: \(message ?? "")"
+        case .tooManyTargetsException(let message):
+            return "TooManyTargetsException: \(message ?? "")"
+        case .unsupportedProtocolException(let message):
+            return "UnsupportedProtocolException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/EMR/EMR_Error.swift
+++ b/Sources/AWSSDKSwift/Services/EMR/EMR_Error.swift
@@ -27,3 +27,16 @@ extension EMRErrorType {
         }
     }
 }
+
+extension EMRErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .internalServerError(let message):
+            return "InternalServerError: \(message ?? "")"
+        case .internalServerException(let message):
+            return "InternalServerException: \(message ?? "")"
+        case .invalidRequestException(let message):
+            return "InvalidRequestException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/ElastiCache/ElastiCache_Error.swift
+++ b/Sources/AWSSDKSwift/Services/ElastiCache/ElastiCache_Error.swift
@@ -165,3 +165,108 @@ extension ElastiCacheErrorType {
         }
     }
 }
+
+extension ElastiCacheErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .aPICallRateForCustomerExceededFault(let message):
+            return "APICallRateForCustomerExceededFault: \(message ?? "")"
+        case .authorizationAlreadyExistsFault(let message):
+            return "AuthorizationAlreadyExistsFault: \(message ?? "")"
+        case .authorizationNotFoundFault(let message):
+            return "AuthorizationNotFoundFault: \(message ?? "")"
+        case .cacheClusterAlreadyExistsFault(let message):
+            return "CacheClusterAlreadyExistsFault: \(message ?? "")"
+        case .cacheClusterNotFoundFault(let message):
+            return "CacheClusterNotFoundFault: \(message ?? "")"
+        case .cacheParameterGroupAlreadyExistsFault(let message):
+            return "CacheParameterGroupAlreadyExistsFault: \(message ?? "")"
+        case .cacheParameterGroupNotFoundFault(let message):
+            return "CacheParameterGroupNotFoundFault: \(message ?? "")"
+        case .cacheParameterGroupQuotaExceededFault(let message):
+            return "CacheParameterGroupQuotaExceededFault: \(message ?? "")"
+        case .cacheSecurityGroupAlreadyExistsFault(let message):
+            return "CacheSecurityGroupAlreadyExistsFault: \(message ?? "")"
+        case .cacheSecurityGroupNotFoundFault(let message):
+            return "CacheSecurityGroupNotFoundFault: \(message ?? "")"
+        case .cacheSecurityGroupQuotaExceededFault(let message):
+            return "CacheSecurityGroupQuotaExceededFault: \(message ?? "")"
+        case .cacheSubnetGroupAlreadyExistsFault(let message):
+            return "CacheSubnetGroupAlreadyExistsFault: \(message ?? "")"
+        case .cacheSubnetGroupInUse(let message):
+            return "CacheSubnetGroupInUse: \(message ?? "")"
+        case .cacheSubnetGroupNotFoundFault(let message):
+            return "CacheSubnetGroupNotFoundFault: \(message ?? "")"
+        case .cacheSubnetGroupQuotaExceededFault(let message):
+            return "CacheSubnetGroupQuotaExceededFault: \(message ?? "")"
+        case .cacheSubnetQuotaExceededFault(let message):
+            return "CacheSubnetQuotaExceededFault: \(message ?? "")"
+        case .clusterQuotaForCustomerExceededFault(let message):
+            return "ClusterQuotaForCustomerExceededFault: \(message ?? "")"
+        case .insufficientCacheClusterCapacityFault(let message):
+            return "InsufficientCacheClusterCapacityFault: \(message ?? "")"
+        case .invalidARNFault(let message):
+            return "InvalidARNFault: \(message ?? "")"
+        case .invalidCacheClusterStateFault(let message):
+            return "InvalidCacheClusterStateFault: \(message ?? "")"
+        case .invalidCacheParameterGroupStateFault(let message):
+            return "InvalidCacheParameterGroupStateFault: \(message ?? "")"
+        case .invalidCacheSecurityGroupStateFault(let message):
+            return "InvalidCacheSecurityGroupStateFault: \(message ?? "")"
+        case .invalidParameterCombinationException(let message):
+            return "InvalidParameterCombinationException: \(message ?? "")"
+        case .invalidParameterValueException(let message):
+            return "InvalidParameterValueException: \(message ?? "")"
+        case .invalidReplicationGroupStateFault(let message):
+            return "InvalidReplicationGroupStateFault: \(message ?? "")"
+        case .invalidSnapshotStateFault(let message):
+            return "InvalidSnapshotStateFault: \(message ?? "")"
+        case .invalidSubnet(let message):
+            return "InvalidSubnet: \(message ?? "")"
+        case .invalidVPCNetworkStateFault(let message):
+            return "InvalidVPCNetworkStateFault: \(message ?? "")"
+        case .noOperationFault(let message):
+            return "NoOperationFault: \(message ?? "")"
+        case .nodeGroupNotFoundFault(let message):
+            return "NodeGroupNotFoundFault: \(message ?? "")"
+        case .nodeGroupsPerReplicationGroupQuotaExceededFault(let message):
+            return "NodeGroupsPerReplicationGroupQuotaExceededFault: \(message ?? "")"
+        case .nodeQuotaForClusterExceededFault(let message):
+            return "NodeQuotaForClusterExceededFault: \(message ?? "")"
+        case .nodeQuotaForCustomerExceededFault(let message):
+            return "NodeQuotaForCustomerExceededFault: \(message ?? "")"
+        case .replicationGroupAlreadyExistsFault(let message):
+            return "ReplicationGroupAlreadyExistsFault: \(message ?? "")"
+        case .replicationGroupNotFoundFault(let message):
+            return "ReplicationGroupNotFoundFault: \(message ?? "")"
+        case .reservedCacheNodeAlreadyExistsFault(let message):
+            return "ReservedCacheNodeAlreadyExistsFault: \(message ?? "")"
+        case .reservedCacheNodeNotFoundFault(let message):
+            return "ReservedCacheNodeNotFoundFault: \(message ?? "")"
+        case .reservedCacheNodeQuotaExceededFault(let message):
+            return "ReservedCacheNodeQuotaExceededFault: \(message ?? "")"
+        case .reservedCacheNodesOfferingNotFoundFault(let message):
+            return "ReservedCacheNodesOfferingNotFoundFault: \(message ?? "")"
+        case .serviceLinkedRoleNotFoundFault(let message):
+            return "ServiceLinkedRoleNotFoundFault: \(message ?? "")"
+        case .serviceUpdateNotFoundFault(let message):
+            return "ServiceUpdateNotFoundFault: \(message ?? "")"
+        case .snapshotAlreadyExistsFault(let message):
+            return "SnapshotAlreadyExistsFault: \(message ?? "")"
+        case .snapshotFeatureNotSupportedFault(let message):
+            return "SnapshotFeatureNotSupportedFault: \(message ?? "")"
+        case .snapshotNotFoundFault(let message):
+            return "SnapshotNotFoundFault: \(message ?? "")"
+        case .snapshotQuotaExceededFault(let message):
+            return "SnapshotQuotaExceededFault: \(message ?? "")"
+        case .subnetInUse(let message):
+            return "SubnetInUse: \(message ?? "")"
+        case .tagNotFoundFault(let message):
+            return "TagNotFoundFault: \(message ?? "")"
+        case .tagQuotaPerResourceExceeded(let message):
+            return "TagQuotaPerResourceExceeded: \(message ?? "")"
+        case .testFailoverNotAvailableFault(let message):
+            return "TestFailoverNotAvailableFault: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/ElasticBeanstalk/ElasticBeanstalk_Error.swift
+++ b/Sources/AWSSDKSwift/Services/ElasticBeanstalk/ElasticBeanstalk_Error.swift
@@ -75,3 +75,48 @@ extension ElasticBeanstalkErrorType {
         }
     }
 }
+
+extension ElasticBeanstalkErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .codeBuildNotInServiceRegionException(let message):
+            return "CodeBuildNotInServiceRegionException: \(message ?? "")"
+        case .elasticBeanstalkServiceException(let message):
+            return "ElasticBeanstalkServiceException: \(message ?? "")"
+        case .insufficientPrivilegesException(let message):
+            return "InsufficientPrivilegesException: \(message ?? "")"
+        case .invalidRequestException(let message):
+            return "InvalidRequestException: \(message ?? "")"
+        case .managedActionInvalidStateException(let message):
+            return "ManagedActionInvalidStateException: \(message ?? "")"
+        case .operationInProgressException(let message):
+            return "OperationInProgressException: \(message ?? "")"
+        case .platformVersionStillReferencedException(let message):
+            return "PlatformVersionStillReferencedException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .resourceTypeNotSupportedException(let message):
+            return "ResourceTypeNotSupportedException: \(message ?? "")"
+        case .s3LocationNotInServiceRegionException(let message):
+            return "S3LocationNotInServiceRegionException: \(message ?? "")"
+        case .s3SubscriptionRequiredException(let message):
+            return "S3SubscriptionRequiredException: \(message ?? "")"
+        case .sourceBundleDeletionException(let message):
+            return "SourceBundleDeletionException: \(message ?? "")"
+        case .tooManyApplicationVersionsException(let message):
+            return "TooManyApplicationVersionsException: \(message ?? "")"
+        case .tooManyApplicationsException(let message):
+            return "TooManyApplicationsException: \(message ?? "")"
+        case .tooManyBucketsException(let message):
+            return "TooManyBucketsException: \(message ?? "")"
+        case .tooManyConfigurationTemplatesException(let message):
+            return "TooManyConfigurationTemplatesException: \(message ?? "")"
+        case .tooManyEnvironmentsException(let message):
+            return "TooManyEnvironmentsException: \(message ?? "")"
+        case .tooManyPlatformsException(let message):
+            return "TooManyPlatformsException: \(message ?? "")"
+        case .tooManyTagsException(let message):
+            return "TooManyTagsException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/ElasticTranscoder/ElasticTranscoder_Error.swift
+++ b/Sources/AWSSDKSwift/Services/ElasticTranscoder/ElasticTranscoder_Error.swift
@@ -39,3 +39,24 @@ extension ElasticTranscoderErrorType {
         }
     }
 }
+
+extension ElasticTranscoderErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .accessDeniedException(let message):
+            return "AccessDeniedException: \(message ?? "")"
+        case .incompatibleVersionException(let message):
+            return "IncompatibleVersionException: \(message ?? "")"
+        case .internalServiceException(let message):
+            return "InternalServiceException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .resourceInUseException(let message):
+            return "ResourceInUseException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .validationException(let message):
+            return "ValidationException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/ElasticsearchService/ElasticsearchService_Error.swift
+++ b/Sources/AWSSDKSwift/Services/ElasticsearchService/ElasticsearchService_Error.swift
@@ -42,3 +42,26 @@ extension ElasticsearchServiceErrorType {
         }
     }
 }
+
+extension ElasticsearchServiceErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .baseException(let message):
+            return "BaseException: \(message ?? "")"
+        case .disabledOperationException(let message):
+            return "DisabledOperationException: \(message ?? "")"
+        case .internalException(let message):
+            return "InternalException: \(message ?? "")"
+        case .invalidTypeException(let message):
+            return "InvalidTypeException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .resourceAlreadyExistsException(let message):
+            return "ResourceAlreadyExistsException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .validationException(let message):
+            return "ValidationException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/FMS/FMS_Error.swift
+++ b/Sources/AWSSDKSwift/Services/FMS/FMS_Error.swift
@@ -36,3 +36,22 @@ extension FMSErrorType {
         }
     }
 }
+
+extension FMSErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .internalErrorException(let message):
+            return "InternalErrorException: \(message ?? "")"
+        case .invalidInputException(let message):
+            return "InvalidInputException: \(message ?? "")"
+        case .invalidOperationException(let message):
+            return "InvalidOperationException: \(message ?? "")"
+        case .invalidTypeException(let message):
+            return "InvalidTypeException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/FSx/FSx_Error.swift
+++ b/Sources/AWSSDKSwift/Services/FSx/FSx_Error.swift
@@ -69,3 +69,44 @@ extension FSxErrorType {
         }
     }
 }
+
+extension FSxErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .activeDirectoryError(let message):
+            return "ActiveDirectoryError: \(message ?? "")"
+        case .backupInProgress(let message):
+            return "BackupInProgress: \(message ?? "")"
+        case .backupNotFound(let message):
+            return "BackupNotFound: \(message ?? "")"
+        case .backupRestoring(let message):
+            return "BackupRestoring: \(message ?? "")"
+        case .badRequest(let message):
+            return "BadRequest: \(message ?? "")"
+        case .fileSystemNotFound(let message):
+            return "FileSystemNotFound: \(message ?? "")"
+        case .incompatibleParameterError(let message):
+            return "IncompatibleParameterError: \(message ?? "")"
+        case .internalServerError(let message):
+            return "InternalServerError: \(message ?? "")"
+        case .invalidExportPath(let message):
+            return "InvalidExportPath: \(message ?? "")"
+        case .invalidImportPath(let message):
+            return "InvalidImportPath: \(message ?? "")"
+        case .invalidNetworkSettings(let message):
+            return "InvalidNetworkSettings: \(message ?? "")"
+        case .missingFileSystemConfiguration(let message):
+            return "MissingFileSystemConfiguration: \(message ?? "")"
+        case .notServiceResourceError(let message):
+            return "NotServiceResourceError: \(message ?? "")"
+        case .resourceDoesNotSupportTagging(let message):
+            return "ResourceDoesNotSupportTagging: \(message ?? "")"
+        case .resourceNotFound(let message):
+            return "ResourceNotFound: \(message ?? "")"
+        case .serviceLimitExceeded(let message):
+            return "ServiceLimitExceeded: \(message ?? "")"
+        case .unsupportedOperation(let message):
+            return "UnsupportedOperation: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Firehose/Firehose_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Firehose/Firehose_Error.swift
@@ -36,3 +36,22 @@ extension FirehoseErrorType {
         }
     }
 }
+
+extension FirehoseErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .concurrentModificationException(let message):
+            return "ConcurrentModificationException: \(message ?? "")"
+        case .invalidArgumentException(let message):
+            return "InvalidArgumentException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .resourceInUseException(let message):
+            return "ResourceInUseException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .serviceUnavailableException(let message):
+            return "ServiceUnavailableException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/GameLift/GameLift_Error.swift
+++ b/Sources/AWSSDKSwift/Services/GameLift/GameLift_Error.swift
@@ -57,3 +57,36 @@ extension GameLiftErrorType {
         }
     }
 }
+
+extension GameLiftErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .conflictException(let message):
+            return "ConflictException: \(message ?? "")"
+        case .fleetCapacityExceededException(let message):
+            return "FleetCapacityExceededException: \(message ?? "")"
+        case .gameSessionFullException(let message):
+            return "GameSessionFullException: \(message ?? "")"
+        case .idempotentParameterMismatchException(let message):
+            return "IdempotentParameterMismatchException: \(message ?? "")"
+        case .internalServiceException(let message):
+            return "InternalServiceException: \(message ?? "")"
+        case .invalidFleetStatusException(let message):
+            return "InvalidFleetStatusException: \(message ?? "")"
+        case .invalidGameSessionStatusException(let message):
+            return "InvalidGameSessionStatusException: \(message ?? "")"
+        case .invalidRequestException(let message):
+            return "InvalidRequestException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .notFoundException(let message):
+            return "NotFoundException: \(message ?? "")"
+        case .terminalRoutingStrategyException(let message):
+            return "TerminalRoutingStrategyException: \(message ?? "")"
+        case .unauthorizedException(let message):
+            return "UnauthorizedException: \(message ?? "")"
+        case .unsupportedRegionException(let message):
+            return "UnsupportedRegionException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Glacier/Glacier_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Glacier/Glacier_Error.swift
@@ -42,3 +42,26 @@ extension GlacierErrorType {
         }
     }
 }
+
+extension GlacierErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .insufficientCapacityException(let message):
+            return "InsufficientCapacityException: \(message ?? "")"
+        case .invalidParameterValueException(let message):
+            return "InvalidParameterValueException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .missingParameterValueException(let message):
+            return "MissingParameterValueException: \(message ?? "")"
+        case .policyEnforcedException(let message):
+            return "PolicyEnforcedException: \(message ?? "")"
+        case .requestTimeoutException(let message):
+            return "RequestTimeoutException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .serviceUnavailableException(let message):
+            return "ServiceUnavailableException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/GlobalAccelerator/GlobalAccelerator_Error.swift
+++ b/Sources/AWSSDKSwift/Services/GlobalAccelerator/GlobalAccelerator_Error.swift
@@ -54,3 +54,34 @@ extension GlobalAcceleratorErrorType {
         }
     }
 }
+
+extension GlobalAcceleratorErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .acceleratorNotDisabledException(let message):
+            return "AcceleratorNotDisabledException: \(message ?? "")"
+        case .acceleratorNotFoundException(let message):
+            return "AcceleratorNotFoundException: \(message ?? "")"
+        case .associatedEndpointGroupFoundException(let message):
+            return "AssociatedEndpointGroupFoundException: \(message ?? "")"
+        case .associatedListenerFoundException(let message):
+            return "AssociatedListenerFoundException: \(message ?? "")"
+        case .endpointGroupAlreadyExistsException(let message):
+            return "EndpointGroupAlreadyExistsException: \(message ?? "")"
+        case .endpointGroupNotFoundException(let message):
+            return "EndpointGroupNotFoundException: \(message ?? "")"
+        case .internalServiceErrorException(let message):
+            return "InternalServiceErrorException: \(message ?? "")"
+        case .invalidArgumentException(let message):
+            return "InvalidArgumentException: \(message ?? "")"
+        case .invalidNextTokenException(let message):
+            return "InvalidNextTokenException: \(message ?? "")"
+        case .invalidPortRangeException(let message):
+            return "InvalidPortRangeException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .listenerNotFoundException(let message):
+            return "ListenerNotFoundException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Glue/Glue_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Glue/Glue_Error.swift
@@ -81,3 +81,52 @@ extension GlueErrorType {
         }
     }
 }
+
+extension GlueErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .accessDeniedException(let message):
+            return "AccessDeniedException: \(message ?? "")"
+        case .alreadyExistsException(let message):
+            return "AlreadyExistsException: \(message ?? "")"
+        case .concurrentModificationException(let message):
+            return "ConcurrentModificationException: \(message ?? "")"
+        case .concurrentRunsExceededException(let message):
+            return "ConcurrentRunsExceededException: \(message ?? "")"
+        case .conditionCheckFailureException(let message):
+            return "ConditionCheckFailureException: \(message ?? "")"
+        case .crawlerNotRunningException(let message):
+            return "CrawlerNotRunningException: \(message ?? "")"
+        case .crawlerRunningException(let message):
+            return "CrawlerRunningException: \(message ?? "")"
+        case .crawlerStoppingException(let message):
+            return "CrawlerStoppingException: \(message ?? "")"
+        case .entityNotFoundException(let message):
+            return "EntityNotFoundException: \(message ?? "")"
+        case .glueEncryptionException(let message):
+            return "GlueEncryptionException: \(message ?? "")"
+        case .idempotentParameterMismatchException(let message):
+            return "IdempotentParameterMismatchException: \(message ?? "")"
+        case .internalServiceException(let message):
+            return "InternalServiceException: \(message ?? "")"
+        case .invalidInputException(let message):
+            return "InvalidInputException: \(message ?? "")"
+        case .noScheduleException(let message):
+            return "NoScheduleException: \(message ?? "")"
+        case .operationTimeoutException(let message):
+            return "OperationTimeoutException: \(message ?? "")"
+        case .resourceNumberLimitExceededException(let message):
+            return "ResourceNumberLimitExceededException: \(message ?? "")"
+        case .schedulerNotRunningException(let message):
+            return "SchedulerNotRunningException: \(message ?? "")"
+        case .schedulerRunningException(let message):
+            return "SchedulerRunningException: \(message ?? "")"
+        case .schedulerTransitioningException(let message):
+            return "SchedulerTransitioningException: \(message ?? "")"
+        case .validationException(let message):
+            return "ValidationException: \(message ?? "")"
+        case .versionMismatchException(let message):
+            return "VersionMismatchException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Greengrass/Greengrass_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Greengrass/Greengrass_Error.swift
@@ -24,3 +24,14 @@ extension GreengrassErrorType {
         }
     }
 }
+
+extension GreengrassErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .badRequestException(let message):
+            return "BadRequestException: \(message ?? "")"
+        case .internalServerErrorException(let message):
+            return "InternalServerErrorException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/GroundStation/GroundStation_Error.swift
+++ b/Sources/AWSSDKSwift/Services/GroundStation/GroundStation_Error.swift
@@ -27,3 +27,16 @@ extension GroundStationErrorType {
         }
     }
 }
+
+extension GroundStationErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .dependencyException(let message):
+            return "DependencyException: \(message ?? "")"
+        case .invalidParameterException(let message):
+            return "InvalidParameterException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/GuardDuty/GuardDuty_Error.swift
+++ b/Sources/AWSSDKSwift/Services/GuardDuty/GuardDuty_Error.swift
@@ -24,3 +24,14 @@ extension GuardDutyErrorType {
         }
     }
 }
+
+extension GuardDutyErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .badRequestException(let message):
+            return "BadRequestException: \(message ?? "")"
+        case .internalServerErrorException(let message):
+            return "InternalServerErrorException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Health/Health_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Health/Health_Error.swift
@@ -24,3 +24,14 @@ extension HealthErrorType {
         }
     }
 }
+
+extension HealthErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .invalidPaginationToken(let message):
+            return "InvalidPaginationToken: \(message ?? "")"
+        case .unsupportedLocale(let message):
+            return "UnsupportedLocale: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/IAM/IAM_Error.swift
+++ b/Sources/AWSSDKSwift/Services/IAM/IAM_Error.swift
@@ -99,3 +99,64 @@ extension IAMErrorType {
         }
     }
 }
+
+extension IAMErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .concurrentModificationException(let message):
+            return "ConcurrentModificationException: \(message ?? "")"
+        case .credentialReportExpiredException(let message):
+            return "CredentialReportExpiredException: \(message ?? "")"
+        case .credentialReportNotPresentException(let message):
+            return "CredentialReportNotPresentException: \(message ?? "")"
+        case .credentialReportNotReadyException(let message):
+            return "CredentialReportNotReadyException: \(message ?? "")"
+        case .deleteConflictException(let message):
+            return "DeleteConflictException: \(message ?? "")"
+        case .duplicateCertificateException(let message):
+            return "DuplicateCertificateException: \(message ?? "")"
+        case .duplicateSSHPublicKeyException(let message):
+            return "DuplicateSSHPublicKeyException: \(message ?? "")"
+        case .entityAlreadyExistsException(let message):
+            return "EntityAlreadyExistsException: \(message ?? "")"
+        case .entityTemporarilyUnmodifiableException(let message):
+            return "EntityTemporarilyUnmodifiableException: \(message ?? "")"
+        case .invalidAuthenticationCodeException(let message):
+            return "InvalidAuthenticationCodeException: \(message ?? "")"
+        case .invalidCertificateException(let message):
+            return "InvalidCertificateException: \(message ?? "")"
+        case .invalidInputException(let message):
+            return "InvalidInputException: \(message ?? "")"
+        case .invalidPublicKeyException(let message):
+            return "InvalidPublicKeyException: \(message ?? "")"
+        case .invalidUserTypeException(let message):
+            return "InvalidUserTypeException: \(message ?? "")"
+        case .keyPairMismatchException(let message):
+            return "KeyPairMismatchException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .malformedCertificateException(let message):
+            return "MalformedCertificateException: \(message ?? "")"
+        case .malformedPolicyDocumentException(let message):
+            return "MalformedPolicyDocumentException: \(message ?? "")"
+        case .noSuchEntityException(let message):
+            return "NoSuchEntityException: \(message ?? "")"
+        case .passwordPolicyViolationException(let message):
+            return "PasswordPolicyViolationException: \(message ?? "")"
+        case .policyEvaluationException(let message):
+            return "PolicyEvaluationException: \(message ?? "")"
+        case .policyNotAttachableException(let message):
+            return "PolicyNotAttachableException: \(message ?? "")"
+        case .reportGenerationLimitExceededException(let message):
+            return "ReportGenerationLimitExceededException: \(message ?? "")"
+        case .serviceFailureException(let message):
+            return "ServiceFailureException: \(message ?? "")"
+        case .serviceNotSupportedException(let message):
+            return "ServiceNotSupportedException: \(message ?? "")"
+        case .unmodifiableEntityException(let message):
+            return "UnmodifiableEntityException: \(message ?? "")"
+        case .unrecognizedPublicKeyEncodingException(let message):
+            return "UnrecognizedPublicKeyEncodingException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/ImportExport/ImportExport_Error.swift
+++ b/Sources/AWSSDKSwift/Services/ImportExport/ImportExport_Error.swift
@@ -78,3 +78,50 @@ extension ImportExportErrorType {
         }
     }
 }
+
+extension ImportExportErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .bucketPermissionException(let message):
+            return "BucketPermissionException: \(message ?? "")"
+        case .canceledJobIdException(let message):
+            return "CanceledJobIdException: \(message ?? "")"
+        case .createJobQuotaExceededException(let message):
+            return "CreateJobQuotaExceededException: \(message ?? "")"
+        case .expiredJobIdException(let message):
+            return "ExpiredJobIdException: \(message ?? "")"
+        case .invalidAccessKeyIdException(let message):
+            return "InvalidAccessKeyIdException: \(message ?? "")"
+        case .invalidAddressException(let message):
+            return "InvalidAddressException: \(message ?? "")"
+        case .invalidCustomsException(let message):
+            return "InvalidCustomsException: \(message ?? "")"
+        case .invalidFileSystemException(let message):
+            return "InvalidFileSystemException: \(message ?? "")"
+        case .invalidJobIdException(let message):
+            return "InvalidJobIdException: \(message ?? "")"
+        case .invalidManifestFieldException(let message):
+            return "InvalidManifestFieldException: \(message ?? "")"
+        case .invalidParameterException(let message):
+            return "InvalidParameterException: \(message ?? "")"
+        case .invalidVersionException(let message):
+            return "InvalidVersionException: \(message ?? "")"
+        case .malformedManifestException(let message):
+            return "MalformedManifestException: \(message ?? "")"
+        case .missingCustomsException(let message):
+            return "MissingCustomsException: \(message ?? "")"
+        case .missingManifestFieldException(let message):
+            return "MissingManifestFieldException: \(message ?? "")"
+        case .missingParameterException(let message):
+            return "MissingParameterException: \(message ?? "")"
+        case .multipleRegionsException(let message):
+            return "MultipleRegionsException: \(message ?? "")"
+        case .noSuchBucketException(let message):
+            return "NoSuchBucketException: \(message ?? "")"
+        case .unableToCancelJobIdException(let message):
+            return "UnableToCancelJobIdException: \(message ?? "")"
+        case .unableToUpdateJobIdException(let message):
+            return "UnableToUpdateJobIdException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Inspector/Inspector_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Inspector/Inspector_Error.swift
@@ -51,3 +51,32 @@ extension InspectorErrorType {
         }
     }
 }
+
+extension InspectorErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .accessDeniedException(let message):
+            return "AccessDeniedException: \(message ?? "")"
+        case .agentsAlreadyRunningAssessmentException(let message):
+            return "AgentsAlreadyRunningAssessmentException: \(message ?? "")"
+        case .assessmentRunInProgressException(let message):
+            return "AssessmentRunInProgressException: \(message ?? "")"
+        case .internalException(let message):
+            return "InternalException: \(message ?? "")"
+        case .invalidCrossAccountRoleException(let message):
+            return "InvalidCrossAccountRoleException: \(message ?? "")"
+        case .invalidInputException(let message):
+            return "InvalidInputException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .noSuchEntityException(let message):
+            return "NoSuchEntityException: \(message ?? "")"
+        case .previewGenerationInProgressException(let message):
+            return "PreviewGenerationInProgressException: \(message ?? "")"
+        case .serviceTemporarilyUnavailableException(let message):
+            return "ServiceTemporarilyUnavailableException: \(message ?? "")"
+        case .unsupportedFeatureException(let message):
+            return "UnsupportedFeatureException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/IoT/IoT_Error.swift
+++ b/Sources/AWSSDKSwift/Services/IoT/IoT_Error.swift
@@ -102,3 +102,66 @@ extension IoTErrorType {
         }
     }
 }
+
+extension IoTErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .certificateConflictException(let message):
+            return "CertificateConflictException: \(message ?? "")"
+        case .certificateStateException(let message):
+            return "CertificateStateException: \(message ?? "")"
+        case .certificateValidationException(let message):
+            return "CertificateValidationException: \(message ?? "")"
+        case .conflictingResourceUpdateException(let message):
+            return "ConflictingResourceUpdateException: \(message ?? "")"
+        case .deleteConflictException(let message):
+            return "DeleteConflictException: \(message ?? "")"
+        case .indexNotReadyException(let message):
+            return "IndexNotReadyException: \(message ?? "")"
+        case .internalException(let message):
+            return "InternalException: \(message ?? "")"
+        case .internalFailureException(let message):
+            return "InternalFailureException: \(message ?? "")"
+        case .invalidAggregationException(let message):
+            return "InvalidAggregationException: \(message ?? "")"
+        case .invalidQueryException(let message):
+            return "InvalidQueryException: \(message ?? "")"
+        case .invalidRequestException(let message):
+            return "InvalidRequestException: \(message ?? "")"
+        case .invalidResponseException(let message):
+            return "InvalidResponseException: \(message ?? "")"
+        case .invalidStateTransitionException(let message):
+            return "InvalidStateTransitionException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .malformedPolicyException(let message):
+            return "MalformedPolicyException: \(message ?? "")"
+        case .notConfiguredException(let message):
+            return "NotConfiguredException: \(message ?? "")"
+        case .registrationCodeValidationException(let message):
+            return "RegistrationCodeValidationException: \(message ?? "")"
+        case .resourceAlreadyExistsException(let message):
+            return "ResourceAlreadyExistsException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .resourceRegistrationFailureException(let message):
+            return "ResourceRegistrationFailureException: \(message ?? "")"
+        case .serviceUnavailableException(let message):
+            return "ServiceUnavailableException: \(message ?? "")"
+        case .sqlParseException(let message):
+            return "SqlParseException: \(message ?? "")"
+        case .throttlingException(let message):
+            return "ThrottlingException: \(message ?? "")"
+        case .transferAlreadyCompletedException(let message):
+            return "TransferAlreadyCompletedException: \(message ?? "")"
+        case .transferConflictException(let message):
+            return "TransferConflictException: \(message ?? "")"
+        case .unauthorizedException(let message):
+            return "UnauthorizedException: \(message ?? "")"
+        case .versionConflictException(let message):
+            return "VersionConflictException: \(message ?? "")"
+        case .versionsLimitExceededException(let message):
+            return "VersionsLimitExceededException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/IoT1ClickDevicesService/IoT1ClickDevicesService_Error.swift
+++ b/Sources/AWSSDKSwift/Services/IoT1ClickDevicesService/IoT1ClickDevicesService_Error.swift
@@ -39,3 +39,24 @@ extension IoT1ClickDevicesServiceErrorType {
         }
     }
 }
+
+extension IoT1ClickDevicesServiceErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .forbiddenException(let message):
+            return "ForbiddenException: \(message ?? "")"
+        case .internalFailureException(let message):
+            return "InternalFailureException: \(message ?? "")"
+        case .invalidRequestException(let message):
+            return "InvalidRequestException: \(message ?? "")"
+        case .preconditionFailedException(let message):
+            return "PreconditionFailedException: \(message ?? "")"
+        case .rangeNotSatisfiableException(let message):
+            return "RangeNotSatisfiableException: \(message ?? "")"
+        case .resourceConflictException(let message):
+            return "ResourceConflictException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/IoT1ClickProjects/IoT1ClickProjects_Error.swift
+++ b/Sources/AWSSDKSwift/Services/IoT1ClickProjects/IoT1ClickProjects_Error.swift
@@ -33,3 +33,20 @@ extension IoT1ClickProjectsErrorType {
         }
     }
 }
+
+extension IoT1ClickProjectsErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .internalFailureException(let message):
+            return "InternalFailureException: \(message ?? "")"
+        case .invalidRequestException(let message):
+            return "InvalidRequestException: \(message ?? "")"
+        case .resourceConflictException(let message):
+            return "ResourceConflictException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .tooManyRequestsException(let message):
+            return "TooManyRequestsException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/IoTAnalytics/IoTAnalytics_Error.swift
+++ b/Sources/AWSSDKSwift/Services/IoTAnalytics/IoTAnalytics_Error.swift
@@ -39,3 +39,24 @@ extension IoTAnalyticsErrorType {
         }
     }
 }
+
+extension IoTAnalyticsErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .internalFailureException(let message):
+            return "InternalFailureException: \(message ?? "")"
+        case .invalidRequestException(let message):
+            return "InvalidRequestException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .resourceAlreadyExistsException(let message):
+            return "ResourceAlreadyExistsException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .serviceUnavailableException(let message):
+            return "ServiceUnavailableException: \(message ?? "")"
+        case .throttlingException(let message):
+            return "ThrottlingException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/IoTDataPlane/IoTDataPlane_Error.swift
+++ b/Sources/AWSSDKSwift/Services/IoTDataPlane/IoTDataPlane_Error.swift
@@ -48,3 +48,30 @@ extension IoTDataPlaneErrorType {
         }
     }
 }
+
+extension IoTDataPlaneErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .conflictException(let message):
+            return "ConflictException: \(message ?? "")"
+        case .internalFailureException(let message):
+            return "InternalFailureException: \(message ?? "")"
+        case .invalidRequestException(let message):
+            return "InvalidRequestException: \(message ?? "")"
+        case .methodNotAllowedException(let message):
+            return "MethodNotAllowedException: \(message ?? "")"
+        case .requestEntityTooLargeException(let message):
+            return "RequestEntityTooLargeException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .serviceUnavailableException(let message):
+            return "ServiceUnavailableException: \(message ?? "")"
+        case .throttlingException(let message):
+            return "ThrottlingException: \(message ?? "")"
+        case .unauthorizedException(let message):
+            return "UnauthorizedException: \(message ?? "")"
+        case .unsupportedDocumentEncodingException(let message):
+            return "UnsupportedDocumentEncodingException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/IoTEvents/IoTEvents_Error.swift
+++ b/Sources/AWSSDKSwift/Services/IoTEvents/IoTEvents_Error.swift
@@ -45,3 +45,28 @@ extension IoTEventsErrorType {
         }
     }
 }
+
+extension IoTEventsErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .internalFailureException(let message):
+            return "InternalFailureException: \(message ?? "")"
+        case .invalidRequestException(let message):
+            return "InvalidRequestException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .resourceAlreadyExistsException(let message):
+            return "ResourceAlreadyExistsException: \(message ?? "")"
+        case .resourceInUseException(let message):
+            return "ResourceInUseException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .serviceUnavailableException(let message):
+            return "ServiceUnavailableException: \(message ?? "")"
+        case .throttlingException(let message):
+            return "ThrottlingException: \(message ?? "")"
+        case .unsupportedOperationException(let message):
+            return "UnsupportedOperationException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/IoTEventsData/IoTEventsData_Error.swift
+++ b/Sources/AWSSDKSwift/Services/IoTEventsData/IoTEventsData_Error.swift
@@ -33,3 +33,20 @@ extension IoTEventsDataErrorType {
         }
     }
 }
+
+extension IoTEventsDataErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .internalFailureException(let message):
+            return "InternalFailureException: \(message ?? "")"
+        case .invalidRequestException(let message):
+            return "InvalidRequestException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .serviceUnavailableException(let message):
+            return "ServiceUnavailableException: \(message ?? "")"
+        case .throttlingException(let message):
+            return "ThrottlingException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/IoTJobsDataPlane/IoTJobsDataPlane_Error.swift
+++ b/Sources/AWSSDKSwift/Services/IoTJobsDataPlane/IoTJobsDataPlane_Error.swift
@@ -39,3 +39,24 @@ extension IoTJobsDataPlaneErrorType {
         }
     }
 }
+
+extension IoTJobsDataPlaneErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .certificateValidationException(let message):
+            return "CertificateValidationException: \(message ?? "")"
+        case .invalidRequestException(let message):
+            return "InvalidRequestException: \(message ?? "")"
+        case .invalidStateTransitionException(let message):
+            return "InvalidStateTransitionException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .serviceUnavailableException(let message):
+            return "ServiceUnavailableException: \(message ?? "")"
+        case .terminalStateException(let message):
+            return "TerminalStateException: \(message ?? "")"
+        case .throttlingException(let message):
+            return "ThrottlingException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/IoTThingsGraph/IoTThingsGraph_Error.swift
+++ b/Sources/AWSSDKSwift/Services/IoTThingsGraph/IoTThingsGraph_Error.swift
@@ -39,3 +39,24 @@ extension IoTThingsGraphErrorType {
         }
     }
 }
+
+extension IoTThingsGraphErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .internalFailureException(let message):
+            return "InternalFailureException: \(message ?? "")"
+        case .invalidRequestException(let message):
+            return "InvalidRequestException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .resourceAlreadyExistsException(let message):
+            return "ResourceAlreadyExistsException: \(message ?? "")"
+        case .resourceInUseException(let message):
+            return "ResourceInUseException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .throttlingException(let message):
+            return "ThrottlingException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/KMS/KMS_Error.swift
+++ b/Sources/AWSSDKSwift/Services/KMS/KMS_Error.swift
@@ -111,3 +111,72 @@ extension KMSErrorType {
         }
     }
 }
+
+extension KMSErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .alreadyExistsException(let message):
+            return "AlreadyExistsException: \(message ?? "")"
+        case .cloudHsmClusterInUseException(let message):
+            return "CloudHsmClusterInUseException: \(message ?? "")"
+        case .cloudHsmClusterInvalidConfigurationException(let message):
+            return "CloudHsmClusterInvalidConfigurationException: \(message ?? "")"
+        case .cloudHsmClusterNotActiveException(let message):
+            return "CloudHsmClusterNotActiveException: \(message ?? "")"
+        case .cloudHsmClusterNotFoundException(let message):
+            return "CloudHsmClusterNotFoundException: \(message ?? "")"
+        case .cloudHsmClusterNotRelatedException(let message):
+            return "CloudHsmClusterNotRelatedException: \(message ?? "")"
+        case .customKeyStoreHasCMKsException(let message):
+            return "CustomKeyStoreHasCMKsException: \(message ?? "")"
+        case .customKeyStoreInvalidStateException(let message):
+            return "CustomKeyStoreInvalidStateException: \(message ?? "")"
+        case .customKeyStoreNameInUseException(let message):
+            return "CustomKeyStoreNameInUseException: \(message ?? "")"
+        case .customKeyStoreNotFoundException(let message):
+            return "CustomKeyStoreNotFoundException: \(message ?? "")"
+        case .dependencyTimeoutException(let message):
+            return "DependencyTimeoutException: \(message ?? "")"
+        case .disabledException(let message):
+            return "DisabledException: \(message ?? "")"
+        case .expiredImportTokenException(let message):
+            return "ExpiredImportTokenException: \(message ?? "")"
+        case .incorrectKeyMaterialException(let message):
+            return "IncorrectKeyMaterialException: \(message ?? "")"
+        case .incorrectTrustAnchorException(let message):
+            return "IncorrectTrustAnchorException: \(message ?? "")"
+        case .invalidAliasNameException(let message):
+            return "InvalidAliasNameException: \(message ?? "")"
+        case .invalidArnException(let message):
+            return "InvalidArnException: \(message ?? "")"
+        case .invalidCiphertextException(let message):
+            return "InvalidCiphertextException: \(message ?? "")"
+        case .invalidGrantIdException(let message):
+            return "InvalidGrantIdException: \(message ?? "")"
+        case .invalidGrantTokenException(let message):
+            return "InvalidGrantTokenException: \(message ?? "")"
+        case .invalidImportTokenException(let message):
+            return "InvalidImportTokenException: \(message ?? "")"
+        case .invalidKeyUsageException(let message):
+            return "InvalidKeyUsageException: \(message ?? "")"
+        case .invalidMarkerException(let message):
+            return "InvalidMarkerException: \(message ?? "")"
+        case .kMSInternalException(let message):
+            return "KMSInternalException: \(message ?? "")"
+        case .kMSInvalidStateException(let message):
+            return "KMSInvalidStateException: \(message ?? "")"
+        case .keyUnavailableException(let message):
+            return "KeyUnavailableException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .malformedPolicyDocumentException(let message):
+            return "MalformedPolicyDocumentException: \(message ?? "")"
+        case .notFoundException(let message):
+            return "NotFoundException: \(message ?? "")"
+        case .tagException(let message):
+            return "TagException: \(message ?? "")"
+        case .unsupportedOperationException(let message):
+            return "UnsupportedOperationException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Kafka/Kafka_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Kafka/Kafka_Error.swift
@@ -42,3 +42,26 @@ extension KafkaErrorType {
         }
     }
 }
+
+extension KafkaErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .badRequestException(let message):
+            return "BadRequestException: \(message ?? "")"
+        case .conflictException(let message):
+            return "ConflictException: \(message ?? "")"
+        case .forbiddenException(let message):
+            return "ForbiddenException: \(message ?? "")"
+        case .internalServerErrorException(let message):
+            return "InternalServerErrorException: \(message ?? "")"
+        case .notFoundException(let message):
+            return "NotFoundException: \(message ?? "")"
+        case .serviceUnavailableException(let message):
+            return "ServiceUnavailableException: \(message ?? "")"
+        case .tooManyRequestsException(let message):
+            return "TooManyRequestsException: \(message ?? "")"
+        case .unauthorizedException(let message):
+            return "UnauthorizedException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Kafka/Kafka_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/Kafka/Kafka_Shapes.swift
@@ -493,8 +493,7 @@ extension Kafka {
         ///             The version of Apache Kafka.
         ///          
         public let kafkaVersion: String
-        ///             The number of broker nodes in the cluster.
-        ///          
+        /// The number of Kafka broker nodes in the Amazon MSK cluster.
         public let numberOfBrokerNodes: Int
         ///             Create tags when creating the cluster.
         ///          

--- a/Sources/AWSSDKSwift/Services/Kinesis/Kinesis_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Kinesis/Kinesis_Error.swift
@@ -57,3 +57,36 @@ extension KinesisErrorType {
         }
     }
 }
+
+extension KinesisErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .expiredIteratorException(let message):
+            return "ExpiredIteratorException: \(message ?? "")"
+        case .expiredNextTokenException(let message):
+            return "ExpiredNextTokenException: \(message ?? "")"
+        case .invalidArgumentException(let message):
+            return "InvalidArgumentException: \(message ?? "")"
+        case .kMSAccessDeniedException(let message):
+            return "KMSAccessDeniedException: \(message ?? "")"
+        case .kMSDisabledException(let message):
+            return "KMSDisabledException: \(message ?? "")"
+        case .kMSInvalidStateException(let message):
+            return "KMSInvalidStateException: \(message ?? "")"
+        case .kMSNotFoundException(let message):
+            return "KMSNotFoundException: \(message ?? "")"
+        case .kMSOptInRequired(let message):
+            return "KMSOptInRequired: \(message ?? "")"
+        case .kMSThrottlingException(let message):
+            return "KMSThrottlingException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .provisionedThroughputExceededException(let message):
+            return "ProvisionedThroughputExceededException: \(message ?? "")"
+        case .resourceInUseException(let message):
+            return "ResourceInUseException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/KinesisAnalytics/KinesisAnalytics_Error.swift
+++ b/Sources/AWSSDKSwift/Services/KinesisAnalytics/KinesisAnalytics_Error.swift
@@ -54,3 +54,34 @@ extension KinesisAnalyticsErrorType {
         }
     }
 }
+
+extension KinesisAnalyticsErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .codeValidationException(let message):
+            return "CodeValidationException: \(message ?? "")"
+        case .concurrentModificationException(let message):
+            return "ConcurrentModificationException: \(message ?? "")"
+        case .invalidApplicationConfigurationException(let message):
+            return "InvalidApplicationConfigurationException: \(message ?? "")"
+        case .invalidArgumentException(let message):
+            return "InvalidArgumentException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .resourceInUseException(let message):
+            return "ResourceInUseException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .resourceProvisionedThroughputExceededException(let message):
+            return "ResourceProvisionedThroughputExceededException: \(message ?? "")"
+        case .serviceUnavailableException(let message):
+            return "ServiceUnavailableException: \(message ?? "")"
+        case .tooManyTagsException(let message):
+            return "TooManyTagsException: \(message ?? "")"
+        case .unableToDetectSchemaException(let message):
+            return "UnableToDetectSchemaException: \(message ?? "")"
+        case .unsupportedOperationException(let message):
+            return "UnsupportedOperationException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/KinesisAnalyticsV2/KinesisAnalyticsV2_Error.swift
+++ b/Sources/AWSSDKSwift/Services/KinesisAnalyticsV2/KinesisAnalyticsV2_Error.swift
@@ -57,3 +57,36 @@ extension KinesisAnalyticsV2ErrorType {
         }
     }
 }
+
+extension KinesisAnalyticsV2ErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .codeValidationException(let message):
+            return "CodeValidationException: \(message ?? "")"
+        case .concurrentModificationException(let message):
+            return "ConcurrentModificationException: \(message ?? "")"
+        case .invalidApplicationConfigurationException(let message):
+            return "InvalidApplicationConfigurationException: \(message ?? "")"
+        case .invalidArgumentException(let message):
+            return "InvalidArgumentException: \(message ?? "")"
+        case .invalidRequestException(let message):
+            return "InvalidRequestException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .resourceInUseException(let message):
+            return "ResourceInUseException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .resourceProvisionedThroughputExceededException(let message):
+            return "ResourceProvisionedThroughputExceededException: \(message ?? "")"
+        case .serviceUnavailableException(let message):
+            return "ServiceUnavailableException: \(message ?? "")"
+        case .tooManyTagsException(let message):
+            return "TooManyTagsException: \(message ?? "")"
+        case .unableToDetectSchemaException(let message):
+            return "UnableToDetectSchemaException: \(message ?? "")"
+        case .unsupportedOperationException(let message):
+            return "UnsupportedOperationException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/KinesisVideo/KinesisVideo_Error.swift
+++ b/Sources/AWSSDKSwift/Services/KinesisVideo/KinesisVideo_Error.swift
@@ -51,3 +51,32 @@ extension KinesisVideoErrorType {
         }
     }
 }
+
+extension KinesisVideoErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .accountStreamLimitExceededException(let message):
+            return "AccountStreamLimitExceededException: \(message ?? "")"
+        case .clientLimitExceededException(let message):
+            return "ClientLimitExceededException: \(message ?? "")"
+        case .deviceStreamLimitExceededException(let message):
+            return "DeviceStreamLimitExceededException: \(message ?? "")"
+        case .invalidArgumentException(let message):
+            return "InvalidArgumentException: \(message ?? "")"
+        case .invalidDeviceException(let message):
+            return "InvalidDeviceException: \(message ?? "")"
+        case .invalidResourceFormatException(let message):
+            return "InvalidResourceFormatException: \(message ?? "")"
+        case .notAuthorizedException(let message):
+            return "NotAuthorizedException: \(message ?? "")"
+        case .resourceInUseException(let message):
+            return "ResourceInUseException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .tagsPerResourceExceededLimitException(let message):
+            return "TagsPerResourceExceededLimitException: \(message ?? "")"
+        case .versionMismatchException(let message):
+            return "VersionMismatchException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/KinesisVideoArchivedMedia/KinesisVideoArchivedMedia_Error.swift
+++ b/Sources/AWSSDKSwift/Services/KinesisVideoArchivedMedia/KinesisVideoArchivedMedia_Error.swift
@@ -42,3 +42,26 @@ extension KinesisVideoArchivedMediaErrorType {
         }
     }
 }
+
+extension KinesisVideoArchivedMediaErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .clientLimitExceededException(let message):
+            return "ClientLimitExceededException: \(message ?? "")"
+        case .invalidArgumentException(let message):
+            return "InvalidArgumentException: \(message ?? "")"
+        case .invalidCodecPrivateDataException(let message):
+            return "InvalidCodecPrivateDataException: \(message ?? "")"
+        case .missingCodecPrivateDataException(let message):
+            return "MissingCodecPrivateDataException: \(message ?? "")"
+        case .noDataRetentionException(let message):
+            return "NoDataRetentionException: \(message ?? "")"
+        case .notAuthorizedException(let message):
+            return "NotAuthorizedException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .unsupportedStreamMediaTypeException(let message):
+            return "UnsupportedStreamMediaTypeException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/KinesisVideoMedia/KinesisVideoMedia_Error.swift
+++ b/Sources/AWSSDKSwift/Services/KinesisVideoMedia/KinesisVideoMedia_Error.swift
@@ -36,3 +36,22 @@ extension KinesisVideoMediaErrorType {
         }
     }
 }
+
+extension KinesisVideoMediaErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .clientLimitExceededException(let message):
+            return "ClientLimitExceededException: \(message ?? "")"
+        case .connectionLimitExceededException(let message):
+            return "ConnectionLimitExceededException: \(message ?? "")"
+        case .invalidArgumentException(let message):
+            return "InvalidArgumentException: \(message ?? "")"
+        case .invalidEndpointException(let message):
+            return "InvalidEndpointException: \(message ?? "")"
+        case .notAuthorizedException(let message):
+            return "NotAuthorizedException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Lambda/Lambda_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Lambda/Lambda_Error.swift
@@ -93,3 +93,60 @@ extension LambdaErrorType {
         }
     }
 }
+
+extension LambdaErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .codeStorageExceededException(let message):
+            return "CodeStorageExceededException: \(message ?? "")"
+        case .eC2AccessDeniedException(let message):
+            return "EC2AccessDeniedException: \(message ?? "")"
+        case .eC2ThrottledException(let message):
+            return "EC2ThrottledException: \(message ?? "")"
+        case .eC2UnexpectedException(let message):
+            return "EC2UnexpectedException: \(message ?? "")"
+        case .eNILimitReachedException(let message):
+            return "ENILimitReachedException: \(message ?? "")"
+        case .invalidParameterValueException(let message):
+            return "InvalidParameterValueException: \(message ?? "")"
+        case .invalidRequestContentException(let message):
+            return "InvalidRequestContentException: \(message ?? "")"
+        case .invalidRuntimeException(let message):
+            return "InvalidRuntimeException: \(message ?? "")"
+        case .invalidSecurityGroupIDException(let message):
+            return "InvalidSecurityGroupIDException: \(message ?? "")"
+        case .invalidSubnetIDException(let message):
+            return "InvalidSubnetIDException: \(message ?? "")"
+        case .invalidZipFileException(let message):
+            return "InvalidZipFileException: \(message ?? "")"
+        case .kMSAccessDeniedException(let message):
+            return "KMSAccessDeniedException: \(message ?? "")"
+        case .kMSDisabledException(let message):
+            return "KMSDisabledException: \(message ?? "")"
+        case .kMSInvalidStateException(let message):
+            return "KMSInvalidStateException: \(message ?? "")"
+        case .kMSNotFoundException(let message):
+            return "KMSNotFoundException: \(message ?? "")"
+        case .policyLengthExceededException(let message):
+            return "PolicyLengthExceededException: \(message ?? "")"
+        case .preconditionFailedException(let message):
+            return "PreconditionFailedException: \(message ?? "")"
+        case .requestTooLargeException(let message):
+            return "RequestTooLargeException: \(message ?? "")"
+        case .resourceConflictException(let message):
+            return "ResourceConflictException: \(message ?? "")"
+        case .resourceInUseException(let message):
+            return "ResourceInUseException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .serviceException(let message):
+            return "ServiceException: \(message ?? "")"
+        case .subnetIPAddressLimitReachedException(let message):
+            return "SubnetIPAddressLimitReachedException: \(message ?? "")"
+        case .tooManyRequestsException(let message):
+            return "TooManyRequestsException: \(message ?? "")"
+        case .unsupportedMediaTypeException(let message):
+            return "UnsupportedMediaTypeException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/LexModelBuildingService/LexModelBuildingService_Error.swift
+++ b/Sources/AWSSDKSwift/Services/LexModelBuildingService/LexModelBuildingService_Error.swift
@@ -39,3 +39,24 @@ extension LexModelBuildingServiceErrorType {
         }
     }
 }
+
+extension LexModelBuildingServiceErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .badRequestException(let message):
+            return "BadRequestException: \(message ?? "")"
+        case .conflictException(let message):
+            return "ConflictException: \(message ?? "")"
+        case .internalFailureException(let message):
+            return "InternalFailureException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .notFoundException(let message):
+            return "NotFoundException: \(message ?? "")"
+        case .preconditionFailedException(let message):
+            return "PreconditionFailedException: \(message ?? "")"
+        case .resourceInUseException(let message):
+            return "ResourceInUseException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/LexRuntimeService/LexRuntimeService_Error.swift
+++ b/Sources/AWSSDKSwift/Services/LexRuntimeService/LexRuntimeService_Error.swift
@@ -51,3 +51,32 @@ extension LexRuntimeServiceErrorType {
         }
     }
 }
+
+extension LexRuntimeServiceErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .badGatewayException(let message):
+            return "BadGatewayException: \(message ?? "")"
+        case .badRequestException(let message):
+            return "BadRequestException: \(message ?? "")"
+        case .conflictException(let message):
+            return "ConflictException: \(message ?? "")"
+        case .dependencyFailedException(let message):
+            return "DependencyFailedException: \(message ?? "")"
+        case .internalFailureException(let message):
+            return "InternalFailureException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .loopDetectedException(let message):
+            return "LoopDetectedException: \(message ?? "")"
+        case .notAcceptableException(let message):
+            return "NotAcceptableException: \(message ?? "")"
+        case .notFoundException(let message):
+            return "NotFoundException: \(message ?? "")"
+        case .requestTimeoutException(let message):
+            return "RequestTimeoutException: \(message ?? "")"
+        case .unsupportedMediaTypeException(let message):
+            return "UnsupportedMediaTypeException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/LicenseManager/LicenseManager_Error.swift
+++ b/Sources/AWSSDKSwift/Services/LicenseManager/LicenseManager_Error.swift
@@ -48,3 +48,30 @@ extension LicenseManagerErrorType {
         }
     }
 }
+
+extension LicenseManagerErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .accessDeniedException(let message):
+            return "AccessDeniedException: \(message ?? "")"
+        case .authorizationException(let message):
+            return "AuthorizationException: \(message ?? "")"
+        case .failedDependencyException(let message):
+            return "FailedDependencyException: \(message ?? "")"
+        case .filterLimitExceededException(let message):
+            return "FilterLimitExceededException: \(message ?? "")"
+        case .invalidParameterValueException(let message):
+            return "InvalidParameterValueException: \(message ?? "")"
+        case .invalidResourceStateException(let message):
+            return "InvalidResourceStateException: \(message ?? "")"
+        case .licenseUsageException(let message):
+            return "LicenseUsageException: \(message ?? "")"
+        case .rateLimitExceededException(let message):
+            return "RateLimitExceededException: \(message ?? "")"
+        case .resourceLimitExceededException(let message):
+            return "ResourceLimitExceededException: \(message ?? "")"
+        case .serverInternalException(let message):
+            return "ServerInternalException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Lightsail/Lightsail_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Lightsail/Lightsail_Error.swift
@@ -39,3 +39,24 @@ extension LightsailErrorType {
         }
     }
 }
+
+extension LightsailErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .accessDeniedException(let message):
+            return "AccessDeniedException: \(message ?? "")"
+        case .accountSetupInProgressException(let message):
+            return "AccountSetupInProgressException: \(message ?? "")"
+        case .invalidInputException(let message):
+            return "InvalidInputException: \(message ?? "")"
+        case .notFoundException(let message):
+            return "NotFoundException: \(message ?? "")"
+        case .operationFailureException(let message):
+            return "OperationFailureException: \(message ?? "")"
+        case .serviceException(let message):
+            return "ServiceException: \(message ?? "")"
+        case .unauthenticatedException(let message):
+            return "UnauthenticatedException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/MQ/MQ_Error.swift
+++ b/Sources/AWSSDKSwift/Services/MQ/MQ_Error.swift
@@ -36,3 +36,22 @@ extension MQErrorType {
         }
     }
 }
+
+extension MQErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .badRequestException(let message):
+            return "BadRequestException: \(message ?? "")"
+        case .conflictException(let message):
+            return "ConflictException: \(message ?? "")"
+        case .forbiddenException(let message):
+            return "ForbiddenException: \(message ?? "")"
+        case .internalServerErrorException(let message):
+            return "InternalServerErrorException: \(message ?? "")"
+        case .notFoundException(let message):
+            return "NotFoundException: \(message ?? "")"
+        case .unauthorizedException(let message):
+            return "UnauthorizedException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/MTurk/MTurk_Error.swift
+++ b/Sources/AWSSDKSwift/Services/MTurk/MTurk_Error.swift
@@ -24,3 +24,14 @@ extension MTurkErrorType {
         }
     }
 }
+
+extension MTurkErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .requestError(let message):
+            return "RequestError: \(message ?? "")"
+        case .serviceFault(let message):
+            return "ServiceFault: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/MachineLearning/MachineLearning_Error.swift
+++ b/Sources/AWSSDKSwift/Services/MachineLearning/MachineLearning_Error.swift
@@ -42,3 +42,26 @@ extension MachineLearningErrorType {
         }
     }
 }
+
+extension MachineLearningErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .idempotentParameterMismatchException(let message):
+            return "IdempotentParameterMismatchException: \(message ?? "")"
+        case .internalServerException(let message):
+            return "InternalServerException: \(message ?? "")"
+        case .invalidInputException(let message):
+            return "InvalidInputException: \(message ?? "")"
+        case .invalidTagException(let message):
+            return "InvalidTagException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .predictorNotMountedException(let message):
+            return "PredictorNotMountedException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .tagLimitExceededException(let message):
+            return "TagLimitExceededException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Macie/Macie_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Macie/Macie_Error.swift
@@ -30,3 +30,18 @@ extension MacieErrorType {
         }
     }
 }
+
+extension MacieErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .accessDeniedException(let message):
+            return "AccessDeniedException: \(message ?? "")"
+        case .internalException(let message):
+            return "InternalException: \(message ?? "")"
+        case .invalidInputException(let message):
+            return "InvalidInputException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/ManagedBlockchain/ManagedBlockchain_Error.swift
+++ b/Sources/AWSSDKSwift/Services/ManagedBlockchain/ManagedBlockchain_Error.swift
@@ -45,3 +45,28 @@ extension ManagedBlockchainErrorType {
         }
     }
 }
+
+extension ManagedBlockchainErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .accessDeniedException(let message):
+            return "AccessDeniedException: \(message ?? "")"
+        case .illegalActionException(let message):
+            return "IllegalActionException: \(message ?? "")"
+        case .internalServiceErrorException(let message):
+            return "InternalServiceErrorException: \(message ?? "")"
+        case .invalidRequestException(let message):
+            return "InvalidRequestException: \(message ?? "")"
+        case .resourceAlreadyExistsException(let message):
+            return "ResourceAlreadyExistsException: \(message ?? "")"
+        case .resourceLimitExceededException(let message):
+            return "ResourceLimitExceededException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .resourceNotReadyException(let message):
+            return "ResourceNotReadyException: \(message ?? "")"
+        case .throttlingException(let message):
+            return "ThrottlingException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/MarketplaceCommerceAnalytics/MarketplaceCommerceAnalytics_Error.swift
+++ b/Sources/AWSSDKSwift/Services/MarketplaceCommerceAnalytics/MarketplaceCommerceAnalytics_Error.swift
@@ -21,3 +21,12 @@ extension MarketplaceCommerceAnalyticsErrorType {
         }
     }
 }
+
+extension MarketplaceCommerceAnalyticsErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .marketplaceCommerceAnalyticsException(let message):
+            return "MarketplaceCommerceAnalyticsException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/MarketplaceEntitlementService/MarketplaceEntitlementService_Error.swift
+++ b/Sources/AWSSDKSwift/Services/MarketplaceEntitlementService/MarketplaceEntitlementService_Error.swift
@@ -27,3 +27,16 @@ extension MarketplaceEntitlementServiceErrorType {
         }
     }
 }
+
+extension MarketplaceEntitlementServiceErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .internalServiceErrorException(let message):
+            return "InternalServiceErrorException: \(message ?? "")"
+        case .invalidParameterException(let message):
+            return "InvalidParameterException: \(message ?? "")"
+        case .throttlingException(let message):
+            return "ThrottlingException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/MarketplaceMetering/MarketplaceMetering_Error.swift
+++ b/Sources/AWSSDKSwift/Services/MarketplaceMetering/MarketplaceMetering_Error.swift
@@ -63,3 +63,40 @@ extension MarketplaceMeteringErrorType {
         }
     }
 }
+
+extension MarketplaceMeteringErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .customerNotEntitledException(let message):
+            return "CustomerNotEntitledException: \(message ?? "")"
+        case .disabledApiException(let message):
+            return "DisabledApiException: \(message ?? "")"
+        case .duplicateRequestException(let message):
+            return "DuplicateRequestException: \(message ?? "")"
+        case .expiredTokenException(let message):
+            return "ExpiredTokenException: \(message ?? "")"
+        case .internalServiceErrorException(let message):
+            return "InternalServiceErrorException: \(message ?? "")"
+        case .invalidCustomerIdentifierException(let message):
+            return "InvalidCustomerIdentifierException: \(message ?? "")"
+        case .invalidEndpointRegionException(let message):
+            return "InvalidEndpointRegionException: \(message ?? "")"
+        case .invalidProductCodeException(let message):
+            return "InvalidProductCodeException: \(message ?? "")"
+        case .invalidPublicKeyVersionException(let message):
+            return "InvalidPublicKeyVersionException: \(message ?? "")"
+        case .invalidRegionException(let message):
+            return "InvalidRegionException: \(message ?? "")"
+        case .invalidTokenException(let message):
+            return "InvalidTokenException: \(message ?? "")"
+        case .invalidUsageDimensionException(let message):
+            return "InvalidUsageDimensionException: \(message ?? "")"
+        case .platformNotSupportedException(let message):
+            return "PlatformNotSupportedException: \(message ?? "")"
+        case .throttlingException(let message):
+            return "ThrottlingException: \(message ?? "")"
+        case .timestampOutOfBoundsException(let message):
+            return "TimestampOutOfBoundsException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/MediaConnect/MediaConnect_Error.swift
+++ b/Sources/AWSSDKSwift/Services/MediaConnect/MediaConnect_Error.swift
@@ -45,3 +45,28 @@ extension MediaConnectErrorType {
         }
     }
 }
+
+extension MediaConnectErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .addFlowOutputs420Exception(let message):
+            return "AddFlowOutputs420Exception: \(message ?? "")"
+        case .badRequestException(let message):
+            return "BadRequestException: \(message ?? "")"
+        case .createFlow420Exception(let message):
+            return "CreateFlow420Exception: \(message ?? "")"
+        case .forbiddenException(let message):
+            return "ForbiddenException: \(message ?? "")"
+        case .grantFlowEntitlements420Exception(let message):
+            return "GrantFlowEntitlements420Exception: \(message ?? "")"
+        case .internalServerErrorException(let message):
+            return "InternalServerErrorException: \(message ?? "")"
+        case .notFoundException(let message):
+            return "NotFoundException: \(message ?? "")"
+        case .serviceUnavailableException(let message):
+            return "ServiceUnavailableException: \(message ?? "")"
+        case .tooManyRequestsException(let message):
+            return "TooManyRequestsException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/MediaConvert/MediaConvert_Error.swift
+++ b/Sources/AWSSDKSwift/Services/MediaConvert/MediaConvert_Error.swift
@@ -36,3 +36,22 @@ extension MediaConvertErrorType {
         }
     }
 }
+
+extension MediaConvertErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .badRequestException(let message):
+            return "BadRequestException: \(message ?? "")"
+        case .conflictException(let message):
+            return "ConflictException: \(message ?? "")"
+        case .forbiddenException(let message):
+            return "ForbiddenException: \(message ?? "")"
+        case .internalServerErrorException(let message):
+            return "InternalServerErrorException: \(message ?? "")"
+        case .notFoundException(let message):
+            return "NotFoundException: \(message ?? "")"
+        case .tooManyRequestsException(let message):
+            return "TooManyRequestsException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/MediaLive/MediaLive_Error.swift
+++ b/Sources/AWSSDKSwift/Services/MediaLive/MediaLive_Error.swift
@@ -45,3 +45,28 @@ extension MediaLiveErrorType {
         }
     }
 }
+
+extension MediaLiveErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .badGatewayException(let message):
+            return "BadGatewayException: \(message ?? "")"
+        case .badRequestException(let message):
+            return "BadRequestException: \(message ?? "")"
+        case .conflictException(let message):
+            return "ConflictException: \(message ?? "")"
+        case .forbiddenException(let message):
+            return "ForbiddenException: \(message ?? "")"
+        case .gatewayTimeoutException(let message):
+            return "GatewayTimeoutException: \(message ?? "")"
+        case .internalServerErrorException(let message):
+            return "InternalServerErrorException: \(message ?? "")"
+        case .notFoundException(let message):
+            return "NotFoundException: \(message ?? "")"
+        case .tooManyRequestsException(let message):
+            return "TooManyRequestsException: \(message ?? "")"
+        case .unprocessableEntityException(let message):
+            return "UnprocessableEntityException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/MediaPackage/MediaPackage_Error.swift
+++ b/Sources/AWSSDKSwift/Services/MediaPackage/MediaPackage_Error.swift
@@ -36,3 +36,22 @@ extension MediaPackageErrorType {
         }
     }
 }
+
+extension MediaPackageErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .forbiddenException(let message):
+            return "ForbiddenException: \(message ?? "")"
+        case .internalServerErrorException(let message):
+            return "InternalServerErrorException: \(message ?? "")"
+        case .notFoundException(let message):
+            return "NotFoundException: \(message ?? "")"
+        case .serviceUnavailableException(let message):
+            return "ServiceUnavailableException: \(message ?? "")"
+        case .tooManyRequestsException(let message):
+            return "TooManyRequestsException: \(message ?? "")"
+        case .unprocessableEntityException(let message):
+            return "UnprocessableEntityException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/MediaPackageVod/MediaPackageVod_Error.swift
+++ b/Sources/AWSSDKSwift/Services/MediaPackageVod/MediaPackageVod_Error.swift
@@ -36,3 +36,22 @@ extension MediaPackageVodErrorType {
         }
     }
 }
+
+extension MediaPackageVodErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .forbiddenException(let message):
+            return "ForbiddenException: \(message ?? "")"
+        case .internalServerErrorException(let message):
+            return "InternalServerErrorException: \(message ?? "")"
+        case .notFoundException(let message):
+            return "NotFoundException: \(message ?? "")"
+        case .serviceUnavailableException(let message):
+            return "ServiceUnavailableException: \(message ?? "")"
+        case .tooManyRequestsException(let message):
+            return "TooManyRequestsException: \(message ?? "")"
+        case .unprocessableEntityException(let message):
+            return "UnprocessableEntityException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/MediaStore/MediaStore_Error.swift
+++ b/Sources/AWSSDKSwift/Services/MediaStore/MediaStore_Error.swift
@@ -36,3 +36,22 @@ extension MediaStoreErrorType {
         }
     }
 }
+
+extension MediaStoreErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .containerInUseException(let message):
+            return "ContainerInUseException: \(message ?? "")"
+        case .containerNotFoundException(let message):
+            return "ContainerNotFoundException: \(message ?? "")"
+        case .corsPolicyNotFoundException(let message):
+            return "CorsPolicyNotFoundException: \(message ?? "")"
+        case .internalServerError(let message):
+            return "InternalServerError: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .policyNotFoundException(let message):
+            return "PolicyNotFoundException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/MediaStoreData/MediaStoreData_Error.swift
+++ b/Sources/AWSSDKSwift/Services/MediaStoreData/MediaStoreData_Error.swift
@@ -30,3 +30,18 @@ extension MediaStoreDataErrorType {
         }
     }
 }
+
+extension MediaStoreDataErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .containerNotFoundException(let message):
+            return "ContainerNotFoundException: \(message ?? "")"
+        case .internalServerError(let message):
+            return "InternalServerError: \(message ?? "")"
+        case .objectNotFoundException(let message):
+            return "ObjectNotFoundException: \(message ?? "")"
+        case .requestedRangeNotSatisfiableException(let message):
+            return "RequestedRangeNotSatisfiableException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/MediaTailor/MediaTailor_Error.swift
+++ b/Sources/AWSSDKSwift/Services/MediaTailor/MediaTailor_Error.swift
@@ -21,3 +21,12 @@ extension MediaTailorErrorType {
         }
     }
 }
+
+extension MediaTailorErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .badRequestException(let message):
+            return "BadRequestException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/MigrationHub/MigrationHub_Error.swift
+++ b/Sources/AWSSDKSwift/Services/MigrationHub/MigrationHub_Error.swift
@@ -42,3 +42,26 @@ extension MigrationHubErrorType {
         }
     }
 }
+
+extension MigrationHubErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .accessDeniedException(let message):
+            return "AccessDeniedException: \(message ?? "")"
+        case .dryRunOperation(let message):
+            return "DryRunOperation: \(message ?? "")"
+        case .internalServerError(let message):
+            return "InternalServerError: \(message ?? "")"
+        case .invalidInputException(let message):
+            return "InvalidInputException: \(message ?? "")"
+        case .policyErrorException(let message):
+            return "PolicyErrorException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .serviceUnavailableException(let message):
+            return "ServiceUnavailableException: \(message ?? "")"
+        case .unauthorizedOperation(let message):
+            return "UnauthorizedOperation: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Mobile/Mobile_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Mobile/Mobile_Error.swift
@@ -42,3 +42,26 @@ extension MobileErrorType {
         }
     }
 }
+
+extension MobileErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .accountActionRequiredException(let message):
+            return "AccountActionRequiredException: \(message ?? "")"
+        case .badRequestException(let message):
+            return "BadRequestException: \(message ?? "")"
+        case .internalFailureException(let message):
+            return "InternalFailureException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .notFoundException(let message):
+            return "NotFoundException: \(message ?? "")"
+        case .serviceUnavailableException(let message):
+            return "ServiceUnavailableException: \(message ?? "")"
+        case .tooManyRequestsException(let message):
+            return "TooManyRequestsException: \(message ?? "")"
+        case .unauthorizedException(let message):
+            return "UnauthorizedException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/MobileAnalytics/MobileAnalytics_Error.swift
+++ b/Sources/AWSSDKSwift/Services/MobileAnalytics/MobileAnalytics_Error.swift
@@ -21,3 +21,12 @@ extension MobileAnalyticsErrorType {
         }
     }
 }
+
+extension MobileAnalyticsErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .badRequestException(let message):
+            return "BadRequestException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Neptune/Neptune_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Neptune/Neptune_Error.swift
@@ -195,3 +195,128 @@ extension NeptuneErrorType {
         }
     }
 }
+
+extension NeptuneErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .authorizationNotFoundFault(let message):
+            return "AuthorizationNotFoundFault: \(message ?? "")"
+        case .certificateNotFoundFault(let message):
+            return "CertificateNotFoundFault: \(message ?? "")"
+        case .dBClusterAlreadyExistsFault(let message):
+            return "DBClusterAlreadyExistsFault: \(message ?? "")"
+        case .dBClusterNotFoundFault(let message):
+            return "DBClusterNotFoundFault: \(message ?? "")"
+        case .dBClusterParameterGroupNotFoundFault(let message):
+            return "DBClusterParameterGroupNotFoundFault: \(message ?? "")"
+        case .dBClusterQuotaExceededFault(let message):
+            return "DBClusterQuotaExceededFault: \(message ?? "")"
+        case .dBClusterRoleAlreadyExistsFault(let message):
+            return "DBClusterRoleAlreadyExistsFault: \(message ?? "")"
+        case .dBClusterRoleNotFoundFault(let message):
+            return "DBClusterRoleNotFoundFault: \(message ?? "")"
+        case .dBClusterRoleQuotaExceededFault(let message):
+            return "DBClusterRoleQuotaExceededFault: \(message ?? "")"
+        case .dBClusterSnapshotAlreadyExistsFault(let message):
+            return "DBClusterSnapshotAlreadyExistsFault: \(message ?? "")"
+        case .dBClusterSnapshotNotFoundFault(let message):
+            return "DBClusterSnapshotNotFoundFault: \(message ?? "")"
+        case .dBInstanceAlreadyExistsFault(let message):
+            return "DBInstanceAlreadyExistsFault: \(message ?? "")"
+        case .dBInstanceNotFoundFault(let message):
+            return "DBInstanceNotFoundFault: \(message ?? "")"
+        case .dBParameterGroupAlreadyExistsFault(let message):
+            return "DBParameterGroupAlreadyExistsFault: \(message ?? "")"
+        case .dBParameterGroupNotFoundFault(let message):
+            return "DBParameterGroupNotFoundFault: \(message ?? "")"
+        case .dBParameterGroupQuotaExceededFault(let message):
+            return "DBParameterGroupQuotaExceededFault: \(message ?? "")"
+        case .dBSecurityGroupNotFoundFault(let message):
+            return "DBSecurityGroupNotFoundFault: \(message ?? "")"
+        case .dBSnapshotAlreadyExistsFault(let message):
+            return "DBSnapshotAlreadyExistsFault: \(message ?? "")"
+        case .dBSnapshotNotFoundFault(let message):
+            return "DBSnapshotNotFoundFault: \(message ?? "")"
+        case .dBSubnetGroupAlreadyExistsFault(let message):
+            return "DBSubnetGroupAlreadyExistsFault: \(message ?? "")"
+        case .dBSubnetGroupDoesNotCoverEnoughAZs(let message):
+            return "DBSubnetGroupDoesNotCoverEnoughAZs: \(message ?? "")"
+        case .dBSubnetGroupNotFoundFault(let message):
+            return "DBSubnetGroupNotFoundFault: \(message ?? "")"
+        case .dBSubnetGroupQuotaExceededFault(let message):
+            return "DBSubnetGroupQuotaExceededFault: \(message ?? "")"
+        case .dBSubnetQuotaExceededFault(let message):
+            return "DBSubnetQuotaExceededFault: \(message ?? "")"
+        case .dBUpgradeDependencyFailureFault(let message):
+            return "DBUpgradeDependencyFailureFault: \(message ?? "")"
+        case .domainNotFoundFault(let message):
+            return "DomainNotFoundFault: \(message ?? "")"
+        case .eventSubscriptionQuotaExceededFault(let message):
+            return "EventSubscriptionQuotaExceededFault: \(message ?? "")"
+        case .instanceQuotaExceededFault(let message):
+            return "InstanceQuotaExceededFault: \(message ?? "")"
+        case .insufficientDBClusterCapacityFault(let message):
+            return "InsufficientDBClusterCapacityFault: \(message ?? "")"
+        case .insufficientDBInstanceCapacityFault(let message):
+            return "InsufficientDBInstanceCapacityFault: \(message ?? "")"
+        case .insufficientStorageClusterCapacityFault(let message):
+            return "InsufficientStorageClusterCapacityFault: \(message ?? "")"
+        case .invalidDBClusterSnapshotStateFault(let message):
+            return "InvalidDBClusterSnapshotStateFault: \(message ?? "")"
+        case .invalidDBClusterStateFault(let message):
+            return "InvalidDBClusterStateFault: \(message ?? "")"
+        case .invalidDBInstanceStateFault(let message):
+            return "InvalidDBInstanceStateFault: \(message ?? "")"
+        case .invalidDBParameterGroupStateFault(let message):
+            return "InvalidDBParameterGroupStateFault: \(message ?? "")"
+        case .invalidDBSecurityGroupStateFault(let message):
+            return "InvalidDBSecurityGroupStateFault: \(message ?? "")"
+        case .invalidDBSnapshotStateFault(let message):
+            return "InvalidDBSnapshotStateFault: \(message ?? "")"
+        case .invalidDBSubnetGroupStateFault(let message):
+            return "InvalidDBSubnetGroupStateFault: \(message ?? "")"
+        case .invalidDBSubnetStateFault(let message):
+            return "InvalidDBSubnetStateFault: \(message ?? "")"
+        case .invalidEventSubscriptionStateFault(let message):
+            return "InvalidEventSubscriptionStateFault: \(message ?? "")"
+        case .invalidRestoreFault(let message):
+            return "InvalidRestoreFault: \(message ?? "")"
+        case .invalidSubnet(let message):
+            return "InvalidSubnet: \(message ?? "")"
+        case .invalidVPCNetworkStateFault(let message):
+            return "InvalidVPCNetworkStateFault: \(message ?? "")"
+        case .kMSKeyNotAccessibleFault(let message):
+            return "KMSKeyNotAccessibleFault: \(message ?? "")"
+        case .optionGroupNotFoundFault(let message):
+            return "OptionGroupNotFoundFault: \(message ?? "")"
+        case .provisionedIopsNotAvailableInAZFault(let message):
+            return "ProvisionedIopsNotAvailableInAZFault: \(message ?? "")"
+        case .resourceNotFoundFault(let message):
+            return "ResourceNotFoundFault: \(message ?? "")"
+        case .sNSInvalidTopicFault(let message):
+            return "SNSInvalidTopicFault: \(message ?? "")"
+        case .sNSNoAuthorizationFault(let message):
+            return "SNSNoAuthorizationFault: \(message ?? "")"
+        case .sNSTopicArnNotFoundFault(let message):
+            return "SNSTopicArnNotFoundFault: \(message ?? "")"
+        case .sharedSnapshotQuotaExceededFault(let message):
+            return "SharedSnapshotQuotaExceededFault: \(message ?? "")"
+        case .snapshotQuotaExceededFault(let message):
+            return "SnapshotQuotaExceededFault: \(message ?? "")"
+        case .sourceNotFoundFault(let message):
+            return "SourceNotFoundFault: \(message ?? "")"
+        case .storageQuotaExceededFault(let message):
+            return "StorageQuotaExceededFault: \(message ?? "")"
+        case .storageTypeNotSupportedFault(let message):
+            return "StorageTypeNotSupportedFault: \(message ?? "")"
+        case .subnetAlreadyInUse(let message):
+            return "SubnetAlreadyInUse: \(message ?? "")"
+        case .subscriptionAlreadyExistFault(let message):
+            return "SubscriptionAlreadyExistFault: \(message ?? "")"
+        case .subscriptionCategoryNotFoundFault(let message):
+            return "SubscriptionCategoryNotFoundFault: \(message ?? "")"
+        case .subscriptionNotFoundFault(let message):
+            return "SubscriptionNotFoundFault: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/OpsWorks/OpsWorks_Error.swift
+++ b/Sources/AWSSDKSwift/Services/OpsWorks/OpsWorks_Error.swift
@@ -24,3 +24,14 @@ extension OpsWorksErrorType {
         }
     }
 }
+
+extension OpsWorksErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .validationException(let message):
+            return "ValidationException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/OpsWorksCM/OpsWorksCM_Error.swift
+++ b/Sources/AWSSDKSwift/Services/OpsWorksCM/OpsWorksCM_Error.swift
@@ -36,3 +36,22 @@ extension OpsWorksCMErrorType {
         }
     }
 }
+
+extension OpsWorksCMErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .invalidNextTokenException(let message):
+            return "InvalidNextTokenException: \(message ?? "")"
+        case .invalidStateException(let message):
+            return "InvalidStateException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .resourceAlreadyExistsException(let message):
+            return "ResourceAlreadyExistsException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .validationException(let message):
+            return "ValidationException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Organizations/Organizations_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Organizations/Organizations_Error.swift
@@ -138,3 +138,90 @@ extension OrganizationsErrorType {
         }
     }
 }
+
+extension OrganizationsErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .aWSOrganizationsNotInUseException(let message):
+            return "AWSOrganizationsNotInUseException: \(message ?? "")"
+        case .accessDeniedException(let message):
+            return "AccessDeniedException: \(message ?? "")"
+        case .accessDeniedForDependencyException(let message):
+            return "AccessDeniedForDependencyException: \(message ?? "")"
+        case .accountNotFoundException(let message):
+            return "AccountNotFoundException: \(message ?? "")"
+        case .accountOwnerNotVerifiedException(let message):
+            return "AccountOwnerNotVerifiedException: \(message ?? "")"
+        case .alreadyInOrganizationException(let message):
+            return "AlreadyInOrganizationException: \(message ?? "")"
+        case .childNotFoundException(let message):
+            return "ChildNotFoundException: \(message ?? "")"
+        case .concurrentModificationException(let message):
+            return "ConcurrentModificationException: \(message ?? "")"
+        case .constraintViolationException(let message):
+            return "ConstraintViolationException: \(message ?? "")"
+        case .createAccountStatusNotFoundException(let message):
+            return "CreateAccountStatusNotFoundException: \(message ?? "")"
+        case .destinationParentNotFoundException(let message):
+            return "DestinationParentNotFoundException: \(message ?? "")"
+        case .duplicateAccountException(let message):
+            return "DuplicateAccountException: \(message ?? "")"
+        case .duplicateHandshakeException(let message):
+            return "DuplicateHandshakeException: \(message ?? "")"
+        case .duplicateOrganizationalUnitException(let message):
+            return "DuplicateOrganizationalUnitException: \(message ?? "")"
+        case .duplicatePolicyAttachmentException(let message):
+            return "DuplicatePolicyAttachmentException: \(message ?? "")"
+        case .duplicatePolicyException(let message):
+            return "DuplicatePolicyException: \(message ?? "")"
+        case .finalizingOrganizationException(let message):
+            return "FinalizingOrganizationException: \(message ?? "")"
+        case .handshakeAlreadyInStateException(let message):
+            return "HandshakeAlreadyInStateException: \(message ?? "")"
+        case .handshakeConstraintViolationException(let message):
+            return "HandshakeConstraintViolationException: \(message ?? "")"
+        case .handshakeNotFoundException(let message):
+            return "HandshakeNotFoundException: \(message ?? "")"
+        case .invalidHandshakeTransitionException(let message):
+            return "InvalidHandshakeTransitionException: \(message ?? "")"
+        case .invalidInputException(let message):
+            return "InvalidInputException: \(message ?? "")"
+        case .malformedPolicyDocumentException(let message):
+            return "MalformedPolicyDocumentException: \(message ?? "")"
+        case .masterCannotLeaveOrganizationException(let message):
+            return "MasterCannotLeaveOrganizationException: \(message ?? "")"
+        case .organizationNotEmptyException(let message):
+            return "OrganizationNotEmptyException: \(message ?? "")"
+        case .organizationalUnitNotEmptyException(let message):
+            return "OrganizationalUnitNotEmptyException: \(message ?? "")"
+        case .organizationalUnitNotFoundException(let message):
+            return "OrganizationalUnitNotFoundException: \(message ?? "")"
+        case .parentNotFoundException(let message):
+            return "ParentNotFoundException: \(message ?? "")"
+        case .policyInUseException(let message):
+            return "PolicyInUseException: \(message ?? "")"
+        case .policyNotAttachedException(let message):
+            return "PolicyNotAttachedException: \(message ?? "")"
+        case .policyNotFoundException(let message):
+            return "PolicyNotFoundException: \(message ?? "")"
+        case .policyTypeAlreadyEnabledException(let message):
+            return "PolicyTypeAlreadyEnabledException: \(message ?? "")"
+        case .policyTypeNotAvailableForOrganizationException(let message):
+            return "PolicyTypeNotAvailableForOrganizationException: \(message ?? "")"
+        case .policyTypeNotEnabledException(let message):
+            return "PolicyTypeNotEnabledException: \(message ?? "")"
+        case .rootNotFoundException(let message):
+            return "RootNotFoundException: \(message ?? "")"
+        case .serviceException(let message):
+            return "ServiceException: \(message ?? "")"
+        case .sourceParentNotFoundException(let message):
+            return "SourceParentNotFoundException: \(message ?? "")"
+        case .targetNotFoundException(let message):
+            return "TargetNotFoundException: \(message ?? "")"
+        case .tooManyRequestsException(let message):
+            return "TooManyRequestsException: \(message ?? "")"
+        case .unsupportedAPIEndpointException(let message):
+            return "UnsupportedAPIEndpointException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/PI/PI_Error.swift
+++ b/Sources/AWSSDKSwift/Services/PI/PI_Error.swift
@@ -27,3 +27,16 @@ extension PIErrorType {
         }
     }
 }
+
+extension PIErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .internalServiceError(let message):
+            return "InternalServiceError: \(message ?? "")"
+        case .invalidArgumentException(let message):
+            return "InvalidArgumentException: \(message ?? "")"
+        case .notAuthorizedException(let message):
+            return "NotAuthorizedException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Personalize/Personalize_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Personalize/Personalize_Error.swift
@@ -36,3 +36,22 @@ extension PersonalizeErrorType {
         }
     }
 }
+
+extension PersonalizeErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .invalidInputException(let message):
+            return "InvalidInputException: \(message ?? "")"
+        case .invalidNextTokenException(let message):
+            return "InvalidNextTokenException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .resourceAlreadyExistsException(let message):
+            return "ResourceAlreadyExistsException: \(message ?? "")"
+        case .resourceInUseException(let message):
+            return "ResourceInUseException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/PersonalizeEvents/PersonalizeEvents_Error.swift
+++ b/Sources/AWSSDKSwift/Services/PersonalizeEvents/PersonalizeEvents_Error.swift
@@ -21,3 +21,12 @@ extension PersonalizeEventsErrorType {
         }
     }
 }
+
+extension PersonalizeEventsErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .invalidInputException(let message):
+            return "InvalidInputException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/PersonalizeRuntime/PersonalizeRuntime_Error.swift
+++ b/Sources/AWSSDKSwift/Services/PersonalizeRuntime/PersonalizeRuntime_Error.swift
@@ -24,3 +24,14 @@ extension PersonalizeRuntimeErrorType {
         }
     }
 }
+
+extension PersonalizeRuntimeErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .invalidInputException(let message):
+            return "InvalidInputException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Pinpoint/Pinpoint_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Pinpoint/Pinpoint_Error.swift
@@ -36,3 +36,22 @@ extension PinpointErrorType {
         }
     }
 }
+
+extension PinpointErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .badRequestException(let message):
+            return "BadRequestException: \(message ?? "")"
+        case .forbiddenException(let message):
+            return "ForbiddenException: \(message ?? "")"
+        case .internalServerErrorException(let message):
+            return "InternalServerErrorException: \(message ?? "")"
+        case .methodNotAllowedException(let message):
+            return "MethodNotAllowedException: \(message ?? "")"
+        case .notFoundException(let message):
+            return "NotFoundException: \(message ?? "")"
+        case .tooManyRequestsException(let message):
+            return "TooManyRequestsException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/PinpointEmail/PinpointEmail_Error.swift
+++ b/Sources/AWSSDKSwift/Services/PinpointEmail/PinpointEmail_Error.swift
@@ -48,3 +48,30 @@ extension PinpointEmailErrorType {
         }
     }
 }
+
+extension PinpointEmailErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .accountSuspendedException(let message):
+            return "AccountSuspendedException: \(message ?? "")"
+        case .alreadyExistsException(let message):
+            return "AlreadyExistsException: \(message ?? "")"
+        case .badRequestException(let message):
+            return "BadRequestException: \(message ?? "")"
+        case .concurrentModificationException(let message):
+            return "ConcurrentModificationException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .mailFromDomainNotVerifiedException(let message):
+            return "MailFromDomainNotVerifiedException: \(message ?? "")"
+        case .messageRejected(let message):
+            return "MessageRejected: \(message ?? "")"
+        case .notFoundException(let message):
+            return "NotFoundException: \(message ?? "")"
+        case .sendingPausedException(let message):
+            return "SendingPausedException: \(message ?? "")"
+        case .tooManyRequestsException(let message):
+            return "TooManyRequestsException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/PinpointSMSVoice/PinpointSMSVoice_Error.swift
+++ b/Sources/AWSSDKSwift/Services/PinpointSMSVoice/PinpointSMSVoice_Error.swift
@@ -36,3 +36,22 @@ extension PinpointSMSVoiceErrorType {
         }
     }
 }
+
+extension PinpointSMSVoiceErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .alreadyExistsException(let message):
+            return "AlreadyExistsException: \(message ?? "")"
+        case .badRequestException(let message):
+            return "BadRequestException: \(message ?? "")"
+        case .internalServiceErrorException(let message):
+            return "InternalServiceErrorException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .notFoundException(let message):
+            return "NotFoundException: \(message ?? "")"
+        case .tooManyRequestsException(let message):
+            return "TooManyRequestsException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Polly/Polly_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Polly/Polly_Error.swift
@@ -78,3 +78,50 @@ extension PollyErrorType {
         }
     }
 }
+
+extension PollyErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .invalidLexiconException(let message):
+            return "InvalidLexiconException: \(message ?? "")"
+        case .invalidNextTokenException(let message):
+            return "InvalidNextTokenException: \(message ?? "")"
+        case .invalidS3BucketException(let message):
+            return "InvalidS3BucketException: \(message ?? "")"
+        case .invalidS3KeyException(let message):
+            return "InvalidS3KeyException: \(message ?? "")"
+        case .invalidSampleRateException(let message):
+            return "InvalidSampleRateException: \(message ?? "")"
+        case .invalidSnsTopicArnException(let message):
+            return "InvalidSnsTopicArnException: \(message ?? "")"
+        case .invalidSsmlException(let message):
+            return "InvalidSsmlException: \(message ?? "")"
+        case .invalidTaskIdException(let message):
+            return "InvalidTaskIdException: \(message ?? "")"
+        case .languageNotSupportedException(let message):
+            return "LanguageNotSupportedException: \(message ?? "")"
+        case .lexiconNotFoundException(let message):
+            return "LexiconNotFoundException: \(message ?? "")"
+        case .lexiconSizeExceededException(let message):
+            return "LexiconSizeExceededException: \(message ?? "")"
+        case .marksNotSupportedForFormatException(let message):
+            return "MarksNotSupportedForFormatException: \(message ?? "")"
+        case .maxLexemeLengthExceededException(let message):
+            return "MaxLexemeLengthExceededException: \(message ?? "")"
+        case .maxLexiconsNumberExceededException(let message):
+            return "MaxLexiconsNumberExceededException: \(message ?? "")"
+        case .serviceFailureException(let message):
+            return "ServiceFailureException: \(message ?? "")"
+        case .ssmlMarksNotSupportedForTextTypeException(let message):
+            return "SsmlMarksNotSupportedForTextTypeException: \(message ?? "")"
+        case .synthesisTaskNotFoundException(let message):
+            return "SynthesisTaskNotFoundException: \(message ?? "")"
+        case .textLengthExceededException(let message):
+            return "TextLengthExceededException: \(message ?? "")"
+        case .unsupportedPlsAlphabetException(let message):
+            return "UnsupportedPlsAlphabetException: \(message ?? "")"
+        case .unsupportedPlsLanguageException(let message):
+            return "UnsupportedPlsLanguageException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Pricing/Pricing_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Pricing/Pricing_Error.swift
@@ -33,3 +33,20 @@ extension PricingErrorType {
         }
     }
 }
+
+extension PricingErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .expiredNextTokenException(let message):
+            return "ExpiredNextTokenException: \(message ?? "")"
+        case .internalErrorException(let message):
+            return "InternalErrorException: \(message ?? "")"
+        case .invalidNextTokenException(let message):
+            return "InvalidNextTokenException: \(message ?? "")"
+        case .invalidParameterException(let message):
+            return "InvalidParameterException: \(message ?? "")"
+        case .notFoundException(let message):
+            return "NotFoundException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/QuickSight/QuickSight_Error.swift
+++ b/Sources/AWSSDKSwift/Services/QuickSight/QuickSight_Error.swift
@@ -63,3 +63,40 @@ extension QuickSightErrorType {
         }
     }
 }
+
+extension QuickSightErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .accessDeniedException(let message):
+            return "AccessDeniedException: \(message ?? "")"
+        case .domainNotWhitelistedException(let message):
+            return "DomainNotWhitelistedException: \(message ?? "")"
+        case .identityTypeNotSupportedException(let message):
+            return "IdentityTypeNotSupportedException: \(message ?? "")"
+        case .internalFailureException(let message):
+            return "InternalFailureException: \(message ?? "")"
+        case .invalidNextTokenException(let message):
+            return "InvalidNextTokenException: \(message ?? "")"
+        case .invalidParameterValueException(let message):
+            return "InvalidParameterValueException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .preconditionNotMetException(let message):
+            return "PreconditionNotMetException: \(message ?? "")"
+        case .quickSightUserNotFoundException(let message):
+            return "QuickSightUserNotFoundException: \(message ?? "")"
+        case .resourceExistsException(let message):
+            return "ResourceExistsException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .resourceUnavailableException(let message):
+            return "ResourceUnavailableException: \(message ?? "")"
+        case .sessionLifetimeInMinutesInvalidException(let message):
+            return "SessionLifetimeInMinutesInvalidException: \(message ?? "")"
+        case .throttlingException(let message):
+            return "ThrottlingException: \(message ?? "")"
+        case .unsupportedUserEditionException(let message):
+            return "UnsupportedUserEditionException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/RAM/RAM_Error.swift
+++ b/Sources/AWSSDKSwift/Services/RAM/RAM_Error.swift
@@ -78,3 +78,50 @@ extension RAMErrorType {
         }
     }
 }
+
+extension RAMErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .idempotentParameterMismatchException(let message):
+            return "IdempotentParameterMismatchException: \(message ?? "")"
+        case .invalidClientTokenException(let message):
+            return "InvalidClientTokenException: \(message ?? "")"
+        case .invalidMaxResultsException(let message):
+            return "InvalidMaxResultsException: \(message ?? "")"
+        case .invalidNextTokenException(let message):
+            return "InvalidNextTokenException: \(message ?? "")"
+        case .invalidParameterException(let message):
+            return "InvalidParameterException: \(message ?? "")"
+        case .invalidResourceTypeException(let message):
+            return "InvalidResourceTypeException: \(message ?? "")"
+        case .invalidStateTransitionException(let message):
+            return "InvalidStateTransitionException: \(message ?? "")"
+        case .malformedArnException(let message):
+            return "MalformedArnException: \(message ?? "")"
+        case .missingRequiredParameterException(let message):
+            return "MissingRequiredParameterException: \(message ?? "")"
+        case .operationNotPermittedException(let message):
+            return "OperationNotPermittedException: \(message ?? "")"
+        case .resourceArnNotFoundException(let message):
+            return "ResourceArnNotFoundException: \(message ?? "")"
+        case .resourceShareInvitationAlreadyAcceptedException(let message):
+            return "ResourceShareInvitationAlreadyAcceptedException: \(message ?? "")"
+        case .resourceShareInvitationAlreadyRejectedException(let message):
+            return "ResourceShareInvitationAlreadyRejectedException: \(message ?? "")"
+        case .resourceShareInvitationArnNotFoundException(let message):
+            return "ResourceShareInvitationArnNotFoundException: \(message ?? "")"
+        case .resourceShareInvitationExpiredException(let message):
+            return "ResourceShareInvitationExpiredException: \(message ?? "")"
+        case .resourceShareLimitExceededException(let message):
+            return "ResourceShareLimitExceededException: \(message ?? "")"
+        case .serverInternalException(let message):
+            return "ServerInternalException: \(message ?? "")"
+        case .serviceUnavailableException(let message):
+            return "ServiceUnavailableException: \(message ?? "")"
+        case .tagLimitExceededException(let message):
+            return "TagLimitExceededException: \(message ?? "")"
+        case .unknownResourceException(let message):
+            return "UnknownResourceException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/RDS/RDS_Error.swift
+++ b/Sources/AWSSDKSwift/Services/RDS/RDS_Error.swift
@@ -297,3 +297,196 @@ extension RDSErrorType {
         }
     }
 }
+
+extension RDSErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .authorizationAlreadyExistsFault(let message):
+            return "AuthorizationAlreadyExistsFault: \(message ?? "")"
+        case .authorizationNotFoundFault(let message):
+            return "AuthorizationNotFoundFault: \(message ?? "")"
+        case .authorizationQuotaExceededFault(let message):
+            return "AuthorizationQuotaExceededFault: \(message ?? "")"
+        case .backupPolicyNotFoundFault(let message):
+            return "BackupPolicyNotFoundFault: \(message ?? "")"
+        case .certificateNotFoundFault(let message):
+            return "CertificateNotFoundFault: \(message ?? "")"
+        case .dBClusterAlreadyExistsFault(let message):
+            return "DBClusterAlreadyExistsFault: \(message ?? "")"
+        case .dBClusterBacktrackNotFoundFault(let message):
+            return "DBClusterBacktrackNotFoundFault: \(message ?? "")"
+        case .dBClusterEndpointAlreadyExistsFault(let message):
+            return "DBClusterEndpointAlreadyExistsFault: \(message ?? "")"
+        case .dBClusterEndpointNotFoundFault(let message):
+            return "DBClusterEndpointNotFoundFault: \(message ?? "")"
+        case .dBClusterEndpointQuotaExceededFault(let message):
+            return "DBClusterEndpointQuotaExceededFault: \(message ?? "")"
+        case .dBClusterNotFoundFault(let message):
+            return "DBClusterNotFoundFault: \(message ?? "")"
+        case .dBClusterParameterGroupNotFoundFault(let message):
+            return "DBClusterParameterGroupNotFoundFault: \(message ?? "")"
+        case .dBClusterQuotaExceededFault(let message):
+            return "DBClusterQuotaExceededFault: \(message ?? "")"
+        case .dBClusterRoleAlreadyExistsFault(let message):
+            return "DBClusterRoleAlreadyExistsFault: \(message ?? "")"
+        case .dBClusterRoleNotFoundFault(let message):
+            return "DBClusterRoleNotFoundFault: \(message ?? "")"
+        case .dBClusterRoleQuotaExceededFault(let message):
+            return "DBClusterRoleQuotaExceededFault: \(message ?? "")"
+        case .dBClusterSnapshotAlreadyExistsFault(let message):
+            return "DBClusterSnapshotAlreadyExistsFault: \(message ?? "")"
+        case .dBClusterSnapshotNotFoundFault(let message):
+            return "DBClusterSnapshotNotFoundFault: \(message ?? "")"
+        case .dBInstanceAlreadyExistsFault(let message):
+            return "DBInstanceAlreadyExistsFault: \(message ?? "")"
+        case .dBInstanceAutomatedBackupNotFoundFault(let message):
+            return "DBInstanceAutomatedBackupNotFoundFault: \(message ?? "")"
+        case .dBInstanceAutomatedBackupQuotaExceededFault(let message):
+            return "DBInstanceAutomatedBackupQuotaExceededFault: \(message ?? "")"
+        case .dBInstanceNotFoundFault(let message):
+            return "DBInstanceNotFoundFault: \(message ?? "")"
+        case .dBInstanceRoleAlreadyExistsFault(let message):
+            return "DBInstanceRoleAlreadyExistsFault: \(message ?? "")"
+        case .dBInstanceRoleNotFoundFault(let message):
+            return "DBInstanceRoleNotFoundFault: \(message ?? "")"
+        case .dBInstanceRoleQuotaExceededFault(let message):
+            return "DBInstanceRoleQuotaExceededFault: \(message ?? "")"
+        case .dBLogFileNotFoundFault(let message):
+            return "DBLogFileNotFoundFault: \(message ?? "")"
+        case .dBParameterGroupAlreadyExistsFault(let message):
+            return "DBParameterGroupAlreadyExistsFault: \(message ?? "")"
+        case .dBParameterGroupNotFoundFault(let message):
+            return "DBParameterGroupNotFoundFault: \(message ?? "")"
+        case .dBParameterGroupQuotaExceededFault(let message):
+            return "DBParameterGroupQuotaExceededFault: \(message ?? "")"
+        case .dBSecurityGroupAlreadyExistsFault(let message):
+            return "DBSecurityGroupAlreadyExistsFault: \(message ?? "")"
+        case .dBSecurityGroupNotFoundFault(let message):
+            return "DBSecurityGroupNotFoundFault: \(message ?? "")"
+        case .dBSecurityGroupNotSupportedFault(let message):
+            return "DBSecurityGroupNotSupportedFault: \(message ?? "")"
+        case .dBSecurityGroupQuotaExceededFault(let message):
+            return "DBSecurityGroupQuotaExceededFault: \(message ?? "")"
+        case .dBSnapshotAlreadyExistsFault(let message):
+            return "DBSnapshotAlreadyExistsFault: \(message ?? "")"
+        case .dBSnapshotNotFoundFault(let message):
+            return "DBSnapshotNotFoundFault: \(message ?? "")"
+        case .dBSubnetGroupAlreadyExistsFault(let message):
+            return "DBSubnetGroupAlreadyExistsFault: \(message ?? "")"
+        case .dBSubnetGroupDoesNotCoverEnoughAZs(let message):
+            return "DBSubnetGroupDoesNotCoverEnoughAZs: \(message ?? "")"
+        case .dBSubnetGroupNotAllowedFault(let message):
+            return "DBSubnetGroupNotAllowedFault: \(message ?? "")"
+        case .dBSubnetGroupNotFoundFault(let message):
+            return "DBSubnetGroupNotFoundFault: \(message ?? "")"
+        case .dBSubnetGroupQuotaExceededFault(let message):
+            return "DBSubnetGroupQuotaExceededFault: \(message ?? "")"
+        case .dBSubnetQuotaExceededFault(let message):
+            return "DBSubnetQuotaExceededFault: \(message ?? "")"
+        case .dBUpgradeDependencyFailureFault(let message):
+            return "DBUpgradeDependencyFailureFault: \(message ?? "")"
+        case .domainNotFoundFault(let message):
+            return "DomainNotFoundFault: \(message ?? "")"
+        case .eventSubscriptionQuotaExceededFault(let message):
+            return "EventSubscriptionQuotaExceededFault: \(message ?? "")"
+        case .globalClusterAlreadyExistsFault(let message):
+            return "GlobalClusterAlreadyExistsFault: \(message ?? "")"
+        case .globalClusterNotFoundFault(let message):
+            return "GlobalClusterNotFoundFault: \(message ?? "")"
+        case .globalClusterQuotaExceededFault(let message):
+            return "GlobalClusterQuotaExceededFault: \(message ?? "")"
+        case .instanceQuotaExceededFault(let message):
+            return "InstanceQuotaExceededFault: \(message ?? "")"
+        case .insufficientDBClusterCapacityFault(let message):
+            return "InsufficientDBClusterCapacityFault: \(message ?? "")"
+        case .insufficientDBInstanceCapacityFault(let message):
+            return "InsufficientDBInstanceCapacityFault: \(message ?? "")"
+        case .insufficientStorageClusterCapacityFault(let message):
+            return "InsufficientStorageClusterCapacityFault: \(message ?? "")"
+        case .invalidDBClusterCapacityFault(let message):
+            return "InvalidDBClusterCapacityFault: \(message ?? "")"
+        case .invalidDBClusterEndpointStateFault(let message):
+            return "InvalidDBClusterEndpointStateFault: \(message ?? "")"
+        case .invalidDBClusterSnapshotStateFault(let message):
+            return "InvalidDBClusterSnapshotStateFault: \(message ?? "")"
+        case .invalidDBClusterStateFault(let message):
+            return "InvalidDBClusterStateFault: \(message ?? "")"
+        case .invalidDBInstanceAutomatedBackupStateFault(let message):
+            return "InvalidDBInstanceAutomatedBackupStateFault: \(message ?? "")"
+        case .invalidDBInstanceStateFault(let message):
+            return "InvalidDBInstanceStateFault: \(message ?? "")"
+        case .invalidDBParameterGroupStateFault(let message):
+            return "InvalidDBParameterGroupStateFault: \(message ?? "")"
+        case .invalidDBSecurityGroupStateFault(let message):
+            return "InvalidDBSecurityGroupStateFault: \(message ?? "")"
+        case .invalidDBSnapshotStateFault(let message):
+            return "InvalidDBSnapshotStateFault: \(message ?? "")"
+        case .invalidDBSubnetGroupFault(let message):
+            return "InvalidDBSubnetGroupFault: \(message ?? "")"
+        case .invalidDBSubnetGroupStateFault(let message):
+            return "InvalidDBSubnetGroupStateFault: \(message ?? "")"
+        case .invalidDBSubnetStateFault(let message):
+            return "InvalidDBSubnetStateFault: \(message ?? "")"
+        case .invalidEventSubscriptionStateFault(let message):
+            return "InvalidEventSubscriptionStateFault: \(message ?? "")"
+        case .invalidGlobalClusterStateFault(let message):
+            return "InvalidGlobalClusterStateFault: \(message ?? "")"
+        case .invalidOptionGroupStateFault(let message):
+            return "InvalidOptionGroupStateFault: \(message ?? "")"
+        case .invalidRestoreFault(let message):
+            return "InvalidRestoreFault: \(message ?? "")"
+        case .invalidS3BucketFault(let message):
+            return "InvalidS3BucketFault: \(message ?? "")"
+        case .invalidSubnet(let message):
+            return "InvalidSubnet: \(message ?? "")"
+        case .invalidVPCNetworkStateFault(let message):
+            return "InvalidVPCNetworkStateFault: \(message ?? "")"
+        case .kMSKeyNotAccessibleFault(let message):
+            return "KMSKeyNotAccessibleFault: \(message ?? "")"
+        case .optionGroupAlreadyExistsFault(let message):
+            return "OptionGroupAlreadyExistsFault: \(message ?? "")"
+        case .optionGroupNotFoundFault(let message):
+            return "OptionGroupNotFoundFault: \(message ?? "")"
+        case .optionGroupQuotaExceededFault(let message):
+            return "OptionGroupQuotaExceededFault: \(message ?? "")"
+        case .pointInTimeRestoreNotEnabledFault(let message):
+            return "PointInTimeRestoreNotEnabledFault: \(message ?? "")"
+        case .provisionedIopsNotAvailableInAZFault(let message):
+            return "ProvisionedIopsNotAvailableInAZFault: \(message ?? "")"
+        case .reservedDBInstanceAlreadyExistsFault(let message):
+            return "ReservedDBInstanceAlreadyExistsFault: \(message ?? "")"
+        case .reservedDBInstanceNotFoundFault(let message):
+            return "ReservedDBInstanceNotFoundFault: \(message ?? "")"
+        case .reservedDBInstanceQuotaExceededFault(let message):
+            return "ReservedDBInstanceQuotaExceededFault: \(message ?? "")"
+        case .reservedDBInstancesOfferingNotFoundFault(let message):
+            return "ReservedDBInstancesOfferingNotFoundFault: \(message ?? "")"
+        case .resourceNotFoundFault(let message):
+            return "ResourceNotFoundFault: \(message ?? "")"
+        case .sNSInvalidTopicFault(let message):
+            return "SNSInvalidTopicFault: \(message ?? "")"
+        case .sNSNoAuthorizationFault(let message):
+            return "SNSNoAuthorizationFault: \(message ?? "")"
+        case .sNSTopicArnNotFoundFault(let message):
+            return "SNSTopicArnNotFoundFault: \(message ?? "")"
+        case .sharedSnapshotQuotaExceededFault(let message):
+            return "SharedSnapshotQuotaExceededFault: \(message ?? "")"
+        case .snapshotQuotaExceededFault(let message):
+            return "SnapshotQuotaExceededFault: \(message ?? "")"
+        case .sourceNotFoundFault(let message):
+            return "SourceNotFoundFault: \(message ?? "")"
+        case .storageQuotaExceededFault(let message):
+            return "StorageQuotaExceededFault: \(message ?? "")"
+        case .storageTypeNotSupportedFault(let message):
+            return "StorageTypeNotSupportedFault: \(message ?? "")"
+        case .subnetAlreadyInUse(let message):
+            return "SubnetAlreadyInUse: \(message ?? "")"
+        case .subscriptionAlreadyExistFault(let message):
+            return "SubscriptionAlreadyExistFault: \(message ?? "")"
+        case .subscriptionCategoryNotFoundFault(let message):
+            return "SubscriptionCategoryNotFoundFault: \(message ?? "")"
+        case .subscriptionNotFoundFault(let message):
+            return "SubscriptionNotFoundFault: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/RDSDataService/RDSDataService_Error.swift
+++ b/Sources/AWSSDKSwift/Services/RDSDataService/RDSDataService_Error.swift
@@ -36,3 +36,22 @@ extension RDSDataServiceErrorType {
         }
     }
 }
+
+extension RDSDataServiceErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .badRequestException(let message):
+            return "BadRequestException: \(message ?? "")"
+        case .forbiddenException(let message):
+            return "ForbiddenException: \(message ?? "")"
+        case .internalServerErrorException(let message):
+            return "InternalServerErrorException: \(message ?? "")"
+        case .notFoundException(let message):
+            return "NotFoundException: \(message ?? "")"
+        case .serviceUnavailableError(let message):
+            return "ServiceUnavailableError: \(message ?? "")"
+        case .statementTimeoutException(let message):
+            return "StatementTimeoutException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Redshift/Redshift_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Redshift/Redshift_Error.swift
@@ -315,3 +315,208 @@ extension RedshiftErrorType {
         }
     }
 }
+
+extension RedshiftErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .accessToSnapshotDeniedFault(let message):
+            return "AccessToSnapshotDeniedFault: \(message ?? "")"
+        case .authorizationAlreadyExistsFault(let message):
+            return "AuthorizationAlreadyExistsFault: \(message ?? "")"
+        case .authorizationNotFoundFault(let message):
+            return "AuthorizationNotFoundFault: \(message ?? "")"
+        case .authorizationQuotaExceededFault(let message):
+            return "AuthorizationQuotaExceededFault: \(message ?? "")"
+        case .batchDeleteRequestSizeExceededFault(let message):
+            return "BatchDeleteRequestSizeExceededFault: \(message ?? "")"
+        case .batchModifyClusterSnapshotsLimitExceededFault(let message):
+            return "BatchModifyClusterSnapshotsLimitExceededFault: \(message ?? "")"
+        case .bucketNotFoundFault(let message):
+            return "BucketNotFoundFault: \(message ?? "")"
+        case .clusterAlreadyExistsFault(let message):
+            return "ClusterAlreadyExistsFault: \(message ?? "")"
+        case .clusterNotFoundFault(let message):
+            return "ClusterNotFoundFault: \(message ?? "")"
+        case .clusterOnLatestRevisionFault(let message):
+            return "ClusterOnLatestRevisionFault: \(message ?? "")"
+        case .clusterParameterGroupAlreadyExistsFault(let message):
+            return "ClusterParameterGroupAlreadyExistsFault: \(message ?? "")"
+        case .clusterParameterGroupNotFoundFault(let message):
+            return "ClusterParameterGroupNotFoundFault: \(message ?? "")"
+        case .clusterParameterGroupQuotaExceededFault(let message):
+            return "ClusterParameterGroupQuotaExceededFault: \(message ?? "")"
+        case .clusterQuotaExceededFault(let message):
+            return "ClusterQuotaExceededFault: \(message ?? "")"
+        case .clusterSecurityGroupAlreadyExistsFault(let message):
+            return "ClusterSecurityGroupAlreadyExistsFault: \(message ?? "")"
+        case .clusterSecurityGroupNotFoundFault(let message):
+            return "ClusterSecurityGroupNotFoundFault: \(message ?? "")"
+        case .clusterSecurityGroupQuotaExceededFault(let message):
+            return "ClusterSecurityGroupQuotaExceededFault: \(message ?? "")"
+        case .clusterSnapshotAlreadyExistsFault(let message):
+            return "ClusterSnapshotAlreadyExistsFault: \(message ?? "")"
+        case .clusterSnapshotNotFoundFault(let message):
+            return "ClusterSnapshotNotFoundFault: \(message ?? "")"
+        case .clusterSnapshotQuotaExceededFault(let message):
+            return "ClusterSnapshotQuotaExceededFault: \(message ?? "")"
+        case .clusterSubnetGroupAlreadyExistsFault(let message):
+            return "ClusterSubnetGroupAlreadyExistsFault: \(message ?? "")"
+        case .clusterSubnetGroupNotFoundFault(let message):
+            return "ClusterSubnetGroupNotFoundFault: \(message ?? "")"
+        case .clusterSubnetGroupQuotaExceededFault(let message):
+            return "ClusterSubnetGroupQuotaExceededFault: \(message ?? "")"
+        case .clusterSubnetQuotaExceededFault(let message):
+            return "ClusterSubnetQuotaExceededFault: \(message ?? "")"
+        case .copyToRegionDisabledFault(let message):
+            return "CopyToRegionDisabledFault: \(message ?? "")"
+        case .dependentServiceRequestThrottlingFault(let message):
+            return "DependentServiceRequestThrottlingFault: \(message ?? "")"
+        case .dependentServiceUnavailableFault(let message):
+            return "DependentServiceUnavailableFault: \(message ?? "")"
+        case .eventSubscriptionQuotaExceededFault(let message):
+            return "EventSubscriptionQuotaExceededFault: \(message ?? "")"
+        case .hsmClientCertificateAlreadyExistsFault(let message):
+            return "HsmClientCertificateAlreadyExistsFault: \(message ?? "")"
+        case .hsmClientCertificateNotFoundFault(let message):
+            return "HsmClientCertificateNotFoundFault: \(message ?? "")"
+        case .hsmClientCertificateQuotaExceededFault(let message):
+            return "HsmClientCertificateQuotaExceededFault: \(message ?? "")"
+        case .hsmConfigurationAlreadyExistsFault(let message):
+            return "HsmConfigurationAlreadyExistsFault: \(message ?? "")"
+        case .hsmConfigurationNotFoundFault(let message):
+            return "HsmConfigurationNotFoundFault: \(message ?? "")"
+        case .hsmConfigurationQuotaExceededFault(let message):
+            return "HsmConfigurationQuotaExceededFault: \(message ?? "")"
+        case .inProgressTableRestoreQuotaExceededFault(let message):
+            return "InProgressTableRestoreQuotaExceededFault: \(message ?? "")"
+        case .incompatibleOrderableOptions(let message):
+            return "IncompatibleOrderableOptions: \(message ?? "")"
+        case .insufficientClusterCapacityFault(let message):
+            return "InsufficientClusterCapacityFault: \(message ?? "")"
+        case .insufficientS3BucketPolicyFault(let message):
+            return "InsufficientS3BucketPolicyFault: \(message ?? "")"
+        case .invalidClusterParameterGroupStateFault(let message):
+            return "InvalidClusterParameterGroupStateFault: \(message ?? "")"
+        case .invalidClusterSecurityGroupStateFault(let message):
+            return "InvalidClusterSecurityGroupStateFault: \(message ?? "")"
+        case .invalidClusterSnapshotScheduleStateFault(let message):
+            return "InvalidClusterSnapshotScheduleStateFault: \(message ?? "")"
+        case .invalidClusterSnapshotStateFault(let message):
+            return "InvalidClusterSnapshotStateFault: \(message ?? "")"
+        case .invalidClusterStateFault(let message):
+            return "InvalidClusterStateFault: \(message ?? "")"
+        case .invalidClusterSubnetGroupStateFault(let message):
+            return "InvalidClusterSubnetGroupStateFault: \(message ?? "")"
+        case .invalidClusterSubnetStateFault(let message):
+            return "InvalidClusterSubnetStateFault: \(message ?? "")"
+        case .invalidClusterTrackFault(let message):
+            return "InvalidClusterTrackFault: \(message ?? "")"
+        case .invalidElasticIpFault(let message):
+            return "InvalidElasticIpFault: \(message ?? "")"
+        case .invalidHsmClientCertificateStateFault(let message):
+            return "InvalidHsmClientCertificateStateFault: \(message ?? "")"
+        case .invalidHsmConfigurationStateFault(let message):
+            return "InvalidHsmConfigurationStateFault: \(message ?? "")"
+        case .invalidReservedNodeStateFault(let message):
+            return "InvalidReservedNodeStateFault: \(message ?? "")"
+        case .invalidRestoreFault(let message):
+            return "InvalidRestoreFault: \(message ?? "")"
+        case .invalidRetentionPeriodFault(let message):
+            return "InvalidRetentionPeriodFault: \(message ?? "")"
+        case .invalidS3BucketNameFault(let message):
+            return "InvalidS3BucketNameFault: \(message ?? "")"
+        case .invalidS3KeyPrefixFault(let message):
+            return "InvalidS3KeyPrefixFault: \(message ?? "")"
+        case .invalidScheduleFault(let message):
+            return "InvalidScheduleFault: \(message ?? "")"
+        case .invalidSnapshotCopyGrantStateFault(let message):
+            return "InvalidSnapshotCopyGrantStateFault: \(message ?? "")"
+        case .invalidSubnet(let message):
+            return "InvalidSubnet: \(message ?? "")"
+        case .invalidSubscriptionStateFault(let message):
+            return "InvalidSubscriptionStateFault: \(message ?? "")"
+        case .invalidTableRestoreArgumentFault(let message):
+            return "InvalidTableRestoreArgumentFault: \(message ?? "")"
+        case .invalidTagFault(let message):
+            return "InvalidTagFault: \(message ?? "")"
+        case .invalidVPCNetworkStateFault(let message):
+            return "InvalidVPCNetworkStateFault: \(message ?? "")"
+        case .limitExceededFault(let message):
+            return "LimitExceededFault: \(message ?? "")"
+        case .numberOfNodesPerClusterLimitExceededFault(let message):
+            return "NumberOfNodesPerClusterLimitExceededFault: \(message ?? "")"
+        case .numberOfNodesQuotaExceededFault(let message):
+            return "NumberOfNodesQuotaExceededFault: \(message ?? "")"
+        case .reservedNodeAlreadyExistsFault(let message):
+            return "ReservedNodeAlreadyExistsFault: \(message ?? "")"
+        case .reservedNodeAlreadyMigratedFault(let message):
+            return "ReservedNodeAlreadyMigratedFault: \(message ?? "")"
+        case .reservedNodeNotFoundFault(let message):
+            return "ReservedNodeNotFoundFault: \(message ?? "")"
+        case .reservedNodeOfferingNotFoundFault(let message):
+            return "ReservedNodeOfferingNotFoundFault: \(message ?? "")"
+        case .reservedNodeQuotaExceededFault(let message):
+            return "ReservedNodeQuotaExceededFault: \(message ?? "")"
+        case .resizeNotFoundFault(let message):
+            return "ResizeNotFoundFault: \(message ?? "")"
+        case .resourceNotFoundFault(let message):
+            return "ResourceNotFoundFault: \(message ?? "")"
+        case .sNSInvalidTopicFault(let message):
+            return "SNSInvalidTopicFault: \(message ?? "")"
+        case .sNSNoAuthorizationFault(let message):
+            return "SNSNoAuthorizationFault: \(message ?? "")"
+        case .sNSTopicArnNotFoundFault(let message):
+            return "SNSTopicArnNotFoundFault: \(message ?? "")"
+        case .scheduleDefinitionTypeUnsupportedFault(let message):
+            return "ScheduleDefinitionTypeUnsupportedFault: \(message ?? "")"
+        case .snapshotCopyAlreadyDisabledFault(let message):
+            return "SnapshotCopyAlreadyDisabledFault: \(message ?? "")"
+        case .snapshotCopyAlreadyEnabledFault(let message):
+            return "SnapshotCopyAlreadyEnabledFault: \(message ?? "")"
+        case .snapshotCopyDisabledFault(let message):
+            return "SnapshotCopyDisabledFault: \(message ?? "")"
+        case .snapshotCopyGrantAlreadyExistsFault(let message):
+            return "SnapshotCopyGrantAlreadyExistsFault: \(message ?? "")"
+        case .snapshotCopyGrantNotFoundFault(let message):
+            return "SnapshotCopyGrantNotFoundFault: \(message ?? "")"
+        case .snapshotCopyGrantQuotaExceededFault(let message):
+            return "SnapshotCopyGrantQuotaExceededFault: \(message ?? "")"
+        case .snapshotScheduleAlreadyExistsFault(let message):
+            return "SnapshotScheduleAlreadyExistsFault: \(message ?? "")"
+        case .snapshotScheduleNotFoundFault(let message):
+            return "SnapshotScheduleNotFoundFault: \(message ?? "")"
+        case .snapshotScheduleQuotaExceededFault(let message):
+            return "SnapshotScheduleQuotaExceededFault: \(message ?? "")"
+        case .snapshotScheduleUpdateInProgressFault(let message):
+            return "SnapshotScheduleUpdateInProgressFault: \(message ?? "")"
+        case .sourceNotFoundFault(let message):
+            return "SourceNotFoundFault: \(message ?? "")"
+        case .subnetAlreadyInUse(let message):
+            return "SubnetAlreadyInUse: \(message ?? "")"
+        case .subscriptionAlreadyExistFault(let message):
+            return "SubscriptionAlreadyExistFault: \(message ?? "")"
+        case .subscriptionCategoryNotFoundFault(let message):
+            return "SubscriptionCategoryNotFoundFault: \(message ?? "")"
+        case .subscriptionEventIdNotFoundFault(let message):
+            return "SubscriptionEventIdNotFoundFault: \(message ?? "")"
+        case .subscriptionNotFoundFault(let message):
+            return "SubscriptionNotFoundFault: \(message ?? "")"
+        case .subscriptionSeverityNotFoundFault(let message):
+            return "SubscriptionSeverityNotFoundFault: \(message ?? "")"
+        case .tableLimitExceededFault(let message):
+            return "TableLimitExceededFault: \(message ?? "")"
+        case .tableRestoreNotFoundFault(let message):
+            return "TableRestoreNotFoundFault: \(message ?? "")"
+        case .tagLimitExceededFault(let message):
+            return "TagLimitExceededFault: \(message ?? "")"
+        case .unauthorizedOperation(let message):
+            return "UnauthorizedOperation: \(message ?? "")"
+        case .unknownSnapshotCopyRegionFault(let message):
+            return "UnknownSnapshotCopyRegionFault: \(message ?? "")"
+        case .unsupportedOperationFault(let message):
+            return "UnsupportedOperationFault: \(message ?? "")"
+        case .unsupportedOptionFault(let message):
+            return "UnsupportedOptionFault: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Rekognition/Rekognition_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Rekognition/Rekognition_Error.swift
@@ -63,3 +63,40 @@ extension RekognitionErrorType {
         }
     }
 }
+
+extension RekognitionErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .accessDeniedException(let message):
+            return "AccessDeniedException: \(message ?? "")"
+        case .idempotentParameterMismatchException(let message):
+            return "IdempotentParameterMismatchException: \(message ?? "")"
+        case .imageTooLargeException(let message):
+            return "ImageTooLargeException: \(message ?? "")"
+        case .internalServerError(let message):
+            return "InternalServerError: \(message ?? "")"
+        case .invalidImageFormatException(let message):
+            return "InvalidImageFormatException: \(message ?? "")"
+        case .invalidPaginationTokenException(let message):
+            return "InvalidPaginationTokenException: \(message ?? "")"
+        case .invalidParameterException(let message):
+            return "InvalidParameterException: \(message ?? "")"
+        case .invalidS3ObjectException(let message):
+            return "InvalidS3ObjectException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .provisionedThroughputExceededException(let message):
+            return "ProvisionedThroughputExceededException: \(message ?? "")"
+        case .resourceAlreadyExistsException(let message):
+            return "ResourceAlreadyExistsException: \(message ?? "")"
+        case .resourceInUseException(let message):
+            return "ResourceInUseException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .throttlingException(let message):
+            return "ThrottlingException: \(message ?? "")"
+        case .videoTooLargeException(let message):
+            return "VideoTooLargeException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/ResourceGroups/ResourceGroups_Error.swift
+++ b/Sources/AWSSDKSwift/Services/ResourceGroups/ResourceGroups_Error.swift
@@ -39,3 +39,24 @@ extension ResourceGroupsErrorType {
         }
     }
 }
+
+extension ResourceGroupsErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .badRequestException(let message):
+            return "BadRequestException: \(message ?? "")"
+        case .forbiddenException(let message):
+            return "ForbiddenException: \(message ?? "")"
+        case .internalServerErrorException(let message):
+            return "InternalServerErrorException: \(message ?? "")"
+        case .methodNotAllowedException(let message):
+            return "MethodNotAllowedException: \(message ?? "")"
+        case .notFoundException(let message):
+            return "NotFoundException: \(message ?? "")"
+        case .tooManyRequestsException(let message):
+            return "TooManyRequestsException: \(message ?? "")"
+        case .unauthorizedException(let message):
+            return "UnauthorizedException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/ResourceGroupsTaggingAPI/ResourceGroupsTaggingAPI_Error.swift
+++ b/Sources/AWSSDKSwift/Services/ResourceGroupsTaggingAPI/ResourceGroupsTaggingAPI_Error.swift
@@ -30,3 +30,18 @@ extension ResourceGroupsTaggingAPIErrorType {
         }
     }
 }
+
+extension ResourceGroupsTaggingAPIErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .internalServiceException(let message):
+            return "InternalServiceException: \(message ?? "")"
+        case .invalidParameterException(let message):
+            return "InvalidParameterException: \(message ?? "")"
+        case .paginationTokenExpiredException(let message):
+            return "PaginationTokenExpiredException: \(message ?? "")"
+        case .throttledException(let message):
+            return "ThrottledException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/RoboMaker/RoboMaker_Error.swift
+++ b/Sources/AWSSDKSwift/Services/RoboMaker/RoboMaker_Error.swift
@@ -45,3 +45,28 @@ extension RoboMakerErrorType {
         }
     }
 }
+
+extension RoboMakerErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .concurrentDeploymentException(let message):
+            return "ConcurrentDeploymentException: \(message ?? "")"
+        case .idempotentParameterMismatchException(let message):
+            return "IdempotentParameterMismatchException: \(message ?? "")"
+        case .internalServerException(let message):
+            return "InternalServerException: \(message ?? "")"
+        case .invalidParameterException(let message):
+            return "InvalidParameterException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .resourceAlreadyExistsException(let message):
+            return "ResourceAlreadyExistsException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .serviceUnavailableException(let message):
+            return "ServiceUnavailableException: \(message ?? "")"
+        case .throttlingException(let message):
+            return "ThrottlingException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Route53/Route53_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Route53/Route53_Error.swift
@@ -171,3 +171,112 @@ extension Route53ErrorType {
         }
     }
 }
+
+extension Route53ErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .concurrentModification(let message):
+            return "ConcurrentModification: \(message ?? "")"
+        case .conflictingDomainExists(let message):
+            return "ConflictingDomainExists: \(message ?? "")"
+        case .conflictingTypes(let message):
+            return "ConflictingTypes: \(message ?? "")"
+        case .delegationSetAlreadyCreated(let message):
+            return "DelegationSetAlreadyCreated: \(message ?? "")"
+        case .delegationSetAlreadyReusable(let message):
+            return "DelegationSetAlreadyReusable: \(message ?? "")"
+        case .delegationSetInUse(let message):
+            return "DelegationSetInUse: \(message ?? "")"
+        case .delegationSetNotAvailable(let message):
+            return "DelegationSetNotAvailable: \(message ?? "")"
+        case .delegationSetNotReusable(let message):
+            return "DelegationSetNotReusable: \(message ?? "")"
+        case .healthCheckAlreadyExists(let message):
+            return "HealthCheckAlreadyExists: \(message ?? "")"
+        case .healthCheckInUse(let message):
+            return "HealthCheckInUse: \(message ?? "")"
+        case .healthCheckVersionMismatch(let message):
+            return "HealthCheckVersionMismatch: \(message ?? "")"
+        case .hostedZoneAlreadyExists(let message):
+            return "HostedZoneAlreadyExists: \(message ?? "")"
+        case .hostedZoneNotEmpty(let message):
+            return "HostedZoneNotEmpty: \(message ?? "")"
+        case .hostedZoneNotFound(let message):
+            return "HostedZoneNotFound: \(message ?? "")"
+        case .hostedZoneNotPrivate(let message):
+            return "HostedZoneNotPrivate: \(message ?? "")"
+        case .incompatibleVersion(let message):
+            return "IncompatibleVersion: \(message ?? "")"
+        case .insufficientCloudWatchLogsResourcePolicy(let message):
+            return "InsufficientCloudWatchLogsResourcePolicy: \(message ?? "")"
+        case .invalidArgument(let message):
+            return "InvalidArgument: \(message ?? "")"
+        case .invalidChangeBatch(let message):
+            return "InvalidChangeBatch: \(message ?? "")"
+        case .invalidDomainName(let message):
+            return "InvalidDomainName: \(message ?? "")"
+        case .invalidInput(let message):
+            return "InvalidInput: \(message ?? "")"
+        case .invalidPaginationToken(let message):
+            return "InvalidPaginationToken: \(message ?? "")"
+        case .invalidTrafficPolicyDocument(let message):
+            return "InvalidTrafficPolicyDocument: \(message ?? "")"
+        case .invalidVPCId(let message):
+            return "InvalidVPCId: \(message ?? "")"
+        case .lastVPCAssociation(let message):
+            return "LastVPCAssociation: \(message ?? "")"
+        case .limitsExceeded(let message):
+            return "LimitsExceeded: \(message ?? "")"
+        case .noSuchChange(let message):
+            return "NoSuchChange: \(message ?? "")"
+        case .noSuchCloudWatchLogsLogGroup(let message):
+            return "NoSuchCloudWatchLogsLogGroup: \(message ?? "")"
+        case .noSuchDelegationSet(let message):
+            return "NoSuchDelegationSet: \(message ?? "")"
+        case .noSuchGeoLocation(let message):
+            return "NoSuchGeoLocation: \(message ?? "")"
+        case .noSuchHealthCheck(let message):
+            return "NoSuchHealthCheck: \(message ?? "")"
+        case .noSuchHostedZone(let message):
+            return "NoSuchHostedZone: \(message ?? "")"
+        case .noSuchQueryLoggingConfig(let message):
+            return "NoSuchQueryLoggingConfig: \(message ?? "")"
+        case .noSuchTrafficPolicy(let message):
+            return "NoSuchTrafficPolicy: \(message ?? "")"
+        case .noSuchTrafficPolicyInstance(let message):
+            return "NoSuchTrafficPolicyInstance: \(message ?? "")"
+        case .notAuthorizedException(let message):
+            return "NotAuthorizedException: \(message ?? "")"
+        case .priorRequestNotComplete(let message):
+            return "PriorRequestNotComplete: \(message ?? "")"
+        case .publicZoneVPCAssociation(let message):
+            return "PublicZoneVPCAssociation: \(message ?? "")"
+        case .queryLoggingConfigAlreadyExists(let message):
+            return "QueryLoggingConfigAlreadyExists: \(message ?? "")"
+        case .throttlingException(let message):
+            return "ThrottlingException: \(message ?? "")"
+        case .tooManyHealthChecks(let message):
+            return "TooManyHealthChecks: \(message ?? "")"
+        case .tooManyHostedZones(let message):
+            return "TooManyHostedZones: \(message ?? "")"
+        case .tooManyTrafficPolicies(let message):
+            return "TooManyTrafficPolicies: \(message ?? "")"
+        case .tooManyTrafficPolicyInstances(let message):
+            return "TooManyTrafficPolicyInstances: \(message ?? "")"
+        case .tooManyTrafficPolicyVersionsForCurrentPolicy(let message):
+            return "TooManyTrafficPolicyVersionsForCurrentPolicy: \(message ?? "")"
+        case .tooManyVPCAssociationAuthorizations(let message):
+            return "TooManyVPCAssociationAuthorizations: \(message ?? "")"
+        case .trafficPolicyAlreadyExists(let message):
+            return "TrafficPolicyAlreadyExists: \(message ?? "")"
+        case .trafficPolicyInUse(let message):
+            return "TrafficPolicyInUse: \(message ?? "")"
+        case .trafficPolicyInstanceAlreadyExists(let message):
+            return "TrafficPolicyInstanceAlreadyExists: \(message ?? "")"
+        case .vPCAssociationAuthorizationNotFound(let message):
+            return "VPCAssociationAuthorizationNotFound: \(message ?? "")"
+        case .vPCAssociationNotFound(let message):
+            return "VPCAssociationNotFound: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Route53Domains/Route53Domains_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Route53Domains/Route53Domains_Error.swift
@@ -36,3 +36,22 @@ extension Route53DomainsErrorType {
         }
     }
 }
+
+extension Route53DomainsErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .domainLimitExceeded(let message):
+            return "DomainLimitExceeded: \(message ?? "")"
+        case .duplicateRequest(let message):
+            return "DuplicateRequest: \(message ?? "")"
+        case .invalidInput(let message):
+            return "InvalidInput: \(message ?? "")"
+        case .operationLimitExceeded(let message):
+            return "OperationLimitExceeded: \(message ?? "")"
+        case .tLDRulesViolation(let message):
+            return "TLDRulesViolation: \(message ?? "")"
+        case .unsupportedTLD(let message):
+            return "UnsupportedTLD: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Route53Resolver/Route53Resolver_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Route53Resolver/Route53Resolver_Error.swift
@@ -57,3 +57,36 @@ extension Route53ResolverErrorType {
         }
     }
 }
+
+extension Route53ResolverErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .internalServiceErrorException(let message):
+            return "InternalServiceErrorException: \(message ?? "")"
+        case .invalidNextTokenException(let message):
+            return "InvalidNextTokenException: \(message ?? "")"
+        case .invalidParameterException(let message):
+            return "InvalidParameterException: \(message ?? "")"
+        case .invalidPolicyDocument(let message):
+            return "InvalidPolicyDocument: \(message ?? "")"
+        case .invalidRequestException(let message):
+            return "InvalidRequestException: \(message ?? "")"
+        case .invalidTagException(let message):
+            return "InvalidTagException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .resourceExistsException(let message):
+            return "ResourceExistsException: \(message ?? "")"
+        case .resourceInUseException(let message):
+            return "ResourceInUseException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .resourceUnavailableException(let message):
+            return "ResourceUnavailableException: \(message ?? "")"
+        case .throttlingException(let message):
+            return "ThrottlingException: \(message ?? "")"
+        case .unknownResourceException(let message):
+            return "UnknownResourceException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/S3/S3_Error.swift
+++ b/Sources/AWSSDKSwift/Services/S3/S3_Error.swift
@@ -39,3 +39,24 @@ extension S3ErrorType {
         }
     }
 }
+
+extension S3ErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .bucketAlreadyExists(let message):
+            return "BucketAlreadyExists: \(message ?? "")"
+        case .bucketAlreadyOwnedByYou(let message):
+            return "BucketAlreadyOwnedByYou: \(message ?? "")"
+        case .noSuchBucket(let message):
+            return "NoSuchBucket: \(message ?? "")"
+        case .noSuchKey(let message):
+            return "NoSuchKey: \(message ?? "")"
+        case .noSuchUpload(let message):
+            return "NoSuchUpload: \(message ?? "")"
+        case .objectAlreadyInActiveTierError(let message):
+            return "ObjectAlreadyInActiveTierError: \(message ?? "")"
+        case .objectNotInActiveTierError(let message):
+            return "ObjectNotInActiveTierError: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/S3Control/S3Control_Error.swift
+++ b/Sources/AWSSDKSwift/Services/S3Control/S3Control_Error.swift
@@ -45,3 +45,28 @@ extension S3ControlErrorType {
         }
     }
 }
+
+extension S3ControlErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .badRequestException(let message):
+            return "BadRequestException: \(message ?? "")"
+        case .idempotencyException(let message):
+            return "IdempotencyException: \(message ?? "")"
+        case .internalServiceException(let message):
+            return "InternalServiceException: \(message ?? "")"
+        case .invalidNextTokenException(let message):
+            return "InvalidNextTokenException: \(message ?? "")"
+        case .invalidRequestException(let message):
+            return "InvalidRequestException: \(message ?? "")"
+        case .jobStatusException(let message):
+            return "JobStatusException: \(message ?? "")"
+        case .noSuchPublicAccessBlockConfiguration(let message):
+            return "NoSuchPublicAccessBlockConfiguration: \(message ?? "")"
+        case .notFoundException(let message):
+            return "NotFoundException: \(message ?? "")"
+        case .tooManyRequestsException(let message):
+            return "TooManyRequestsException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/SES/SES_Error.swift
+++ b/Sources/AWSSDKSwift/Services/SES/SES_Error.swift
@@ -120,3 +120,78 @@ extension SESErrorType {
         }
     }
 }
+
+extension SESErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .accountSendingPausedException(let message):
+            return "AccountSendingPausedException: \(message ?? "")"
+        case .alreadyExistsException(let message):
+            return "AlreadyExistsException: \(message ?? "")"
+        case .cannotDeleteException(let message):
+            return "CannotDeleteException: \(message ?? "")"
+        case .configurationSetAlreadyExistsException(let message):
+            return "ConfigurationSetAlreadyExistsException: \(message ?? "")"
+        case .configurationSetDoesNotExistException(let message):
+            return "ConfigurationSetDoesNotExistException: \(message ?? "")"
+        case .configurationSetSendingPausedException(let message):
+            return "ConfigurationSetSendingPausedException: \(message ?? "")"
+        case .customVerificationEmailInvalidContentException(let message):
+            return "CustomVerificationEmailInvalidContentException: \(message ?? "")"
+        case .customVerificationEmailTemplateAlreadyExistsException(let message):
+            return "CustomVerificationEmailTemplateAlreadyExistsException: \(message ?? "")"
+        case .customVerificationEmailTemplateDoesNotExistException(let message):
+            return "CustomVerificationEmailTemplateDoesNotExistException: \(message ?? "")"
+        case .eventDestinationAlreadyExistsException(let message):
+            return "EventDestinationAlreadyExistsException: \(message ?? "")"
+        case .eventDestinationDoesNotExistException(let message):
+            return "EventDestinationDoesNotExistException: \(message ?? "")"
+        case .fromEmailAddressNotVerifiedException(let message):
+            return "FromEmailAddressNotVerifiedException: \(message ?? "")"
+        case .invalidCloudWatchDestinationException(let message):
+            return "InvalidCloudWatchDestinationException: \(message ?? "")"
+        case .invalidConfigurationSetException(let message):
+            return "InvalidConfigurationSetException: \(message ?? "")"
+        case .invalidDeliveryOptionsException(let message):
+            return "InvalidDeliveryOptionsException: \(message ?? "")"
+        case .invalidFirehoseDestinationException(let message):
+            return "InvalidFirehoseDestinationException: \(message ?? "")"
+        case .invalidLambdaFunctionException(let message):
+            return "InvalidLambdaFunctionException: \(message ?? "")"
+        case .invalidPolicyException(let message):
+            return "InvalidPolicyException: \(message ?? "")"
+        case .invalidRenderingParameterException(let message):
+            return "InvalidRenderingParameterException: \(message ?? "")"
+        case .invalidS3ConfigurationException(let message):
+            return "InvalidS3ConfigurationException: \(message ?? "")"
+        case .invalidSNSDestinationException(let message):
+            return "InvalidSNSDestinationException: \(message ?? "")"
+        case .invalidSnsTopicException(let message):
+            return "InvalidSnsTopicException: \(message ?? "")"
+        case .invalidTemplateException(let message):
+            return "InvalidTemplateException: \(message ?? "")"
+        case .invalidTrackingOptionsException(let message):
+            return "InvalidTrackingOptionsException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .mailFromDomainNotVerifiedException(let message):
+            return "MailFromDomainNotVerifiedException: \(message ?? "")"
+        case .messageRejected(let message):
+            return "MessageRejected: \(message ?? "")"
+        case .missingRenderingAttributeException(let message):
+            return "MissingRenderingAttributeException: \(message ?? "")"
+        case .productionAccessNotGrantedException(let message):
+            return "ProductionAccessNotGrantedException: \(message ?? "")"
+        case .ruleDoesNotExistException(let message):
+            return "RuleDoesNotExistException: \(message ?? "")"
+        case .ruleSetDoesNotExistException(let message):
+            return "RuleSetDoesNotExistException: \(message ?? "")"
+        case .templateDoesNotExistException(let message):
+            return "TemplateDoesNotExistException: \(message ?? "")"
+        case .trackingOptionsAlreadyExistsException(let message):
+            return "TrackingOptionsAlreadyExistsException: \(message ?? "")"
+        case .trackingOptionsDoesNotExistException(let message):
+            return "TrackingOptionsDoesNotExistException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/SFN/SFN_Error.swift
+++ b/Sources/AWSSDKSwift/Services/SFN/SFN_Error.swift
@@ -81,3 +81,52 @@ extension SFNErrorType {
         }
     }
 }
+
+extension SFNErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .activityDoesNotExist(let message):
+            return "ActivityDoesNotExist: \(message ?? "")"
+        case .activityLimitExceeded(let message):
+            return "ActivityLimitExceeded: \(message ?? "")"
+        case .activityWorkerLimitExceeded(let message):
+            return "ActivityWorkerLimitExceeded: \(message ?? "")"
+        case .executionAlreadyExists(let message):
+            return "ExecutionAlreadyExists: \(message ?? "")"
+        case .executionDoesNotExist(let message):
+            return "ExecutionDoesNotExist: \(message ?? "")"
+        case .executionLimitExceeded(let message):
+            return "ExecutionLimitExceeded: \(message ?? "")"
+        case .invalidArn(let message):
+            return "InvalidArn: \(message ?? "")"
+        case .invalidDefinition(let message):
+            return "InvalidDefinition: \(message ?? "")"
+        case .invalidExecutionInput(let message):
+            return "InvalidExecutionInput: \(message ?? "")"
+        case .invalidName(let message):
+            return "InvalidName: \(message ?? "")"
+        case .invalidOutput(let message):
+            return "InvalidOutput: \(message ?? "")"
+        case .invalidToken(let message):
+            return "InvalidToken: \(message ?? "")"
+        case .missingRequiredParameter(let message):
+            return "MissingRequiredParameter: \(message ?? "")"
+        case .resourceNotFound(let message):
+            return "ResourceNotFound: \(message ?? "")"
+        case .stateMachineAlreadyExists(let message):
+            return "StateMachineAlreadyExists: \(message ?? "")"
+        case .stateMachineDeleting(let message):
+            return "StateMachineDeleting: \(message ?? "")"
+        case .stateMachineDoesNotExist(let message):
+            return "StateMachineDoesNotExist: \(message ?? "")"
+        case .stateMachineLimitExceeded(let message):
+            return "StateMachineLimitExceeded: \(message ?? "")"
+        case .taskDoesNotExist(let message):
+            return "TaskDoesNotExist: \(message ?? "")"
+        case .taskTimedOut(let message):
+            return "TaskTimedOut: \(message ?? "")"
+        case .tooManyTags(let message):
+            return "TooManyTags: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/SMS/SMS_Error.swift
+++ b/Sources/AWSSDKSwift/Services/SMS/SMS_Error.swift
@@ -51,3 +51,32 @@ extension SMSErrorType {
         }
     }
 }
+
+extension SMSErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .internalError(let message):
+            return "InternalError: \(message ?? "")"
+        case .invalidParameterException(let message):
+            return "InvalidParameterException: \(message ?? "")"
+        case .missingRequiredParameterException(let message):
+            return "MissingRequiredParameterException: \(message ?? "")"
+        case .noConnectorsAvailableException(let message):
+            return "NoConnectorsAvailableException: \(message ?? "")"
+        case .operationNotPermittedException(let message):
+            return "OperationNotPermittedException: \(message ?? "")"
+        case .replicationJobAlreadyExistsException(let message):
+            return "ReplicationJobAlreadyExistsException: \(message ?? "")"
+        case .replicationJobNotFoundException(let message):
+            return "ReplicationJobNotFoundException: \(message ?? "")"
+        case .replicationRunLimitExceededException(let message):
+            return "ReplicationRunLimitExceededException: \(message ?? "")"
+        case .serverCannotBeReplicatedException(let message):
+            return "ServerCannotBeReplicatedException: \(message ?? "")"
+        case .temporarilyUnavailableException(let message):
+            return "TemporarilyUnavailableException: \(message ?? "")"
+        case .unauthorizedOperationException(let message):
+            return "UnauthorizedOperationException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/SNS/SNS_Error.swift
+++ b/Sources/AWSSDKSwift/Services/SNS/SNS_Error.swift
@@ -87,3 +87,56 @@ extension SNSErrorType {
         }
     }
 }
+
+extension SNSErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .authorizationErrorException(let message):
+            return "AuthorizationErrorException: \(message ?? "")"
+        case .concurrentAccessException(let message):
+            return "ConcurrentAccessException: \(message ?? "")"
+        case .endpointDisabledException(let message):
+            return "EndpointDisabledException: \(message ?? "")"
+        case .filterPolicyLimitExceededException(let message):
+            return "FilterPolicyLimitExceededException: \(message ?? "")"
+        case .internalErrorException(let message):
+            return "InternalErrorException: \(message ?? "")"
+        case .invalidParameterException(let message):
+            return "InvalidParameterException: \(message ?? "")"
+        case .invalidParameterValueException(let message):
+            return "InvalidParameterValueException: \(message ?? "")"
+        case .invalidSecurityException(let message):
+            return "InvalidSecurityException: \(message ?? "")"
+        case .kMSAccessDeniedException(let message):
+            return "KMSAccessDeniedException: \(message ?? "")"
+        case .kMSDisabledException(let message):
+            return "KMSDisabledException: \(message ?? "")"
+        case .kMSInvalidStateException(let message):
+            return "KMSInvalidStateException: \(message ?? "")"
+        case .kMSNotFoundException(let message):
+            return "KMSNotFoundException: \(message ?? "")"
+        case .kMSOptInRequired(let message):
+            return "KMSOptInRequired: \(message ?? "")"
+        case .kMSThrottlingException(let message):
+            return "KMSThrottlingException: \(message ?? "")"
+        case .notFoundException(let message):
+            return "NotFoundException: \(message ?? "")"
+        case .platformApplicationDisabledException(let message):
+            return "PlatformApplicationDisabledException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .staleTagException(let message):
+            return "StaleTagException: \(message ?? "")"
+        case .subscriptionLimitExceededException(let message):
+            return "SubscriptionLimitExceededException: \(message ?? "")"
+        case .tagLimitExceededException(let message):
+            return "TagLimitExceededException: \(message ?? "")"
+        case .tagPolicyException(let message):
+            return "TagPolicyException: \(message ?? "")"
+        case .throttledException(let message):
+            return "ThrottledException: \(message ?? "")"
+        case .topicLimitExceededException(let message):
+            return "TopicLimitExceededException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/SQS/SQS_Error.swift
+++ b/Sources/AWSSDKSwift/Services/SQS/SQS_Error.swift
@@ -66,3 +66,42 @@ extension SQSErrorType {
         }
     }
 }
+
+extension SQSErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .batchEntryIdsNotDistinct(let message):
+            return "BatchEntryIdsNotDistinct: \(message ?? "")"
+        case .batchRequestTooLong(let message):
+            return "BatchRequestTooLong: \(message ?? "")"
+        case .emptyBatchRequest(let message):
+            return "EmptyBatchRequest: \(message ?? "")"
+        case .invalidAttributeName(let message):
+            return "InvalidAttributeName: \(message ?? "")"
+        case .invalidBatchEntryId(let message):
+            return "InvalidBatchEntryId: \(message ?? "")"
+        case .invalidIdFormat(let message):
+            return "InvalidIdFormat: \(message ?? "")"
+        case .invalidMessageContents(let message):
+            return "InvalidMessageContents: \(message ?? "")"
+        case .messageNotInflight(let message):
+            return "MessageNotInflight: \(message ?? "")"
+        case .overLimit(let message):
+            return "OverLimit: \(message ?? "")"
+        case .purgeQueueInProgress(let message):
+            return "PurgeQueueInProgress: \(message ?? "")"
+        case .queueDeletedRecently(let message):
+            return "QueueDeletedRecently: \(message ?? "")"
+        case .queueDoesNotExist(let message):
+            return "QueueDoesNotExist: \(message ?? "")"
+        case .queueNameExists(let message):
+            return "QueueNameExists: \(message ?? "")"
+        case .receiptHandleIsInvalid(let message):
+            return "ReceiptHandleIsInvalid: \(message ?? "")"
+        case .tooManyEntriesInBatchRequest(let message):
+            return "TooManyEntriesInBatchRequest: \(message ?? "")"
+        case .unsupportedOperation(let message):
+            return "UnsupportedOperation: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/SSM/SSM_Error.swift
+++ b/Sources/AWSSDKSwift/Services/SSM/SSM_Error.swift
@@ -348,3 +348,230 @@ extension SSMErrorType {
         }
     }
 }
+
+extension SSMErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .alreadyExistsException(let message):
+            return "AlreadyExistsException: \(message ?? "")"
+        case .associatedInstances(let message):
+            return "AssociatedInstances: \(message ?? "")"
+        case .associationAlreadyExists(let message):
+            return "AssociationAlreadyExists: \(message ?? "")"
+        case .associationDoesNotExist(let message):
+            return "AssociationDoesNotExist: \(message ?? "")"
+        case .associationExecutionDoesNotExist(let message):
+            return "AssociationExecutionDoesNotExist: \(message ?? "")"
+        case .associationLimitExceeded(let message):
+            return "AssociationLimitExceeded: \(message ?? "")"
+        case .associationVersionLimitExceeded(let message):
+            return "AssociationVersionLimitExceeded: \(message ?? "")"
+        case .automationDefinitionNotFoundException(let message):
+            return "AutomationDefinitionNotFoundException: \(message ?? "")"
+        case .automationDefinitionVersionNotFoundException(let message):
+            return "AutomationDefinitionVersionNotFoundException: \(message ?? "")"
+        case .automationExecutionLimitExceededException(let message):
+            return "AutomationExecutionLimitExceededException: \(message ?? "")"
+        case .automationExecutionNotFoundException(let message):
+            return "AutomationExecutionNotFoundException: \(message ?? "")"
+        case .automationStepNotFoundException(let message):
+            return "AutomationStepNotFoundException: \(message ?? "")"
+        case .complianceTypeCountLimitExceededException(let message):
+            return "ComplianceTypeCountLimitExceededException: \(message ?? "")"
+        case .customSchemaCountLimitExceededException(let message):
+            return "CustomSchemaCountLimitExceededException: \(message ?? "")"
+        case .documentAlreadyExists(let message):
+            return "DocumentAlreadyExists: \(message ?? "")"
+        case .documentLimitExceeded(let message):
+            return "DocumentLimitExceeded: \(message ?? "")"
+        case .documentPermissionLimit(let message):
+            return "DocumentPermissionLimit: \(message ?? "")"
+        case .documentVersionLimitExceeded(let message):
+            return "DocumentVersionLimitExceeded: \(message ?? "")"
+        case .doesNotExistException(let message):
+            return "DoesNotExistException: \(message ?? "")"
+        case .duplicateDocumentContent(let message):
+            return "DuplicateDocumentContent: \(message ?? "")"
+        case .duplicateDocumentVersionName(let message):
+            return "DuplicateDocumentVersionName: \(message ?? "")"
+        case .duplicateInstanceId(let message):
+            return "DuplicateInstanceId: \(message ?? "")"
+        case .featureNotAvailableException(let message):
+            return "FeatureNotAvailableException: \(message ?? "")"
+        case .hierarchyLevelLimitExceededException(let message):
+            return "HierarchyLevelLimitExceededException: \(message ?? "")"
+        case .hierarchyTypeMismatchException(let message):
+            return "HierarchyTypeMismatchException: \(message ?? "")"
+        case .idempotentParameterMismatch(let message):
+            return "IdempotentParameterMismatch: \(message ?? "")"
+        case .incompatiblePolicyException(let message):
+            return "IncompatiblePolicyException: \(message ?? "")"
+        case .internalServerError(let message):
+            return "InternalServerError: \(message ?? "")"
+        case .invalidActivation(let message):
+            return "InvalidActivation: \(message ?? "")"
+        case .invalidActivationId(let message):
+            return "InvalidActivationId: \(message ?? "")"
+        case .invalidAggregatorException(let message):
+            return "InvalidAggregatorException: \(message ?? "")"
+        case .invalidAllowedPatternException(let message):
+            return "InvalidAllowedPatternException: \(message ?? "")"
+        case .invalidAssociation(let message):
+            return "InvalidAssociation: \(message ?? "")"
+        case .invalidAssociationVersion(let message):
+            return "InvalidAssociationVersion: \(message ?? "")"
+        case .invalidAutomationExecutionParametersException(let message):
+            return "InvalidAutomationExecutionParametersException: \(message ?? "")"
+        case .invalidAutomationSignalException(let message):
+            return "InvalidAutomationSignalException: \(message ?? "")"
+        case .invalidAutomationStatusUpdateException(let message):
+            return "InvalidAutomationStatusUpdateException: \(message ?? "")"
+        case .invalidCommandId(let message):
+            return "InvalidCommandId: \(message ?? "")"
+        case .invalidDeleteInventoryParametersException(let message):
+            return "InvalidDeleteInventoryParametersException: \(message ?? "")"
+        case .invalidDeletionIdException(let message):
+            return "InvalidDeletionIdException: \(message ?? "")"
+        case .invalidDocument(let message):
+            return "InvalidDocument: \(message ?? "")"
+        case .invalidDocumentContent(let message):
+            return "InvalidDocumentContent: \(message ?? "")"
+        case .invalidDocumentOperation(let message):
+            return "InvalidDocumentOperation: \(message ?? "")"
+        case .invalidDocumentSchemaVersion(let message):
+            return "InvalidDocumentSchemaVersion: \(message ?? "")"
+        case .invalidDocumentVersion(let message):
+            return "InvalidDocumentVersion: \(message ?? "")"
+        case .invalidFilter(let message):
+            return "InvalidFilter: \(message ?? "")"
+        case .invalidFilterKey(let message):
+            return "InvalidFilterKey: \(message ?? "")"
+        case .invalidFilterOption(let message):
+            return "InvalidFilterOption: \(message ?? "")"
+        case .invalidFilterValue(let message):
+            return "InvalidFilterValue: \(message ?? "")"
+        case .invalidInstanceId(let message):
+            return "InvalidInstanceId: \(message ?? "")"
+        case .invalidInstanceInformationFilterValue(let message):
+            return "InvalidInstanceInformationFilterValue: \(message ?? "")"
+        case .invalidInventoryGroupException(let message):
+            return "InvalidInventoryGroupException: \(message ?? "")"
+        case .invalidInventoryItemContextException(let message):
+            return "InvalidInventoryItemContextException: \(message ?? "")"
+        case .invalidInventoryRequestException(let message):
+            return "InvalidInventoryRequestException: \(message ?? "")"
+        case .invalidItemContentException(let message):
+            return "InvalidItemContentException: \(message ?? "")"
+        case .invalidKeyId(let message):
+            return "InvalidKeyId: \(message ?? "")"
+        case .invalidNextToken(let message):
+            return "InvalidNextToken: \(message ?? "")"
+        case .invalidNotificationConfig(let message):
+            return "InvalidNotificationConfig: \(message ?? "")"
+        case .invalidOptionException(let message):
+            return "InvalidOptionException: \(message ?? "")"
+        case .invalidOutputFolder(let message):
+            return "InvalidOutputFolder: \(message ?? "")"
+        case .invalidOutputLocation(let message):
+            return "InvalidOutputLocation: \(message ?? "")"
+        case .invalidParameters(let message):
+            return "InvalidParameters: \(message ?? "")"
+        case .invalidPermissionType(let message):
+            return "InvalidPermissionType: \(message ?? "")"
+        case .invalidPluginName(let message):
+            return "InvalidPluginName: \(message ?? "")"
+        case .invalidPolicyAttributeException(let message):
+            return "InvalidPolicyAttributeException: \(message ?? "")"
+        case .invalidPolicyTypeException(let message):
+            return "InvalidPolicyTypeException: \(message ?? "")"
+        case .invalidResourceId(let message):
+            return "InvalidResourceId: \(message ?? "")"
+        case .invalidResourceType(let message):
+            return "InvalidResourceType: \(message ?? "")"
+        case .invalidResultAttributeException(let message):
+            return "InvalidResultAttributeException: \(message ?? "")"
+        case .invalidRole(let message):
+            return "InvalidRole: \(message ?? "")"
+        case .invalidSchedule(let message):
+            return "InvalidSchedule: \(message ?? "")"
+        case .invalidTarget(let message):
+            return "InvalidTarget: \(message ?? "")"
+        case .invalidTypeNameException(let message):
+            return "InvalidTypeNameException: \(message ?? "")"
+        case .invalidUpdate(let message):
+            return "InvalidUpdate: \(message ?? "")"
+        case .invocationDoesNotExist(let message):
+            return "InvocationDoesNotExist: \(message ?? "")"
+        case .itemContentMismatchException(let message):
+            return "ItemContentMismatchException: \(message ?? "")"
+        case .itemSizeLimitExceededException(let message):
+            return "ItemSizeLimitExceededException: \(message ?? "")"
+        case .maxDocumentSizeExceeded(let message):
+            return "MaxDocumentSizeExceeded: \(message ?? "")"
+        case .opsItemAlreadyExistsException(let message):
+            return "OpsItemAlreadyExistsException: \(message ?? "")"
+        case .opsItemInvalidParameterException(let message):
+            return "OpsItemInvalidParameterException: \(message ?? "")"
+        case .opsItemLimitExceededException(let message):
+            return "OpsItemLimitExceededException: \(message ?? "")"
+        case .opsItemNotFoundException(let message):
+            return "OpsItemNotFoundException: \(message ?? "")"
+        case .parameterAlreadyExists(let message):
+            return "ParameterAlreadyExists: \(message ?? "")"
+        case .parameterLimitExceeded(let message):
+            return "ParameterLimitExceeded: \(message ?? "")"
+        case .parameterMaxVersionLimitExceeded(let message):
+            return "ParameterMaxVersionLimitExceeded: \(message ?? "")"
+        case .parameterNotFound(let message):
+            return "ParameterNotFound: \(message ?? "")"
+        case .parameterPatternMismatchException(let message):
+            return "ParameterPatternMismatchException: \(message ?? "")"
+        case .parameterVersionLabelLimitExceeded(let message):
+            return "ParameterVersionLabelLimitExceeded: \(message ?? "")"
+        case .parameterVersionNotFound(let message):
+            return "ParameterVersionNotFound: \(message ?? "")"
+        case .policiesLimitExceededException(let message):
+            return "PoliciesLimitExceededException: \(message ?? "")"
+        case .resourceDataSyncAlreadyExistsException(let message):
+            return "ResourceDataSyncAlreadyExistsException: \(message ?? "")"
+        case .resourceDataSyncCountExceededException(let message):
+            return "ResourceDataSyncCountExceededException: \(message ?? "")"
+        case .resourceDataSyncInvalidConfigurationException(let message):
+            return "ResourceDataSyncInvalidConfigurationException: \(message ?? "")"
+        case .resourceDataSyncNotFoundException(let message):
+            return "ResourceDataSyncNotFoundException: \(message ?? "")"
+        case .resourceInUseException(let message):
+            return "ResourceInUseException: \(message ?? "")"
+        case .resourceLimitExceededException(let message):
+            return "ResourceLimitExceededException: \(message ?? "")"
+        case .serviceSettingNotFound(let message):
+            return "ServiceSettingNotFound: \(message ?? "")"
+        case .statusUnchanged(let message):
+            return "StatusUnchanged: \(message ?? "")"
+        case .subTypeCountLimitExceededException(let message):
+            return "SubTypeCountLimitExceededException: \(message ?? "")"
+        case .targetInUseException(let message):
+            return "TargetInUseException: \(message ?? "")"
+        case .targetNotConnected(let message):
+            return "TargetNotConnected: \(message ?? "")"
+        case .tooManyTagsError(let message):
+            return "TooManyTagsError: \(message ?? "")"
+        case .tooManyUpdates(let message):
+            return "TooManyUpdates: \(message ?? "")"
+        case .totalSizeLimitExceededException(let message):
+            return "TotalSizeLimitExceededException: \(message ?? "")"
+        case .unsupportedFeatureRequiredException(let message):
+            return "UnsupportedFeatureRequiredException: \(message ?? "")"
+        case .unsupportedInventoryItemContextException(let message):
+            return "UnsupportedInventoryItemContextException: \(message ?? "")"
+        case .unsupportedInventorySchemaVersionException(let message):
+            return "UnsupportedInventorySchemaVersionException: \(message ?? "")"
+        case .unsupportedOperatingSystem(let message):
+            return "UnsupportedOperatingSystem: \(message ?? "")"
+        case .unsupportedParameterType(let message):
+            return "UnsupportedParameterType: \(message ?? "")"
+        case .unsupportedPlatformType(let message):
+            return "UnsupportedPlatformType: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/STS/STS_Error.swift
+++ b/Sources/AWSSDKSwift/Services/STS/STS_Error.swift
@@ -42,3 +42,26 @@ extension STSErrorType {
         }
     }
 }
+
+extension STSErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .expiredTokenException(let message):
+            return "ExpiredTokenException: \(message ?? "")"
+        case .iDPCommunicationErrorException(let message):
+            return "IDPCommunicationErrorException: \(message ?? "")"
+        case .iDPRejectedClaimException(let message):
+            return "IDPRejectedClaimException: \(message ?? "")"
+        case .invalidAuthorizationMessageException(let message):
+            return "InvalidAuthorizationMessageException: \(message ?? "")"
+        case .invalidIdentityTokenException(let message):
+            return "InvalidIdentityTokenException: \(message ?? "")"
+        case .malformedPolicyDocumentException(let message):
+            return "MalformedPolicyDocumentException: \(message ?? "")"
+        case .packedPolicyTooLargeException(let message):
+            return "PackedPolicyTooLargeException: \(message ?? "")"
+        case .regionDisabledException(let message):
+            return "RegionDisabledException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/SWF/SWF_Error.swift
+++ b/Sources/AWSSDKSwift/Services/SWF/SWF_Error.swift
@@ -48,3 +48,30 @@ extension SWFErrorType {
         }
     }
 }
+
+extension SWFErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .defaultUndefinedFault(let message):
+            return "DefaultUndefinedFault: \(message ?? "")"
+        case .domainAlreadyExistsFault(let message):
+            return "DomainAlreadyExistsFault: \(message ?? "")"
+        case .domainDeprecatedFault(let message):
+            return "DomainDeprecatedFault: \(message ?? "")"
+        case .limitExceededFault(let message):
+            return "LimitExceededFault: \(message ?? "")"
+        case .operationNotPermittedFault(let message):
+            return "OperationNotPermittedFault: \(message ?? "")"
+        case .tooManyTagsFault(let message):
+            return "TooManyTagsFault: \(message ?? "")"
+        case .typeAlreadyExistsFault(let message):
+            return "TypeAlreadyExistsFault: \(message ?? "")"
+        case .typeDeprecatedFault(let message):
+            return "TypeDeprecatedFault: \(message ?? "")"
+        case .unknownResourceFault(let message):
+            return "UnknownResourceFault: \(message ?? "")"
+        case .workflowExecutionAlreadyStartedFault(let message):
+            return "WorkflowExecutionAlreadyStartedFault: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/SageMaker/SageMaker_Error.swift
+++ b/Sources/AWSSDKSwift/Services/SageMaker/SageMaker_Error.swift
@@ -27,3 +27,16 @@ extension SageMakerErrorType {
         }
     }
 }
+
+extension SageMakerErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .resourceInUse(let message):
+            return "ResourceInUse: \(message ?? "")"
+        case .resourceLimitExceeded(let message):
+            return "ResourceLimitExceeded: \(message ?? "")"
+        case .resourceNotFound(let message):
+            return "ResourceNotFound: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/SageMakerRuntime/SageMakerRuntime_Error.swift
+++ b/Sources/AWSSDKSwift/Services/SageMakerRuntime/SageMakerRuntime_Error.swift
@@ -30,3 +30,18 @@ extension SageMakerRuntimeErrorType {
         }
     }
 }
+
+extension SageMakerRuntimeErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .internalFailure(let message):
+            return "InternalFailure: \(message ?? "")"
+        case .modelError(let message):
+            return "ModelError: \(message ?? "")"
+        case .serviceUnavailable(let message):
+            return "ServiceUnavailable: \(message ?? "")"
+        case .validationError(let message):
+            return "ValidationError: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/SecretsManager/SecretsManager_Error.swift
+++ b/Sources/AWSSDKSwift/Services/SecretsManager/SecretsManager_Error.swift
@@ -51,3 +51,32 @@ extension SecretsManagerErrorType {
         }
     }
 }
+
+extension SecretsManagerErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .decryptionFailure(let message):
+            return "DecryptionFailure: \(message ?? "")"
+        case .encryptionFailure(let message):
+            return "EncryptionFailure: \(message ?? "")"
+        case .internalServiceError(let message):
+            return "InternalServiceError: \(message ?? "")"
+        case .invalidNextTokenException(let message):
+            return "InvalidNextTokenException: \(message ?? "")"
+        case .invalidParameterException(let message):
+            return "InvalidParameterException: \(message ?? "")"
+        case .invalidRequestException(let message):
+            return "InvalidRequestException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .malformedPolicyDocumentException(let message):
+            return "MalformedPolicyDocumentException: \(message ?? "")"
+        case .preconditionNotMetException(let message):
+            return "PreconditionNotMetException: \(message ?? "")"
+        case .resourceExistsException(let message):
+            return "ResourceExistsException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/SecurityHub/SecurityHub_Error.swift
+++ b/Sources/AWSSDKSwift/Services/SecurityHub/SecurityHub_Error.swift
@@ -39,3 +39,24 @@ extension SecurityHubErrorType {
         }
     }
 }
+
+extension SecurityHubErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .accessDeniedException(let message):
+            return "AccessDeniedException: \(message ?? "")"
+        case .internalException(let message):
+            return "InternalException: \(message ?? "")"
+        case .invalidAccessException(let message):
+            return "InvalidAccessException: \(message ?? "")"
+        case .invalidInputException(let message):
+            return "InvalidInputException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .resourceConflictException(let message):
+            return "ResourceConflictException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/ServerlessApplicationRepository/ServerlessApplicationRepository_Error.swift
+++ b/Sources/AWSSDKSwift/Services/ServerlessApplicationRepository/ServerlessApplicationRepository_Error.swift
@@ -36,3 +36,22 @@ extension ServerlessApplicationRepositoryErrorType {
         }
     }
 }
+
+extension ServerlessApplicationRepositoryErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .badRequestException(let message):
+            return "BadRequestException: \(message ?? "")"
+        case .conflictException(let message):
+            return "ConflictException: \(message ?? "")"
+        case .forbiddenException(let message):
+            return "ForbiddenException: \(message ?? "")"
+        case .internalServerErrorException(let message):
+            return "InternalServerErrorException: \(message ?? "")"
+        case .notFoundException(let message):
+            return "NotFoundException: \(message ?? "")"
+        case .tooManyRequestsException(let message):
+            return "TooManyRequestsException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/ServiceCatalog/ServiceCatalog_Error.swift
+++ b/Sources/AWSSDKSwift/Services/ServiceCatalog/ServiceCatalog_Error.swift
@@ -42,3 +42,26 @@ extension ServiceCatalogErrorType {
         }
     }
 }
+
+extension ServiceCatalogErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .duplicateResourceException(let message):
+            return "DuplicateResourceException: \(message ?? "")"
+        case .invalidParametersException(let message):
+            return "InvalidParametersException: \(message ?? "")"
+        case .invalidStateException(let message):
+            return "InvalidStateException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .operationNotSupportedException(let message):
+            return "OperationNotSupportedException: \(message ?? "")"
+        case .resourceInUseException(let message):
+            return "ResourceInUseException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .tagOptionNotMigratedException(let message):
+            return "TagOptionNotMigratedException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/ServiceDiscovery/ServiceDiscovery_Error.swift
+++ b/Sources/AWSSDKSwift/Services/ServiceDiscovery/ServiceDiscovery_Error.swift
@@ -51,3 +51,32 @@ extension ServiceDiscoveryErrorType {
         }
     }
 }
+
+extension ServiceDiscoveryErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .customHealthNotFound(let message):
+            return "CustomHealthNotFound: \(message ?? "")"
+        case .duplicateRequest(let message):
+            return "DuplicateRequest: \(message ?? "")"
+        case .instanceNotFound(let message):
+            return "InstanceNotFound: \(message ?? "")"
+        case .invalidInput(let message):
+            return "InvalidInput: \(message ?? "")"
+        case .namespaceAlreadyExists(let message):
+            return "NamespaceAlreadyExists: \(message ?? "")"
+        case .namespaceNotFound(let message):
+            return "NamespaceNotFound: \(message ?? "")"
+        case .operationNotFound(let message):
+            return "OperationNotFound: \(message ?? "")"
+        case .resourceInUse(let message):
+            return "ResourceInUse: \(message ?? "")"
+        case .resourceLimitExceeded(let message):
+            return "ResourceLimitExceeded: \(message ?? "")"
+        case .serviceAlreadyExists(let message):
+            return "ServiceAlreadyExists: \(message ?? "")"
+        case .serviceNotFound(let message):
+            return "ServiceNotFound: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/ServiceQuotas/ServiceQuotas_Error.swift
+++ b/Sources/AWSSDKSwift/Services/ServiceQuotas/ServiceQuotas_Error.swift
@@ -63,3 +63,40 @@ extension ServiceQuotasErrorType {
         }
     }
 }
+
+extension ServiceQuotasErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .aWSServiceAccessNotEnabledException(let message):
+            return "AWSServiceAccessNotEnabledException: \(message ?? "")"
+        case .accessDeniedException(let message):
+            return "AccessDeniedException: \(message ?? "")"
+        case .dependencyAccessDeniedException(let message):
+            return "DependencyAccessDeniedException: \(message ?? "")"
+        case .illegalArgumentException(let message):
+            return "IllegalArgumentException: \(message ?? "")"
+        case .invalidPaginationTokenException(let message):
+            return "InvalidPaginationTokenException: \(message ?? "")"
+        case .invalidResourceStateException(let message):
+            return "InvalidResourceStateException: \(message ?? "")"
+        case .noAvailableOrganizationException(let message):
+            return "NoAvailableOrganizationException: \(message ?? "")"
+        case .noSuchResourceException(let message):
+            return "NoSuchResourceException: \(message ?? "")"
+        case .organizationNotInAllFeaturesModeException(let message):
+            return "OrganizationNotInAllFeaturesModeException: \(message ?? "")"
+        case .quotaExceededException(let message):
+            return "QuotaExceededException: \(message ?? "")"
+        case .resourceAlreadyExistsException(let message):
+            return "ResourceAlreadyExistsException: \(message ?? "")"
+        case .serviceException(let message):
+            return "ServiceException: \(message ?? "")"
+        case .serviceQuotaTemplateNotInUseException(let message):
+            return "ServiceQuotaTemplateNotInUseException: \(message ?? "")"
+        case .templatesNotAvailableInRegionException(let message):
+            return "TemplatesNotAvailableInRegionException: \(message ?? "")"
+        case .tooManyRequestsException(let message):
+            return "TooManyRequestsException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Shield/Shield_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Shield/Shield_Error.swift
@@ -57,3 +57,36 @@ extension ShieldErrorType {
         }
     }
 }
+
+extension ShieldErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .accessDeniedException(let message):
+            return "AccessDeniedException: \(message ?? "")"
+        case .accessDeniedForDependencyException(let message):
+            return "AccessDeniedForDependencyException: \(message ?? "")"
+        case .internalErrorException(let message):
+            return "InternalErrorException: \(message ?? "")"
+        case .invalidOperationException(let message):
+            return "InvalidOperationException: \(message ?? "")"
+        case .invalidPaginationTokenException(let message):
+            return "InvalidPaginationTokenException: \(message ?? "")"
+        case .invalidParameterException(let message):
+            return "InvalidParameterException: \(message ?? "")"
+        case .invalidResourceException(let message):
+            return "InvalidResourceException: \(message ?? "")"
+        case .limitsExceededException(let message):
+            return "LimitsExceededException: \(message ?? "")"
+        case .lockedSubscriptionException(let message):
+            return "LockedSubscriptionException: \(message ?? "")"
+        case .noAssociatedRoleException(let message):
+            return "NoAssociatedRoleException: \(message ?? "")"
+        case .optimisticLockException(let message):
+            return "OptimisticLockException: \(message ?? "")"
+        case .resourceAlreadyExistsException(let message):
+            return "ResourceAlreadyExistsException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Signer/Signer_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Signer/Signer_Error.swift
@@ -33,3 +33,20 @@ extension SignerErrorType {
         }
     }
 }
+
+extension SignerErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .accessDeniedException(let message):
+            return "AccessDeniedException: \(message ?? "")"
+        case .internalServiceErrorException(let message):
+            return "InternalServiceErrorException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .throttlingException(let message):
+            return "ThrottlingException: \(message ?? "")"
+        case .validationException(let message):
+            return "ValidationException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/SimpleDB/SimpleDB_Error.swift
+++ b/Sources/AWSSDKSwift/Services/SimpleDB/SimpleDB_Error.swift
@@ -69,3 +69,44 @@ extension SimpleDBErrorType {
         }
     }
 }
+
+extension SimpleDBErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .attributeDoesNotExist(let message):
+            return "AttributeDoesNotExist: \(message ?? "")"
+        case .duplicateItemName(let message):
+            return "DuplicateItemName: \(message ?? "")"
+        case .invalidNextToken(let message):
+            return "InvalidNextToken: \(message ?? "")"
+        case .invalidNumberPredicates(let message):
+            return "InvalidNumberPredicates: \(message ?? "")"
+        case .invalidNumberValueTests(let message):
+            return "InvalidNumberValueTests: \(message ?? "")"
+        case .invalidParameterValue(let message):
+            return "InvalidParameterValue: \(message ?? "")"
+        case .invalidQueryExpression(let message):
+            return "InvalidQueryExpression: \(message ?? "")"
+        case .missingParameter(let message):
+            return "MissingParameter: \(message ?? "")"
+        case .noSuchDomain(let message):
+            return "NoSuchDomain: \(message ?? "")"
+        case .numberDomainAttributesExceeded(let message):
+            return "NumberDomainAttributesExceeded: \(message ?? "")"
+        case .numberDomainBytesExceeded(let message):
+            return "NumberDomainBytesExceeded: \(message ?? "")"
+        case .numberDomainsExceeded(let message):
+            return "NumberDomainsExceeded: \(message ?? "")"
+        case .numberItemAttributesExceeded(let message):
+            return "NumberItemAttributesExceeded: \(message ?? "")"
+        case .numberSubmittedAttributesExceeded(let message):
+            return "NumberSubmittedAttributesExceeded: \(message ?? "")"
+        case .numberSubmittedItemsExceeded(let message):
+            return "NumberSubmittedItemsExceeded: \(message ?? "")"
+        case .requestTimeout(let message):
+            return "RequestTimeout: \(message ?? "")"
+        case .tooManyRequestedAttributes(let message):
+            return "TooManyRequestedAttributes: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Snowball/Snowball_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Snowball/Snowball_Error.swift
@@ -45,3 +45,28 @@ extension SnowballErrorType {
         }
     }
 }
+
+extension SnowballErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .clusterLimitExceededException(let message):
+            return "ClusterLimitExceededException: \(message ?? "")"
+        case .ec2RequestFailedException(let message):
+            return "Ec2RequestFailedException: \(message ?? "")"
+        case .invalidAddressException(let message):
+            return "InvalidAddressException: \(message ?? "")"
+        case .invalidInputCombinationException(let message):
+            return "InvalidInputCombinationException: \(message ?? "")"
+        case .invalidJobStateException(let message):
+            return "InvalidJobStateException: \(message ?? "")"
+        case .invalidNextTokenException(let message):
+            return "InvalidNextTokenException: \(message ?? "")"
+        case .invalidResourceException(let message):
+            return "InvalidResourceException: \(message ?? "")"
+        case .kMSRequestFailedException(let message):
+            return "KMSRequestFailedException: \(message ?? "")"
+        case .unsupportedAddressException(let message):
+            return "UnsupportedAddressException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/StorageGateway/StorageGateway_Error.swift
+++ b/Sources/AWSSDKSwift/Services/StorageGateway/StorageGateway_Error.swift
@@ -27,3 +27,16 @@ extension StorageGatewayErrorType {
         }
     }
 }
+
+extension StorageGatewayErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .internalServerError(let message):
+            return "InternalServerError: \(message ?? "")"
+        case .invalidGatewayRequestException(let message):
+            return "InvalidGatewayRequestException: \(message ?? "")"
+        case .serviceUnavailableError(let message):
+            return "ServiceUnavailableError: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Support/Support_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Support/Support_Error.swift
@@ -45,3 +45,28 @@ extension SupportErrorType {
         }
     }
 }
+
+extension SupportErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .attachmentIdNotFound(let message):
+            return "AttachmentIdNotFound: \(message ?? "")"
+        case .attachmentLimitExceeded(let message):
+            return "AttachmentLimitExceeded: \(message ?? "")"
+        case .attachmentSetExpired(let message):
+            return "AttachmentSetExpired: \(message ?? "")"
+        case .attachmentSetIdNotFound(let message):
+            return "AttachmentSetIdNotFound: \(message ?? "")"
+        case .attachmentSetSizeLimitExceeded(let message):
+            return "AttachmentSetSizeLimitExceeded: \(message ?? "")"
+        case .caseCreationLimitExceeded(let message):
+            return "CaseCreationLimitExceeded: \(message ?? "")"
+        case .caseIdNotFound(let message):
+            return "CaseIdNotFound: \(message ?? "")"
+        case .describeAttachmentLimitExceeded(let message):
+            return "DescribeAttachmentLimitExceeded: \(message ?? "")"
+        case .internalServerError(let message):
+            return "InternalServerError: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Textract/Textract_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Textract/Textract_Error.swift
@@ -54,3 +54,34 @@ extension TextractErrorType {
         }
     }
 }
+
+extension TextractErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .accessDeniedException(let message):
+            return "AccessDeniedException: \(message ?? "")"
+        case .badDocumentException(let message):
+            return "BadDocumentException: \(message ?? "")"
+        case .documentTooLargeException(let message):
+            return "DocumentTooLargeException: \(message ?? "")"
+        case .idempotentParameterMismatchException(let message):
+            return "IdempotentParameterMismatchException: \(message ?? "")"
+        case .internalServerError(let message):
+            return "InternalServerError: \(message ?? "")"
+        case .invalidJobIdException(let message):
+            return "InvalidJobIdException: \(message ?? "")"
+        case .invalidParameterException(let message):
+            return "InvalidParameterException: \(message ?? "")"
+        case .invalidS3ObjectException(let message):
+            return "InvalidS3ObjectException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .provisionedThroughputExceededException(let message):
+            return "ProvisionedThroughputExceededException: \(message ?? "")"
+        case .throttlingException(let message):
+            return "ThrottlingException: \(message ?? "")"
+        case .unsupportedDocumentException(let message):
+            return "UnsupportedDocumentException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/TranscribeService/TranscribeService_Error.swift
+++ b/Sources/AWSSDKSwift/Services/TranscribeService/TranscribeService_Error.swift
@@ -33,3 +33,20 @@ extension TranscribeServiceErrorType {
         }
     }
 }
+
+extension TranscribeServiceErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .badRequestException(let message):
+            return "BadRequestException: \(message ?? "")"
+        case .conflictException(let message):
+            return "ConflictException: \(message ?? "")"
+        case .internalFailureException(let message):
+            return "InternalFailureException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .notFoundException(let message):
+            return "NotFoundException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Transfer/Transfer_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Transfer/Transfer_Error.swift
@@ -36,3 +36,22 @@ extension TransferErrorType {
         }
     }
 }
+
+extension TransferErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .internalServiceError(let message):
+            return "InternalServiceError: \(message ?? "")"
+        case .invalidNextTokenException(let message):
+            return "InvalidNextTokenException: \(message ?? "")"
+        case .invalidRequestException(let message):
+            return "InvalidRequestException: \(message ?? "")"
+        case .resourceExistsException(let message):
+            return "ResourceExistsException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .serviceUnavailableException(let message):
+            return "ServiceUnavailableException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/Translate/Translate_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Translate/Translate_Error.swift
@@ -48,3 +48,30 @@ extension TranslateErrorType {
         }
     }
 }
+
+extension TranslateErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .detectedLanguageLowConfidenceException(let message):
+            return "DetectedLanguageLowConfidenceException: \(message ?? "")"
+        case .internalServerException(let message):
+            return "InternalServerException: \(message ?? "")"
+        case .invalidParameterValueException(let message):
+            return "InvalidParameterValueException: \(message ?? "")"
+        case .invalidRequestException(let message):
+            return "InvalidRequestException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .serviceUnavailableException(let message):
+            return "ServiceUnavailableException: \(message ?? "")"
+        case .textSizeLimitExceededException(let message):
+            return "TextSizeLimitExceededException: \(message ?? "")"
+        case .tooManyRequestsException(let message):
+            return "TooManyRequestsException: \(message ?? "")"
+        case .unsupportedLanguagePairException(let message):
+            return "UnsupportedLanguagePairException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/WAF/WAF_Error.swift
+++ b/Sources/AWSSDKSwift/Services/WAF/WAF_Error.swift
@@ -72,3 +72,46 @@ extension WAFErrorType {
         }
     }
 }
+
+extension WAFErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .wAFBadRequestException(let message):
+            return "WAFBadRequestException: \(message ?? "")"
+        case .wAFDisallowedNameException(let message):
+            return "WAFDisallowedNameException: \(message ?? "")"
+        case .wAFInternalErrorException(let message):
+            return "WAFInternalErrorException: \(message ?? "")"
+        case .wAFInvalidAccountException(let message):
+            return "WAFInvalidAccountException: \(message ?? "")"
+        case .wAFInvalidOperationException(let message):
+            return "WAFInvalidOperationException: \(message ?? "")"
+        case .wAFInvalidParameterException(let message):
+            return "WAFInvalidParameterException: \(message ?? "")"
+        case .wAFInvalidPermissionPolicyException(let message):
+            return "WAFInvalidPermissionPolicyException: \(message ?? "")"
+        case .wAFInvalidRegexPatternException(let message):
+            return "WAFInvalidRegexPatternException: \(message ?? "")"
+        case .wAFLimitsExceededException(let message):
+            return "WAFLimitsExceededException: \(message ?? "")"
+        case .wAFNonEmptyEntityException(let message):
+            return "WAFNonEmptyEntityException: \(message ?? "")"
+        case .wAFNonexistentContainerException(let message):
+            return "WAFNonexistentContainerException: \(message ?? "")"
+        case .wAFNonexistentItemException(let message):
+            return "WAFNonexistentItemException: \(message ?? "")"
+        case .wAFReferencedItemException(let message):
+            return "WAFReferencedItemException: \(message ?? "")"
+        case .wAFServiceLinkedRoleErrorException(let message):
+            return "WAFServiceLinkedRoleErrorException: \(message ?? "")"
+        case .wAFStaleDataException(let message):
+            return "WAFStaleDataException: \(message ?? "")"
+        case .wAFSubscriptionNotFoundException(let message):
+            return "WAFSubscriptionNotFoundException: \(message ?? "")"
+        case .wAFTagOperationException(let message):
+            return "WAFTagOperationException: \(message ?? "")"
+        case .wAFTagOperationInternalErrorException(let message):
+            return "WAFTagOperationInternalErrorException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/WAFRegional/WAFRegional_Error.swift
+++ b/Sources/AWSSDKSwift/Services/WAFRegional/WAFRegional_Error.swift
@@ -75,3 +75,48 @@ extension WAFRegionalErrorType {
         }
     }
 }
+
+extension WAFRegionalErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .wAFBadRequestException(let message):
+            return "WAFBadRequestException: \(message ?? "")"
+        case .wAFDisallowedNameException(let message):
+            return "WAFDisallowedNameException: \(message ?? "")"
+        case .wAFInternalErrorException(let message):
+            return "WAFInternalErrorException: \(message ?? "")"
+        case .wAFInvalidAccountException(let message):
+            return "WAFInvalidAccountException: \(message ?? "")"
+        case .wAFInvalidOperationException(let message):
+            return "WAFInvalidOperationException: \(message ?? "")"
+        case .wAFInvalidParameterException(let message):
+            return "WAFInvalidParameterException: \(message ?? "")"
+        case .wAFInvalidPermissionPolicyException(let message):
+            return "WAFInvalidPermissionPolicyException: \(message ?? "")"
+        case .wAFInvalidRegexPatternException(let message):
+            return "WAFInvalidRegexPatternException: \(message ?? "")"
+        case .wAFLimitsExceededException(let message):
+            return "WAFLimitsExceededException: \(message ?? "")"
+        case .wAFNonEmptyEntityException(let message):
+            return "WAFNonEmptyEntityException: \(message ?? "")"
+        case .wAFNonexistentContainerException(let message):
+            return "WAFNonexistentContainerException: \(message ?? "")"
+        case .wAFNonexistentItemException(let message):
+            return "WAFNonexistentItemException: \(message ?? "")"
+        case .wAFReferencedItemException(let message):
+            return "WAFReferencedItemException: \(message ?? "")"
+        case .wAFServiceLinkedRoleErrorException(let message):
+            return "WAFServiceLinkedRoleErrorException: \(message ?? "")"
+        case .wAFStaleDataException(let message):
+            return "WAFStaleDataException: \(message ?? "")"
+        case .wAFSubscriptionNotFoundException(let message):
+            return "WAFSubscriptionNotFoundException: \(message ?? "")"
+        case .wAFTagOperationException(let message):
+            return "WAFTagOperationException: \(message ?? "")"
+        case .wAFTagOperationInternalErrorException(let message):
+            return "WAFTagOperationInternalErrorException: \(message ?? "")"
+        case .wAFUnavailableEntityException(let message):
+            return "WAFUnavailableEntityException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/WorkDocs/WorkDocs_Error.swift
+++ b/Sources/AWSSDKSwift/Services/WorkDocs/WorkDocs_Error.swift
@@ -93,3 +93,60 @@ extension WorkDocsErrorType {
         }
     }
 }
+
+extension WorkDocsErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .concurrentModificationException(let message):
+            return "ConcurrentModificationException: \(message ?? "")"
+        case .conflictingOperationException(let message):
+            return "ConflictingOperationException: \(message ?? "")"
+        case .customMetadataLimitExceededException(let message):
+            return "CustomMetadataLimitExceededException: \(message ?? "")"
+        case .deactivatingLastSystemUserException(let message):
+            return "DeactivatingLastSystemUserException: \(message ?? "")"
+        case .documentLockedForCommentsException(let message):
+            return "DocumentLockedForCommentsException: \(message ?? "")"
+        case .draftUploadOutOfSyncException(let message):
+            return "DraftUploadOutOfSyncException: \(message ?? "")"
+        case .entityAlreadyExistsException(let message):
+            return "EntityAlreadyExistsException: \(message ?? "")"
+        case .entityNotExistsException(let message):
+            return "EntityNotExistsException: \(message ?? "")"
+        case .failedDependencyException(let message):
+            return "FailedDependencyException: \(message ?? "")"
+        case .illegalUserStateException(let message):
+            return "IllegalUserStateException: \(message ?? "")"
+        case .invalidArgumentException(let message):
+            return "InvalidArgumentException: \(message ?? "")"
+        case .invalidCommentOperationException(let message):
+            return "InvalidCommentOperationException: \(message ?? "")"
+        case .invalidOperationException(let message):
+            return "InvalidOperationException: \(message ?? "")"
+        case .invalidPasswordException(let message):
+            return "InvalidPasswordException: \(message ?? "")"
+        case .limitExceededException(let message):
+            return "LimitExceededException: \(message ?? "")"
+        case .prohibitedStateException(let message):
+            return "ProhibitedStateException: \(message ?? "")"
+        case .requestedEntityTooLargeException(let message):
+            return "RequestedEntityTooLargeException: \(message ?? "")"
+        case .resourceAlreadyCheckedOutException(let message):
+            return "ResourceAlreadyCheckedOutException: \(message ?? "")"
+        case .serviceUnavailableException(let message):
+            return "ServiceUnavailableException: \(message ?? "")"
+        case .storageLimitExceededException(let message):
+            return "StorageLimitExceededException: \(message ?? "")"
+        case .storageLimitWillExceedException(let message):
+            return "StorageLimitWillExceedException: \(message ?? "")"
+        case .tooManyLabelsException(let message):
+            return "TooManyLabelsException: \(message ?? "")"
+        case .tooManySubscriptionsException(let message):
+            return "TooManySubscriptionsException: \(message ?? "")"
+        case .unauthorizedOperationException(let message):
+            return "UnauthorizedOperationException: \(message ?? "")"
+        case .unauthorizedResourceAccessException(let message):
+            return "UnauthorizedResourceAccessException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/WorkLink/WorkLink_Error.swift
+++ b/Sources/AWSSDKSwift/Services/WorkLink/WorkLink_Error.swift
@@ -36,3 +36,22 @@ extension WorkLinkErrorType {
         }
     }
 }
+
+extension WorkLinkErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .internalServerErrorException(let message):
+            return "InternalServerErrorException: \(message ?? "")"
+        case .invalidRequestException(let message):
+            return "InvalidRequestException: \(message ?? "")"
+        case .resourceAlreadyExistsException(let message):
+            return "ResourceAlreadyExistsException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .tooManyRequestsException(let message):
+            return "TooManyRequestsException: \(message ?? "")"
+        case .unauthorizedException(let message):
+            return "UnauthorizedException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/WorkMail/WorkMail_Error.swift
+++ b/Sources/AWSSDKSwift/Services/WorkMail/WorkMail_Error.swift
@@ -66,3 +66,42 @@ extension WorkMailErrorType {
         }
     }
 }
+
+extension WorkMailErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .directoryServiceAuthenticationFailedException(let message):
+            return "DirectoryServiceAuthenticationFailedException: \(message ?? "")"
+        case .directoryUnavailableException(let message):
+            return "DirectoryUnavailableException: \(message ?? "")"
+        case .emailAddressInUseException(let message):
+            return "EmailAddressInUseException: \(message ?? "")"
+        case .entityAlreadyRegisteredException(let message):
+            return "EntityAlreadyRegisteredException: \(message ?? "")"
+        case .entityNotFoundException(let message):
+            return "EntityNotFoundException: \(message ?? "")"
+        case .entityStateException(let message):
+            return "EntityStateException: \(message ?? "")"
+        case .invalidConfigurationException(let message):
+            return "InvalidConfigurationException: \(message ?? "")"
+        case .invalidParameterException(let message):
+            return "InvalidParameterException: \(message ?? "")"
+        case .invalidPasswordException(let message):
+            return "InvalidPasswordException: \(message ?? "")"
+        case .mailDomainNotFoundException(let message):
+            return "MailDomainNotFoundException: \(message ?? "")"
+        case .mailDomainStateException(let message):
+            return "MailDomainStateException: \(message ?? "")"
+        case .nameAvailabilityException(let message):
+            return "NameAvailabilityException: \(message ?? "")"
+        case .organizationNotFoundException(let message):
+            return "OrganizationNotFoundException: \(message ?? "")"
+        case .organizationStateException(let message):
+            return "OrganizationStateException: \(message ?? "")"
+        case .reservedNameException(let message):
+            return "ReservedNameException: \(message ?? "")"
+        case .unsupportedOperationException(let message):
+            return "UnsupportedOperationException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/WorkSpaces/WorkSpaces_Error.swift
+++ b/Sources/AWSSDKSwift/Services/WorkSpaces/WorkSpaces_Error.swift
@@ -54,3 +54,34 @@ extension WorkSpacesErrorType {
         }
     }
 }
+
+extension WorkSpacesErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .accessDeniedException(let message):
+            return "AccessDeniedException: \(message ?? "")"
+        case .invalidParameterValuesException(let message):
+            return "InvalidParameterValuesException: \(message ?? "")"
+        case .invalidResourceStateException(let message):
+            return "InvalidResourceStateException: \(message ?? "")"
+        case .operationInProgressException(let message):
+            return "OperationInProgressException: \(message ?? "")"
+        case .operationNotSupportedException(let message):
+            return "OperationNotSupportedException: \(message ?? "")"
+        case .resourceAlreadyExistsException(let message):
+            return "ResourceAlreadyExistsException: \(message ?? "")"
+        case .resourceAssociatedException(let message):
+            return "ResourceAssociatedException: \(message ?? "")"
+        case .resourceCreationFailedException(let message):
+            return "ResourceCreationFailedException: \(message ?? "")"
+        case .resourceLimitExceededException(let message):
+            return "ResourceLimitExceededException: \(message ?? "")"
+        case .resourceNotFoundException(let message):
+            return "ResourceNotFoundException: \(message ?? "")"
+        case .resourceUnavailableException(let message):
+            return "ResourceUnavailableException: \(message ?? "")"
+        case .unsupportedWorkspaceConfigurationException(let message):
+            return "UnsupportedWorkspaceConfigurationException: \(message ?? "")"
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Services/XRay/XRay_Error.swift
+++ b/Sources/AWSSDKSwift/Services/XRay/XRay_Error.swift
@@ -27,3 +27,16 @@ extension XRayErrorType {
         }
     }
 }
+
+extension XRayErrorType : CustomStringConvertible {
+    public var description : String {
+        switch self {
+        case .invalidRequestException(let message):
+            return "InvalidRequestException: \(message ?? "")"
+        case .ruleLimitExceededException(let message):
+            return "RuleLimitExceededException: \(message ?? "")"
+        case .throttledException(let message):
+            return "ThrottledException: \(message ?? "")"
+        }
+    }
+}


### PR DESCRIPTION
Extend AWS service error classes to conform to CustomStringConvertible
```
do {
    // aws code
} catch {
   print(error.localizedDescription)
} 
```
Previously code above would print out name of error class, plus error index on Mac and on Linux would print "The operation could not be completed". With this change it now prints the errorCodeString and the associated Message. 