### PR TITLE
S3 bucket name validation

### DIFF
--- a/Sources/AWSSDKSwift/Services/S3/S3_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/S3/S3_Shapes.swift
@@ -62,6 +62,7 @@ extension S3 {
         }
 
         public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
             try validate(self.key, name:"key", parent: name, min: 1)
         }
 
@@ -179,6 +180,7 @@ extension S3 {
 
         public func validate(name: String) throws {
             try self.filter?.validate(name: "\(name).filter")
+            try self.storageClassAnalysis.validate(name: "\(name).storageClassAnalysis")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -198,6 +200,10 @@ extension S3 {
 
         public init(s3BucketDestination: AnalyticsS3BucketDestination) {
             self.s3BucketDestination = s3BucketDestination
+        }
+
+        public func validate(name: String) throws {
+            try self.s3BucketDestination.validate(name: "\(name).s3BucketDestination")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -259,6 +265,10 @@ extension S3 {
             self.bucketAccountId = bucketAccountId
             self.format = format
             self.prefix = prefix
+        }
+
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -649,6 +659,7 @@ extension S3 {
         }
 
         public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
             try validate(self.key, name:"key", parent: name, min: 1)
         }
 
@@ -943,6 +954,7 @@ extension S3 {
         }
 
         public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
             try validate(self.copySource, name:"copySource", parent: name, pattern: "\\/.+\\/.+")
             try validate(self.key, name:"key", parent: name, min: 1)
         }
@@ -1106,6 +1118,10 @@ extension S3 {
             self.grantWrite = grantWrite
             self.grantWriteACP = grantWriteACP
             self.objectLockEnabledForBucket = objectLockEnabledForBucket
+        }
+
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -1301,6 +1317,7 @@ extension S3 {
         }
 
         public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
             try validate(self.key, name:"key", parent: name, min: 1)
         }
 
@@ -1405,6 +1422,10 @@ extension S3 {
             self.id = id
         }
 
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
+        }
+
         private enum CodingKeys: String, CodingKey {
             case bucket = "Bucket"
             case id = "id"
@@ -1422,6 +1443,10 @@ extension S3 {
             self.bucket = bucket
         }
 
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
+        }
+
         private enum CodingKeys: String, CodingKey {
             case bucket = "Bucket"
         }
@@ -1437,6 +1462,10 @@ extension S3 {
 
         public init(bucket: String) {
             self.bucket = bucket
+        }
+
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -1460,6 +1489,10 @@ extension S3 {
             self.id = id
         }
 
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
+        }
+
         private enum CodingKeys: String, CodingKey {
             case bucket = "Bucket"
             case id = "id"
@@ -1475,6 +1508,10 @@ extension S3 {
 
         public init(bucket: String) {
             self.bucket = bucket
+        }
+
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -1498,6 +1535,10 @@ extension S3 {
             self.id = id
         }
 
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
+        }
+
         private enum CodingKeys: String, CodingKey {
             case bucket = "Bucket"
             case id = "id"
@@ -1513,6 +1554,10 @@ extension S3 {
 
         public init(bucket: String) {
             self.bucket = bucket
+        }
+
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -1532,6 +1577,10 @@ extension S3 {
             self.bucket = bucket
         }
 
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
+        }
+
         private enum CodingKeys: String, CodingKey {
             case bucket = "Bucket"
         }
@@ -1546,6 +1595,10 @@ extension S3 {
 
         public init(bucket: String) {
             self.bucket = bucket
+        }
+
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -1564,6 +1617,10 @@ extension S3 {
             self.bucket = bucket
         }
 
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
+        }
+
         private enum CodingKeys: String, CodingKey {
             case bucket = "Bucket"
         }
@@ -1578,6 +1635,10 @@ extension S3 {
 
         public init(bucket: String) {
             self.bucket = bucket
+        }
+
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -1700,6 +1761,7 @@ extension S3 {
         }
 
         public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
             try validate(self.key, name:"key", parent: name, min: 1)
         }
 
@@ -1749,6 +1811,7 @@ extension S3 {
         }
 
         public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
             try validate(self.key, name:"key", parent: name, min: 1)
         }
 
@@ -1812,6 +1875,7 @@ extension S3 {
         }
 
         public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
             try self.delete.validate(name: "\(name).delete")
         }
 
@@ -1834,6 +1898,10 @@ extension S3 {
 
         public init(bucket: String) {
             self.bucket = bucket
+        }
+
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -1895,6 +1963,10 @@ extension S3 {
             self.bucket = bucket
             self.encryptionConfiguration = encryptionConfiguration
             self.storageClass = storageClass
+        }
+
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -2094,6 +2166,10 @@ extension S3 {
             self.bucket = bucket
         }
 
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
+        }
+
         private enum CodingKeys: String, CodingKey {
             case bucket = "Bucket"
         }
@@ -2129,6 +2205,10 @@ extension S3 {
 
         public init(bucket: String) {
             self.bucket = bucket
+        }
+
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -2171,6 +2251,10 @@ extension S3 {
             self.id = id
         }
 
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
+        }
+
         private enum CodingKeys: String, CodingKey {
             case bucket = "Bucket"
             case id = "id"
@@ -2202,6 +2286,10 @@ extension S3 {
 
         public init(bucket: String) {
             self.bucket = bucket
+        }
+
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -2237,6 +2325,10 @@ extension S3 {
 
         public init(bucket: String) {
             self.bucket = bucket
+        }
+
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -2279,6 +2371,10 @@ extension S3 {
             self.id = id
         }
 
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
+        }
+
         private enum CodingKeys: String, CodingKey {
             case bucket = "Bucket"
             case id = "id"
@@ -2310,6 +2406,10 @@ extension S3 {
 
         public init(bucket: String) {
             self.bucket = bucket
+        }
+
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -2344,6 +2444,10 @@ extension S3 {
             self.bucket = bucket
         }
 
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
+        }
+
         private enum CodingKeys: String, CodingKey {
             case bucket = "Bucket"
         }
@@ -2376,6 +2480,10 @@ extension S3 {
             self.bucket = bucket
         }
 
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
+        }
+
         private enum CodingKeys: String, CodingKey {
             case bucket = "Bucket"
         }
@@ -2406,6 +2514,10 @@ extension S3 {
 
         public init(bucket: String) {
             self.bucket = bucket
+        }
+
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -2448,6 +2560,10 @@ extension S3 {
             self.id = id
         }
 
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
+        }
+
         private enum CodingKeys: String, CodingKey {
             case bucket = "Bucket"
             case id = "id"
@@ -2464,6 +2580,10 @@ extension S3 {
 
         public init(bucket: String) {
             self.bucket = bucket
+        }
+
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -2499,6 +2619,10 @@ extension S3 {
 
         public init(bucket: String) {
             self.bucket = bucket
+        }
+
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -2537,6 +2661,10 @@ extension S3 {
             self.bucket = bucket
         }
 
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
+        }
+
         private enum CodingKeys: String, CodingKey {
             case bucket = "Bucket"
         }
@@ -2569,6 +2697,10 @@ extension S3 {
 
         public init(bucket: String) {
             self.bucket = bucket
+        }
+
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -2604,6 +2736,10 @@ extension S3 {
             self.bucket = bucket
         }
 
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
+        }
+
         private enum CodingKeys: String, CodingKey {
             case bucket = "Bucket"
         }
@@ -2634,6 +2770,10 @@ extension S3 {
 
         public init(bucket: String) {
             self.bucket = bucket
+        }
+
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -2672,6 +2812,10 @@ extension S3 {
 
         public init(bucket: String) {
             self.bucket = bucket
+        }
+
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -2716,6 +2860,10 @@ extension S3 {
 
         public init(bucket: String) {
             self.bucket = bucket
+        }
+
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -2770,6 +2918,7 @@ extension S3 {
         }
 
         public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
             try validate(self.key, name:"key", parent: name, min: 1)
         }
 
@@ -2824,6 +2973,7 @@ extension S3 {
         }
 
         public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
             try validate(self.key, name:"key", parent: name, min: 1)
         }
 
@@ -2864,6 +3014,10 @@ extension S3 {
 
         public init(bucket: String) {
             self.bucket = bucket
+        }
+
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -3118,6 +3272,7 @@ extension S3 {
         }
 
         public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
             try validate(self.key, name:"key", parent: name, min: 1)
         }
 
@@ -3187,6 +3342,7 @@ extension S3 {
         }
 
         public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
             try validate(self.key, name:"key", parent: name, min: 1)
         }
 
@@ -3236,6 +3392,7 @@ extension S3 {
         }
 
         public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
             try validate(self.key, name:"key", parent: name, min: 1)
         }
 
@@ -3286,6 +3443,7 @@ extension S3 {
         }
 
         public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
             try validate(self.key, name:"key", parent: name, min: 1)
         }
 
@@ -3325,6 +3483,10 @@ extension S3 {
 
         public init(bucket: String) {
             self.bucket = bucket
+        }
+
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -3416,6 +3578,10 @@ extension S3 {
 
         public init(bucket: String) {
             self.bucket = bucket
+        }
+
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -3629,6 +3795,7 @@ extension S3 {
         }
 
         public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
             try validate(self.key, name:"key", parent: name, min: 1)
         }
 
@@ -3756,6 +3923,10 @@ extension S3 {
             self.schedule = schedule
         }
 
+        public func validate(name: String) throws {
+            try self.destination.validate(name: "\(name).destination")
+        }
+
         private enum CodingKeys: String, CodingKey {
             case destination = "Destination"
             case filter = "Filter"
@@ -3777,6 +3948,10 @@ extension S3 {
 
         public init(s3BucketDestination: InventoryS3BucketDestination) {
             self.s3BucketDestination = s3BucketDestination
+        }
+
+        public func validate(name: String) throws {
+            try self.s3BucketDestination.validate(name: "\(name).s3BucketDestination")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -3882,6 +4057,10 @@ extension S3 {
             self.encryption = encryption
             self.format = format
             self.prefix = prefix
+        }
+
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -4179,6 +4358,10 @@ extension S3 {
             self.continuationToken = continuationToken
         }
 
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
+        }
+
         private enum CodingKeys: String, CodingKey {
             case bucket = "Bucket"
             case continuationToken = "continuation-token"
@@ -4233,6 +4416,10 @@ extension S3 {
             self.continuationToken = continuationToken
         }
 
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
+        }
+
         private enum CodingKeys: String, CodingKey {
             case bucket = "Bucket"
             case continuationToken = "continuation-token"
@@ -4285,6 +4472,10 @@ extension S3 {
         public init(bucket: String, continuationToken: String? = nil) {
             self.bucket = bucket
             self.continuationToken = continuationToken
+        }
+
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -4416,6 +4607,10 @@ extension S3 {
             self.uploadIdMarker = uploadIdMarker
         }
 
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
+        }
+
         private enum CodingKeys: String, CodingKey {
             case bucket = "Bucket"
             case delimiter = "delimiter"
@@ -4530,6 +4725,10 @@ extension S3 {
             self.versionIdMarker = versionIdMarker
         }
 
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
+        }
+
         private enum CodingKeys: String, CodingKey {
             case bucket = "Bucket"
             case delimiter = "delimiter"
@@ -4628,6 +4827,10 @@ extension S3 {
             self.maxKeys = maxKeys
             self.prefix = prefix
             self.requestPayer = requestPayer
+        }
+
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -4757,6 +4960,10 @@ extension S3 {
             self.startAfter = startAfter
         }
 
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
+        }
+
         private enum CodingKeys: String, CodingKey {
             case bucket = "Bucket"
             case continuationToken = "continuation-token"
@@ -4879,6 +5086,7 @@ extension S3 {
         }
 
         public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
             try validate(self.key, name:"key", parent: name, min: 1)
         }
 
@@ -5627,6 +5835,10 @@ extension S3 {
             self.bucket = bucket
         }
 
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
+        }
+
         private enum CodingKeys: String, CodingKey {
             case accelerateConfiguration = "AccelerateConfiguration"
             case bucket = "Bucket"
@@ -5678,6 +5890,10 @@ extension S3 {
             self.grantWriteACP = grantWriteACP
         }
 
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
+        }
+
         private enum CodingKeys: String, CodingKey {
             case accessControlPolicy = "AccessControlPolicy"
             case acl = "x-amz-acl"
@@ -5716,6 +5932,7 @@ extension S3 {
 
         public func validate(name: String) throws {
             try self.analyticsConfiguration.validate(name: "\(name).analyticsConfiguration")
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -5745,6 +5962,10 @@ extension S3 {
             self.cORSConfiguration = cORSConfiguration
         }
 
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
+        }
+
         private enum CodingKeys: String, CodingKey {
             case bucket = "Bucket"
             case contentMD5 = "Content-MD5"
@@ -5772,6 +5993,10 @@ extension S3 {
             self.bucket = bucket
             self.contentMD5 = contentMD5
             self.serverSideEncryptionConfiguration = serverSideEncryptionConfiguration
+        }
+
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -5804,6 +6029,11 @@ extension S3 {
             self.inventoryConfiguration = inventoryConfiguration
         }
 
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
+            try self.inventoryConfiguration.validate(name: "\(name).inventoryConfiguration")
+        }
+
         private enum CodingKeys: String, CodingKey {
             case bucket = "Bucket"
             case id = "id"
@@ -5829,6 +6059,7 @@ extension S3 {
         }
 
         public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
             try self.lifecycleConfiguration?.validate(name: "\(name).lifecycleConfiguration")
         }
 
@@ -5858,6 +6089,10 @@ extension S3 {
             self.lifecycleConfiguration = lifecycleConfiguration
         }
 
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
+        }
+
         private enum CodingKeys: String, CodingKey {
             case bucket = "Bucket"
             case contentMD5 = "Content-MD5"
@@ -5883,6 +6118,10 @@ extension S3 {
             self.bucket = bucket
             self.bucketLoggingStatus = bucketLoggingStatus
             self.contentMD5 = contentMD5
+        }
+
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -5916,6 +6155,7 @@ extension S3 {
         }
 
         public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
             try self.metricsConfiguration.validate(name: "\(name).metricsConfiguration")
         }
 
@@ -5943,6 +6183,10 @@ extension S3 {
             self.notificationConfiguration = notificationConfiguration
         }
 
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
+        }
+
         private enum CodingKeys: String, CodingKey {
             case bucket = "Bucket"
             case notificationConfiguration = "NotificationConfiguration"
@@ -5967,6 +6211,10 @@ extension S3 {
             self.bucket = bucket
             self.contentMD5 = contentMD5
             self.notificationConfiguration = notificationConfiguration
+        }
+
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -5998,6 +6246,10 @@ extension S3 {
             self.confirmRemoveSelfBucketAccess = confirmRemoveSelfBucketAccess
             self.contentMD5 = contentMD5
             self.policy = policy
+        }
+
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -6034,6 +6286,7 @@ extension S3 {
         }
 
         public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
             try self.replicationConfiguration.validate(name: "\(name).replicationConfiguration")
         }
 
@@ -6065,6 +6318,10 @@ extension S3 {
             self.requestPaymentConfiguration = requestPaymentConfiguration
         }
 
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
+        }
+
         private enum CodingKeys: String, CodingKey {
             case bucket = "Bucket"
             case contentMD5 = "Content-MD5"
@@ -6093,6 +6350,7 @@ extension S3 {
         }
 
         public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
             try self.tagging.validate(name: "\(name).tagging")
         }
 
@@ -6127,6 +6385,10 @@ extension S3 {
             self.versioningConfiguration = versioningConfiguration
         }
 
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
+        }
+
         private enum CodingKeys: String, CodingKey {
             case bucket = "Bucket"
             case contentMD5 = "Content-MD5"
@@ -6156,6 +6418,7 @@ extension S3 {
         }
 
         public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
             try self.websiteConfiguration.validate(name: "\(name).websiteConfiguration")
         }
 
@@ -6238,6 +6501,7 @@ extension S3 {
         }
 
         public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
             try validate(self.key, name:"key", parent: name, min: 1)
         }
 
@@ -6308,6 +6572,7 @@ extension S3 {
         }
 
         public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
             try validate(self.key, name:"key", parent: name, min: 1)
         }
 
@@ -6365,6 +6630,10 @@ extension S3 {
             self.objectLockConfiguration = objectLockConfiguration
             self.requestPayer = requestPayer
             self.token = token
+        }
+
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -6562,6 +6831,7 @@ extension S3 {
         }
 
         public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
             try validate(self.key, name:"key", parent: name, min: 1)
         }
 
@@ -6654,6 +6924,7 @@ extension S3 {
         }
 
         public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
             try validate(self.key, name:"key", parent: name, min: 1)
         }
 
@@ -6711,6 +6982,7 @@ extension S3 {
         }
 
         public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
             try validate(self.key, name:"key", parent: name, min: 1)
             try self.tagging.validate(name: "\(name).tagging")
         }
@@ -6745,6 +7017,10 @@ extension S3 {
             self.bucket = bucket
             self.contentMD5 = contentMD5
             self.publicAccessBlockConfiguration = publicAccessBlockConfiguration
+        }
+
+        public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -6935,6 +7211,7 @@ extension S3 {
         }
 
         public func validate(name: String) throws {
+            try self.destination.validate(name: "\(name).destination")
             try self.filter?.validate(name: "\(name).filter")
         }
 
@@ -7113,6 +7390,7 @@ extension S3 {
         }
 
         public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
             try validate(self.key, name:"key", parent: name, min: 1)
             try self.restoreRequest?.validate(name: "\(name).restoreRequest")
         }
@@ -7307,6 +7585,7 @@ extension S3 {
         }
 
         public func validate(name: String) throws {
+            try validate(self.bucketName, name:"bucketName", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
             try self.tagging?.validate(name: "\(name).tagging")
         }
 
@@ -7396,6 +7675,7 @@ extension S3 {
         }
 
         public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
             try validate(self.key, name:"key", parent: name, min: 1)
         }
 
@@ -7570,6 +7850,10 @@ extension S3 {
             self.dataExport = dataExport
         }
 
+        public func validate(name: String) throws {
+            try self.dataExport?.validate(name: "\(name).dataExport")
+        }
+
         private enum CodingKeys: String, CodingKey {
             case dataExport = "DataExport"
         }
@@ -7589,6 +7873,10 @@ extension S3 {
         public init(destination: AnalyticsExportDestination, outputSchemaVersion: StorageClassAnalysisSchemaVersion) {
             self.destination = destination
             self.outputSchemaVersion = outputSchemaVersion
+        }
+
+        public func validate(name: String) throws {
+            try self.destination.validate(name: "\(name).destination")
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -7903,6 +8191,7 @@ extension S3 {
         }
 
         public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
             try validate(self.copySource, name:"copySource", parent: name, pattern: "\\/.+\\/.+")
             try validate(self.key, name:"key", parent: name, min: 1)
         }
@@ -8023,6 +8312,7 @@ extension S3 {
         }
 
         public func validate(name: String) throws {
+            try validate(self.bucket, name:"bucket", parent: name, pattern: "^[a-z0-9][a-z0-9-]+[a-z0-9]$")
             try validate(self.key, name:"key", parent: name, min: 1)
         }
 


### PR DESCRIPTION
Added ability to add entries to dictionaries in patch code of CodeGenerator
Added regex pattern validation for s3 bucket name.
- Bucket names can have lowercase letters, numbers or hyphen
- Bucket names can only start and end with a lowercase letter or number
- Originally bucket names could include periods but these don't work with s3 virtual addressing so I am not allowing these here.

The user will get a more useful error now instead of the SSL unableToValidateCertificate error you get if you use a bucket name containing a period which is not informative at all. See #173