### PR TITLE
Extract "error","code" from service model files

### DIFF
--- a/CodeGenerator/Sources/CodeGenerator/CodeGenerator.swift
+++ b/CodeGenerator/Sources/CodeGenerator/CodeGenerator.swift
@@ -241,8 +241,9 @@ extension AWSService {
         context["errorName"] = serviceErrorName
 
         var errorContexts: [ErrorContext] = []
-        for error in errorShapeNames {
-            errorContexts.append(ErrorContext(enum: error.toSwiftVariableCase(), string: error))
+        for error in errors {
+            let code = error.code ?? error.name
+            errorContexts.append(ErrorContext(enum: error.name.toSwiftVariableCase(), string: code))
         }
         if errorContexts.count > 0 {
             context["errors"] = errorContexts
@@ -279,7 +280,7 @@ extension AWSService {
         default:
             break
         }
-        if !errorShapeNames.isEmpty {
+        if !errors.isEmpty {
             context["errorTypes"] = serviceErrorName
         }
 
@@ -462,7 +463,7 @@ extension AWSService {
                 continue
             }
             // don't output error shapes
-            if errorShapeNames.contains(shape.name) { continue }
+            //if errorShapeNames.contains(shape.name) { continue }
 
             switch shape.type {
             case .enum(let values):

--- a/CodeGenerator/Sources/CodeGenerator/Doc/Error.swift
+++ b/CodeGenerator/Sources/CodeGenerator/Doc/Error.swift
@@ -1,0 +1,20 @@
+//
+//  Error.swift
+//  AWSSDKSwift
+//
+//  Created by Adam Fowler on 2019/10/22.
+//
+//
+
+public struct ErrorShape {
+    public let name: String
+    public let code: String?
+    public let httpStatusCode: Int?
+    
+    public init(name: String, code: String?, httpStatusCode: Int?) {
+        self.name = name
+        self.code = code
+        self.httpStatusCode = httpStatusCode
+    }
+}
+

--- a/CodeGenerator/Sources/CodeGenerator/patch.swift
+++ b/CodeGenerator/Sources/CodeGenerator/patch.swift
@@ -20,6 +20,11 @@ let servicePatches : [String: [Patch]] = [
         Patch(.replace, entry:["shapes", "HttpVersion", "enum", 0], value:"HTTP1_1", originalValue:"http1.1"),
         Patch(.replace, entry:["shapes", "HttpVersion", "enum", 1], value:"HTTP2", originalValue:"http2")
     ],
+    "CloudWatch" : [
+        // Patch error shape to avoid warning in generated code. Both errors have the same code "ResourceNotFound"
+        Patch(.replace, entry:["operations", "GetDashboard", "errors", 1, "shape"], value:"ResourceNotFoundException", originalValue: "DashboardNotFoundError"),
+        Patch(.replace, entry:["operations", "DeleteDashboards", "errors", 1, "shape"], value:"ResourceNotFoundException", originalValue: "DashboardNotFoundError")
+    ],
     "DirectoryService" : [
         // DirectoryService clashes with a macOS framework, so need to rename the framework
         Patch(.replace, entry:["serviceName"], value:"AWSDirectoryService", originalValue:"DirectoryService")

--- a/Sources/AWSSDKSwift/Services/AutoScaling/AutoScaling_Error.swift
+++ b/Sources/AWSSDKSwift/Services/AutoScaling/AutoScaling_Error.swift
@@ -20,17 +20,17 @@ extension AutoScalingErrorType {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
         switch errorCode {
-        case "AlreadyExistsFault":
+        case "AlreadyExists":
             self = .alreadyExistsFault(message: message)
         case "InvalidNextToken":
             self = .invalidNextToken(message: message)
-        case "LimitExceededFault":
+        case "LimitExceeded":
             self = .limitExceededFault(message: message)
-        case "ResourceContentionFault":
+        case "ResourceContention":
             self = .resourceContentionFault(message: message)
-        case "ResourceInUseFault":
+        case "ResourceInUse":
             self = .resourceInUseFault(message: message)
-        case "ScalingActivityInProgressFault":
+        case "ScalingActivityInProgress":
             self = .scalingActivityInProgressFault(message: message)
         case "ServiceLinkedRoleFailure":
             self = .serviceLinkedRoleFailure(message: message)
@@ -44,17 +44,17 @@ extension AutoScalingErrorType : CustomStringConvertible {
     public var description : String {
         switch self {
         case .alreadyExistsFault(let message):
-            return "AlreadyExistsFault: \(message ?? "")"
+            return "AlreadyExists: \(message ?? "")"
         case .invalidNextToken(let message):
             return "InvalidNextToken: \(message ?? "")"
         case .limitExceededFault(let message):
-            return "LimitExceededFault: \(message ?? "")"
+            return "LimitExceeded: \(message ?? "")"
         case .resourceContentionFault(let message):
-            return "ResourceContentionFault: \(message ?? "")"
+            return "ResourceContention: \(message ?? "")"
         case .resourceInUseFault(let message):
-            return "ResourceInUseFault: \(message ?? "")"
+            return "ResourceInUse: \(message ?? "")"
         case .scalingActivityInProgressFault(let message):
-            return "ScalingActivityInProgressFault: \(message ?? "")"
+            return "ScalingActivityInProgress: \(message ?? "")"
         case .serviceLinkedRoleFailure(let message):
             return "ServiceLinkedRoleFailure: \(message ?? "")"
         }

--- a/Sources/AWSSDKSwift/Services/CloudFormation/CloudFormation_Error.swift
+++ b/Sources/AWSSDKSwift/Services/CloudFormation/CloudFormation_Error.swift
@@ -31,13 +31,13 @@ extension CloudFormationErrorType {
         switch errorCode {
         case "AlreadyExistsException":
             self = .alreadyExistsException(message: message)
-        case "ChangeSetNotFoundException":
+        case "ChangeSetNotFound":
             self = .changeSetNotFoundException(message: message)
         case "CreatedButModifiedException":
             self = .createdButModifiedException(message: message)
         case "InsufficientCapabilitiesException":
             self = .insufficientCapabilitiesException(message: message)
-        case "InvalidChangeSetStatusException":
+        case "InvalidChangeSetStatus":
             self = .invalidChangeSetStatusException(message: message)
         case "InvalidOperationException":
             self = .invalidOperationException(message: message)
@@ -73,13 +73,13 @@ extension CloudFormationErrorType : CustomStringConvertible {
         case .alreadyExistsException(let message):
             return "AlreadyExistsException: \(message ?? "")"
         case .changeSetNotFoundException(let message):
-            return "ChangeSetNotFoundException: \(message ?? "")"
+            return "ChangeSetNotFound: \(message ?? "")"
         case .createdButModifiedException(let message):
             return "CreatedButModifiedException: \(message ?? "")"
         case .insufficientCapabilitiesException(let message):
             return "InsufficientCapabilitiesException: \(message ?? "")"
         case .invalidChangeSetStatusException(let message):
-            return "InvalidChangeSetStatusException: \(message ?? "")"
+            return "InvalidChangeSetStatus: \(message ?? "")"
         case .invalidOperationException(let message):
             return "InvalidOperationException: \(message ?? "")"
         case .limitExceededException(let message):

--- a/Sources/AWSSDKSwift/Services/CloudSearch/CloudSearch_Error.swift
+++ b/Sources/AWSSDKSwift/Services/CloudSearch/CloudSearch_Error.swift
@@ -21,15 +21,15 @@ extension CloudSearchErrorType {
         switch errorCode {
         case "BaseException":
             self = .baseException(message: message)
-        case "DisabledOperationException":
+        case "DisabledAction":
             self = .disabledOperationException(message: message)
         case "InternalException":
             self = .internalException(message: message)
-        case "InvalidTypeException":
+        case "InvalidType":
             self = .invalidTypeException(message: message)
-        case "LimitExceededException":
+        case "LimitExceeded":
             self = .limitExceededException(message: message)
-        case "ResourceNotFoundException":
+        case "ResourceNotFound":
             self = .resourceNotFoundException(message: message)
         default:
             return nil
@@ -43,15 +43,15 @@ extension CloudSearchErrorType : CustomStringConvertible {
         case .baseException(let message):
             return "BaseException: \(message ?? "")"
         case .disabledOperationException(let message):
-            return "DisabledOperationException: \(message ?? "")"
+            return "DisabledAction: \(message ?? "")"
         case .internalException(let message):
             return "InternalException: \(message ?? "")"
         case .invalidTypeException(let message):
-            return "InvalidTypeException: \(message ?? "")"
+            return "InvalidType: \(message ?? "")"
         case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
+            return "LimitExceeded: \(message ?? "")"
         case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
+            return "ResourceNotFound: \(message ?? "")"
         }
     }
 }

--- a/Sources/AWSSDKSwift/Services/CloudWatch/CloudWatch_Error.swift
+++ b/Sources/AWSSDKSwift/Services/CloudWatch/CloudWatch_Error.swift
@@ -6,7 +6,6 @@ import AWSSDKSwiftCore
 public enum CloudWatchErrorType: AWSErrorType {
     case concurrentModificationException(message: String?)
     case dashboardInvalidInputError(message: String?)
-    case dashboardNotFoundError(message: String?)
     case internalServiceFault(message: String?)
     case invalidFormatFault(message: String?)
     case invalidNextToken(message: String?)
@@ -28,25 +27,23 @@ extension CloudWatchErrorType {
         switch errorCode {
         case "ConcurrentModificationException":
             self = .concurrentModificationException(message: message)
-        case "DashboardInvalidInputError":
+        case "InvalidParameterInput":
             self = .dashboardInvalidInputError(message: message)
-        case "DashboardNotFoundError":
-            self = .dashboardNotFoundError(message: message)
-        case "InternalServiceFault":
+        case "InternalServiceError":
             self = .internalServiceFault(message: message)
-        case "InvalidFormatFault":
+        case "InvalidFormat":
             self = .invalidFormatFault(message: message)
         case "InvalidNextToken":
             self = .invalidNextToken(message: message)
-        case "InvalidParameterCombinationException":
+        case "InvalidParameterCombination":
             self = .invalidParameterCombinationException(message: message)
-        case "InvalidParameterValueException":
+        case "InvalidParameterValue":
             self = .invalidParameterValueException(message: message)
         case "LimitExceededException":
             self = .limitExceededException(message: message)
-        case "LimitExceededFault":
+        case "LimitExceeded":
             self = .limitExceededFault(message: message)
-        case "MissingRequiredParameterException":
+        case "MissingParameter":
             self = .missingRequiredParameterException(message: message)
         case "ResourceNotFound":
             self = .resourceNotFound(message: message)
@@ -64,25 +61,23 @@ extension CloudWatchErrorType : CustomStringConvertible {
         case .concurrentModificationException(let message):
             return "ConcurrentModificationException: \(message ?? "")"
         case .dashboardInvalidInputError(let message):
-            return "DashboardInvalidInputError: \(message ?? "")"
-        case .dashboardNotFoundError(let message):
-            return "DashboardNotFoundError: \(message ?? "")"
+            return "InvalidParameterInput: \(message ?? "")"
         case .internalServiceFault(let message):
-            return "InternalServiceFault: \(message ?? "")"
+            return "InternalServiceError: \(message ?? "")"
         case .invalidFormatFault(let message):
-            return "InvalidFormatFault: \(message ?? "")"
+            return "InvalidFormat: \(message ?? "")"
         case .invalidNextToken(let message):
             return "InvalidNextToken: \(message ?? "")"
         case .invalidParameterCombinationException(let message):
-            return "InvalidParameterCombinationException: \(message ?? "")"
+            return "InvalidParameterCombination: \(message ?? "")"
         case .invalidParameterValueException(let message):
-            return "InvalidParameterValueException: \(message ?? "")"
+            return "InvalidParameterValue: \(message ?? "")"
         case .limitExceededException(let message):
             return "LimitExceededException: \(message ?? "")"
         case .limitExceededFault(let message):
-            return "LimitExceededFault: \(message ?? "")"
+            return "LimitExceeded: \(message ?? "")"
         case .missingRequiredParameterException(let message):
-            return "MissingRequiredParameterException: \(message ?? "")"
+            return "MissingParameter: \(message ?? "")"
         case .resourceNotFound(let message):
             return "ResourceNotFound: \(message ?? "")"
         case .resourceNotFoundException(let message):

--- a/Sources/AWSSDKSwift/Services/CognitoSync/CognitoSync_Error.swift
+++ b/Sources/AWSSDKSwift/Services/CognitoSync/CognitoSync_Error.swift
@@ -26,31 +26,31 @@ extension CognitoSyncErrorType {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
         switch errorCode {
-        case "AlreadyStreamedException":
+        case "AlreadyStreamed":
             self = .alreadyStreamedException(message: message)
-        case "ConcurrentModificationException":
+        case "ConcurrentModification":
             self = .concurrentModificationException(message: message)
-        case "DuplicateRequestException":
+        case "DuplicateRequest":
             self = .duplicateRequestException(message: message)
-        case "InternalErrorException":
+        case "InternalError":
             self = .internalErrorException(message: message)
-        case "InvalidConfigurationException":
+        case "InvalidConfiguration":
             self = .invalidConfigurationException(message: message)
-        case "InvalidLambdaFunctionOutputException":
+        case "InvalidLambdaFunctionOutput":
             self = .invalidLambdaFunctionOutputException(message: message)
-        case "InvalidParameterException":
+        case "InvalidParameter":
             self = .invalidParameterException(message: message)
-        case "LambdaThrottledException":
+        case "LambdaThrottled":
             self = .lambdaThrottledException(message: message)
-        case "LimitExceededException":
+        case "LimitExceeded":
             self = .limitExceededException(message: message)
-        case "NotAuthorizedException":
+        case "NotAuthorizedError":
             self = .notAuthorizedException(message: message)
-        case "ResourceConflictException":
+        case "ResourceConflict":
             self = .resourceConflictException(message: message)
-        case "ResourceNotFoundException":
+        case "ResourceNotFound":
             self = .resourceNotFoundException(message: message)
-        case "TooManyRequestsException":
+        case "TooManyRequests":
             self = .tooManyRequestsException(message: message)
         default:
             return nil
@@ -62,31 +62,31 @@ extension CognitoSyncErrorType : CustomStringConvertible {
     public var description : String {
         switch self {
         case .alreadyStreamedException(let message):
-            return "AlreadyStreamedException: \(message ?? "")"
+            return "AlreadyStreamed: \(message ?? "")"
         case .concurrentModificationException(let message):
-            return "ConcurrentModificationException: \(message ?? "")"
+            return "ConcurrentModification: \(message ?? "")"
         case .duplicateRequestException(let message):
-            return "DuplicateRequestException: \(message ?? "")"
+            return "DuplicateRequest: \(message ?? "")"
         case .internalErrorException(let message):
-            return "InternalErrorException: \(message ?? "")"
+            return "InternalError: \(message ?? "")"
         case .invalidConfigurationException(let message):
-            return "InvalidConfigurationException: \(message ?? "")"
+            return "InvalidConfiguration: \(message ?? "")"
         case .invalidLambdaFunctionOutputException(let message):
-            return "InvalidLambdaFunctionOutputException: \(message ?? "")"
+            return "InvalidLambdaFunctionOutput: \(message ?? "")"
         case .invalidParameterException(let message):
-            return "InvalidParameterException: \(message ?? "")"
+            return "InvalidParameter: \(message ?? "")"
         case .lambdaThrottledException(let message):
-            return "LambdaThrottledException: \(message ?? "")"
+            return "LambdaThrottled: \(message ?? "")"
         case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
+            return "LimitExceeded: \(message ?? "")"
         case .notAuthorizedException(let message):
-            return "NotAuthorizedException: \(message ?? "")"
+            return "NotAuthorizedError: \(message ?? "")"
         case .resourceConflictException(let message):
-            return "ResourceConflictException: \(message ?? "")"
+            return "ResourceConflict: \(message ?? "")"
         case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
+            return "ResourceNotFound: \(message ?? "")"
         case .tooManyRequestsException(let message):
-            return "TooManyRequestsException: \(message ?? "")"
+            return "TooManyRequests: \(message ?? "")"
         }
     }
 }

--- a/Sources/AWSSDKSwift/Services/DocDB/DocDB_Error.swift
+++ b/Sources/AWSSDKSwift/Services/DocDB/DocDB_Error.swift
@@ -57,15 +57,15 @@ extension DocDBErrorType {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
         switch errorCode {
-        case "AuthorizationNotFoundFault":
+        case "AuthorizationNotFound":
             self = .authorizationNotFoundFault(message: message)
-        case "CertificateNotFoundFault":
+        case "CertificateNotFound":
             self = .certificateNotFoundFault(message: message)
         case "DBClusterAlreadyExistsFault":
             self = .dBClusterAlreadyExistsFault(message: message)
         case "DBClusterNotFoundFault":
             self = .dBClusterNotFoundFault(message: message)
-        case "DBClusterParameterGroupNotFoundFault":
+        case "DBClusterParameterGroupNotFound":
             self = .dBClusterParameterGroupNotFoundFault(message: message)
         case "DBClusterQuotaExceededFault":
             self = .dBClusterQuotaExceededFault(message: message)
@@ -73,53 +73,53 @@ extension DocDBErrorType {
             self = .dBClusterSnapshotAlreadyExistsFault(message: message)
         case "DBClusterSnapshotNotFoundFault":
             self = .dBClusterSnapshotNotFoundFault(message: message)
-        case "DBInstanceAlreadyExistsFault":
+        case "DBInstanceAlreadyExists":
             self = .dBInstanceAlreadyExistsFault(message: message)
-        case "DBInstanceNotFoundFault":
+        case "DBInstanceNotFound":
             self = .dBInstanceNotFoundFault(message: message)
-        case "DBParameterGroupAlreadyExistsFault":
+        case "DBParameterGroupAlreadyExists":
             self = .dBParameterGroupAlreadyExistsFault(message: message)
-        case "DBParameterGroupNotFoundFault":
+        case "DBParameterGroupNotFound":
             self = .dBParameterGroupNotFoundFault(message: message)
-        case "DBParameterGroupQuotaExceededFault":
+        case "DBParameterGroupQuotaExceeded":
             self = .dBParameterGroupQuotaExceededFault(message: message)
-        case "DBSecurityGroupNotFoundFault":
+        case "DBSecurityGroupNotFound":
             self = .dBSecurityGroupNotFoundFault(message: message)
-        case "DBSnapshotAlreadyExistsFault":
+        case "DBSnapshotAlreadyExists":
             self = .dBSnapshotAlreadyExistsFault(message: message)
-        case "DBSnapshotNotFoundFault":
+        case "DBSnapshotNotFound":
             self = .dBSnapshotNotFoundFault(message: message)
-        case "DBSubnetGroupAlreadyExistsFault":
+        case "DBSubnetGroupAlreadyExists":
             self = .dBSubnetGroupAlreadyExistsFault(message: message)
         case "DBSubnetGroupDoesNotCoverEnoughAZs":
             self = .dBSubnetGroupDoesNotCoverEnoughAZs(message: message)
         case "DBSubnetGroupNotFoundFault":
             self = .dBSubnetGroupNotFoundFault(message: message)
-        case "DBSubnetGroupQuotaExceededFault":
+        case "DBSubnetGroupQuotaExceeded":
             self = .dBSubnetGroupQuotaExceededFault(message: message)
         case "DBSubnetQuotaExceededFault":
             self = .dBSubnetQuotaExceededFault(message: message)
-        case "DBUpgradeDependencyFailureFault":
+        case "DBUpgradeDependencyFailure":
             self = .dBUpgradeDependencyFailureFault(message: message)
-        case "InstanceQuotaExceededFault":
+        case "InstanceQuotaExceeded":
             self = .instanceQuotaExceededFault(message: message)
         case "InsufficientDBClusterCapacityFault":
             self = .insufficientDBClusterCapacityFault(message: message)
-        case "InsufficientDBInstanceCapacityFault":
+        case "InsufficientDBInstanceCapacity":
             self = .insufficientDBInstanceCapacityFault(message: message)
-        case "InsufficientStorageClusterCapacityFault":
+        case "InsufficientStorageClusterCapacity":
             self = .insufficientStorageClusterCapacityFault(message: message)
         case "InvalidDBClusterSnapshotStateFault":
             self = .invalidDBClusterSnapshotStateFault(message: message)
         case "InvalidDBClusterStateFault":
             self = .invalidDBClusterStateFault(message: message)
-        case "InvalidDBInstanceStateFault":
+        case "InvalidDBInstanceState":
             self = .invalidDBInstanceStateFault(message: message)
-        case "InvalidDBParameterGroupStateFault":
+        case "InvalidDBParameterGroupState":
             self = .invalidDBParameterGroupStateFault(message: message)
-        case "InvalidDBSecurityGroupStateFault":
+        case "InvalidDBSecurityGroupState":
             self = .invalidDBSecurityGroupStateFault(message: message)
-        case "InvalidDBSnapshotStateFault":
+        case "InvalidDBSnapshotState":
             self = .invalidDBSnapshotStateFault(message: message)
         case "InvalidDBSubnetGroupStateFault":
             self = .invalidDBSubnetGroupStateFault(message: message)
@@ -135,13 +135,13 @@ extension DocDBErrorType {
             self = .kMSKeyNotAccessibleFault(message: message)
         case "ResourceNotFoundFault":
             self = .resourceNotFoundFault(message: message)
-        case "SharedSnapshotQuotaExceededFault":
+        case "SharedSnapshotQuotaExceeded":
             self = .sharedSnapshotQuotaExceededFault(message: message)
-        case "SnapshotQuotaExceededFault":
+        case "SnapshotQuotaExceeded":
             self = .snapshotQuotaExceededFault(message: message)
-        case "StorageQuotaExceededFault":
+        case "StorageQuotaExceeded":
             self = .storageQuotaExceededFault(message: message)
-        case "StorageTypeNotSupportedFault":
+        case "StorageTypeNotSupported":
             self = .storageTypeNotSupportedFault(message: message)
         case "SubnetAlreadyInUse":
             self = .subnetAlreadyInUse(message: message)
@@ -155,15 +155,15 @@ extension DocDBErrorType : CustomStringConvertible {
     public var description : String {
         switch self {
         case .authorizationNotFoundFault(let message):
-            return "AuthorizationNotFoundFault: \(message ?? "")"
+            return "AuthorizationNotFound: \(message ?? "")"
         case .certificateNotFoundFault(let message):
-            return "CertificateNotFoundFault: \(message ?? "")"
+            return "CertificateNotFound: \(message ?? "")"
         case .dBClusterAlreadyExistsFault(let message):
             return "DBClusterAlreadyExistsFault: \(message ?? "")"
         case .dBClusterNotFoundFault(let message):
             return "DBClusterNotFoundFault: \(message ?? "")"
         case .dBClusterParameterGroupNotFoundFault(let message):
-            return "DBClusterParameterGroupNotFoundFault: \(message ?? "")"
+            return "DBClusterParameterGroupNotFound: \(message ?? "")"
         case .dBClusterQuotaExceededFault(let message):
             return "DBClusterQuotaExceededFault: \(message ?? "")"
         case .dBClusterSnapshotAlreadyExistsFault(let message):
@@ -171,53 +171,53 @@ extension DocDBErrorType : CustomStringConvertible {
         case .dBClusterSnapshotNotFoundFault(let message):
             return "DBClusterSnapshotNotFoundFault: \(message ?? "")"
         case .dBInstanceAlreadyExistsFault(let message):
-            return "DBInstanceAlreadyExistsFault: \(message ?? "")"
+            return "DBInstanceAlreadyExists: \(message ?? "")"
         case .dBInstanceNotFoundFault(let message):
-            return "DBInstanceNotFoundFault: \(message ?? "")"
+            return "DBInstanceNotFound: \(message ?? "")"
         case .dBParameterGroupAlreadyExistsFault(let message):
-            return "DBParameterGroupAlreadyExistsFault: \(message ?? "")"
+            return "DBParameterGroupAlreadyExists: \(message ?? "")"
         case .dBParameterGroupNotFoundFault(let message):
-            return "DBParameterGroupNotFoundFault: \(message ?? "")"
+            return "DBParameterGroupNotFound: \(message ?? "")"
         case .dBParameterGroupQuotaExceededFault(let message):
-            return "DBParameterGroupQuotaExceededFault: \(message ?? "")"
+            return "DBParameterGroupQuotaExceeded: \(message ?? "")"
         case .dBSecurityGroupNotFoundFault(let message):
-            return "DBSecurityGroupNotFoundFault: \(message ?? "")"
+            return "DBSecurityGroupNotFound: \(message ?? "")"
         case .dBSnapshotAlreadyExistsFault(let message):
-            return "DBSnapshotAlreadyExistsFault: \(message ?? "")"
+            return "DBSnapshotAlreadyExists: \(message ?? "")"
         case .dBSnapshotNotFoundFault(let message):
-            return "DBSnapshotNotFoundFault: \(message ?? "")"
+            return "DBSnapshotNotFound: \(message ?? "")"
         case .dBSubnetGroupAlreadyExistsFault(let message):
-            return "DBSubnetGroupAlreadyExistsFault: \(message ?? "")"
+            return "DBSubnetGroupAlreadyExists: \(message ?? "")"
         case .dBSubnetGroupDoesNotCoverEnoughAZs(let message):
             return "DBSubnetGroupDoesNotCoverEnoughAZs: \(message ?? "")"
         case .dBSubnetGroupNotFoundFault(let message):
             return "DBSubnetGroupNotFoundFault: \(message ?? "")"
         case .dBSubnetGroupQuotaExceededFault(let message):
-            return "DBSubnetGroupQuotaExceededFault: \(message ?? "")"
+            return "DBSubnetGroupQuotaExceeded: \(message ?? "")"
         case .dBSubnetQuotaExceededFault(let message):
             return "DBSubnetQuotaExceededFault: \(message ?? "")"
         case .dBUpgradeDependencyFailureFault(let message):
-            return "DBUpgradeDependencyFailureFault: \(message ?? "")"
+            return "DBUpgradeDependencyFailure: \(message ?? "")"
         case .instanceQuotaExceededFault(let message):
-            return "InstanceQuotaExceededFault: \(message ?? "")"
+            return "InstanceQuotaExceeded: \(message ?? "")"
         case .insufficientDBClusterCapacityFault(let message):
             return "InsufficientDBClusterCapacityFault: \(message ?? "")"
         case .insufficientDBInstanceCapacityFault(let message):
-            return "InsufficientDBInstanceCapacityFault: \(message ?? "")"
+            return "InsufficientDBInstanceCapacity: \(message ?? "")"
         case .insufficientStorageClusterCapacityFault(let message):
-            return "InsufficientStorageClusterCapacityFault: \(message ?? "")"
+            return "InsufficientStorageClusterCapacity: \(message ?? "")"
         case .invalidDBClusterSnapshotStateFault(let message):
             return "InvalidDBClusterSnapshotStateFault: \(message ?? "")"
         case .invalidDBClusterStateFault(let message):
             return "InvalidDBClusterStateFault: \(message ?? "")"
         case .invalidDBInstanceStateFault(let message):
-            return "InvalidDBInstanceStateFault: \(message ?? "")"
+            return "InvalidDBInstanceState: \(message ?? "")"
         case .invalidDBParameterGroupStateFault(let message):
-            return "InvalidDBParameterGroupStateFault: \(message ?? "")"
+            return "InvalidDBParameterGroupState: \(message ?? "")"
         case .invalidDBSecurityGroupStateFault(let message):
-            return "InvalidDBSecurityGroupStateFault: \(message ?? "")"
+            return "InvalidDBSecurityGroupState: \(message ?? "")"
         case .invalidDBSnapshotStateFault(let message):
-            return "InvalidDBSnapshotStateFault: \(message ?? "")"
+            return "InvalidDBSnapshotState: \(message ?? "")"
         case .invalidDBSubnetGroupStateFault(let message):
             return "InvalidDBSubnetGroupStateFault: \(message ?? "")"
         case .invalidDBSubnetStateFault(let message):
@@ -233,13 +233,13 @@ extension DocDBErrorType : CustomStringConvertible {
         case .resourceNotFoundFault(let message):
             return "ResourceNotFoundFault: \(message ?? "")"
         case .sharedSnapshotQuotaExceededFault(let message):
-            return "SharedSnapshotQuotaExceededFault: \(message ?? "")"
+            return "SharedSnapshotQuotaExceeded: \(message ?? "")"
         case .snapshotQuotaExceededFault(let message):
-            return "SnapshotQuotaExceededFault: \(message ?? "")"
+            return "SnapshotQuotaExceeded: \(message ?? "")"
         case .storageQuotaExceededFault(let message):
-            return "StorageQuotaExceededFault: \(message ?? "")"
+            return "StorageQuotaExceeded: \(message ?? "")"
         case .storageTypeNotSupportedFault(let message):
-            return "StorageTypeNotSupportedFault: \(message ?? "")"
+            return "StorageTypeNotSupported: \(message ?? "")"
         case .subnetAlreadyInUse(let message):
             return "SubnetAlreadyInUse: \(message ?? "")"
         }

--- a/Sources/AWSSDKSwift/Services/ELB/ELB_Error.swift
+++ b/Sources/AWSSDKSwift/Services/ELB/ELB_Error.swift
@@ -35,49 +35,49 @@ extension ELBErrorType {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
         switch errorCode {
-        case "AccessPointNotFoundException":
+        case "LoadBalancerNotFound":
             self = .accessPointNotFoundException(message: message)
-        case "CertificateNotFoundException":
+        case "CertificateNotFound":
             self = .certificateNotFoundException(message: message)
-        case "DependencyThrottleException":
+        case "DependencyThrottle":
             self = .dependencyThrottleException(message: message)
-        case "DuplicateAccessPointNameException":
+        case "DuplicateLoadBalancerName":
             self = .duplicateAccessPointNameException(message: message)
-        case "DuplicateListenerException":
+        case "DuplicateListener":
             self = .duplicateListenerException(message: message)
-        case "DuplicatePolicyNameException":
+        case "DuplicatePolicyName":
             self = .duplicatePolicyNameException(message: message)
-        case "DuplicateTagKeysException":
+        case "DuplicateTagKeys":
             self = .duplicateTagKeysException(message: message)
-        case "InvalidConfigurationRequestException":
+        case "InvalidConfigurationRequest":
             self = .invalidConfigurationRequestException(message: message)
-        case "InvalidEndPointException":
+        case "InvalidInstance":
             self = .invalidEndPointException(message: message)
-        case "InvalidSchemeException":
+        case "InvalidScheme":
             self = .invalidSchemeException(message: message)
-        case "InvalidSecurityGroupException":
+        case "InvalidSecurityGroup":
             self = .invalidSecurityGroupException(message: message)
-        case "InvalidSubnetException":
+        case "InvalidSubnet":
             self = .invalidSubnetException(message: message)
-        case "ListenerNotFoundException":
+        case "ListenerNotFound":
             self = .listenerNotFoundException(message: message)
-        case "LoadBalancerAttributeNotFoundException":
+        case "LoadBalancerAttributeNotFound":
             self = .loadBalancerAttributeNotFoundException(message: message)
-        case "OperationNotPermittedException":
+        case "OperationNotPermitted":
             self = .operationNotPermittedException(message: message)
-        case "PolicyNotFoundException":
+        case "PolicyNotFound":
             self = .policyNotFoundException(message: message)
-        case "PolicyTypeNotFoundException":
+        case "PolicyTypeNotFound":
             self = .policyTypeNotFoundException(message: message)
-        case "SubnetNotFoundException":
+        case "SubnetNotFound":
             self = .subnetNotFoundException(message: message)
-        case "TooManyAccessPointsException":
+        case "TooManyLoadBalancers":
             self = .tooManyAccessPointsException(message: message)
-        case "TooManyPoliciesException":
+        case "TooManyPolicies":
             self = .tooManyPoliciesException(message: message)
-        case "TooManyTagsException":
+        case "TooManyTags":
             self = .tooManyTagsException(message: message)
-        case "UnsupportedProtocolException":
+        case "UnsupportedProtocol":
             self = .unsupportedProtocolException(message: message)
         default:
             return nil
@@ -89,49 +89,49 @@ extension ELBErrorType : CustomStringConvertible {
     public var description : String {
         switch self {
         case .accessPointNotFoundException(let message):
-            return "AccessPointNotFoundException: \(message ?? "")"
+            return "LoadBalancerNotFound: \(message ?? "")"
         case .certificateNotFoundException(let message):
-            return "CertificateNotFoundException: \(message ?? "")"
+            return "CertificateNotFound: \(message ?? "")"
         case .dependencyThrottleException(let message):
-            return "DependencyThrottleException: \(message ?? "")"
+            return "DependencyThrottle: \(message ?? "")"
         case .duplicateAccessPointNameException(let message):
-            return "DuplicateAccessPointNameException: \(message ?? "")"
+            return "DuplicateLoadBalancerName: \(message ?? "")"
         case .duplicateListenerException(let message):
-            return "DuplicateListenerException: \(message ?? "")"
+            return "DuplicateListener: \(message ?? "")"
         case .duplicatePolicyNameException(let message):
-            return "DuplicatePolicyNameException: \(message ?? "")"
+            return "DuplicatePolicyName: \(message ?? "")"
         case .duplicateTagKeysException(let message):
-            return "DuplicateTagKeysException: \(message ?? "")"
+            return "DuplicateTagKeys: \(message ?? "")"
         case .invalidConfigurationRequestException(let message):
-            return "InvalidConfigurationRequestException: \(message ?? "")"
+            return "InvalidConfigurationRequest: \(message ?? "")"
         case .invalidEndPointException(let message):
-            return "InvalidEndPointException: \(message ?? "")"
+            return "InvalidInstance: \(message ?? "")"
         case .invalidSchemeException(let message):
-            return "InvalidSchemeException: \(message ?? "")"
+            return "InvalidScheme: \(message ?? "")"
         case .invalidSecurityGroupException(let message):
-            return "InvalidSecurityGroupException: \(message ?? "")"
+            return "InvalidSecurityGroup: \(message ?? "")"
         case .invalidSubnetException(let message):
-            return "InvalidSubnetException: \(message ?? "")"
+            return "InvalidSubnet: \(message ?? "")"
         case .listenerNotFoundException(let message):
-            return "ListenerNotFoundException: \(message ?? "")"
+            return "ListenerNotFound: \(message ?? "")"
         case .loadBalancerAttributeNotFoundException(let message):
-            return "LoadBalancerAttributeNotFoundException: \(message ?? "")"
+            return "LoadBalancerAttributeNotFound: \(message ?? "")"
         case .operationNotPermittedException(let message):
-            return "OperationNotPermittedException: \(message ?? "")"
+            return "OperationNotPermitted: \(message ?? "")"
         case .policyNotFoundException(let message):
-            return "PolicyNotFoundException: \(message ?? "")"
+            return "PolicyNotFound: \(message ?? "")"
         case .policyTypeNotFoundException(let message):
-            return "PolicyTypeNotFoundException: \(message ?? "")"
+            return "PolicyTypeNotFound: \(message ?? "")"
         case .subnetNotFoundException(let message):
-            return "SubnetNotFoundException: \(message ?? "")"
+            return "SubnetNotFound: \(message ?? "")"
         case .tooManyAccessPointsException(let message):
-            return "TooManyAccessPointsException: \(message ?? "")"
+            return "TooManyLoadBalancers: \(message ?? "")"
         case .tooManyPoliciesException(let message):
-            return "TooManyPoliciesException: \(message ?? "")"
+            return "TooManyPolicies: \(message ?? "")"
         case .tooManyTagsException(let message):
-            return "TooManyTagsException: \(message ?? "")"
+            return "TooManyTags: \(message ?? "")"
         case .unsupportedProtocolException(let message):
-            return "UnsupportedProtocolException: \(message ?? "")"
+            return "UnsupportedProtocol: \(message ?? "")"
         }
     }
 }

--- a/Sources/AWSSDKSwift/Services/ELBV2/ELBV2_Error.swift
+++ b/Sources/AWSSDKSwift/Services/ELBV2/ELBV2_Error.swift
@@ -48,75 +48,75 @@ extension ELBV2ErrorType {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
         switch errorCode {
-        case "AllocationIdNotFoundException":
+        case "AllocationIdNotFound":
             self = .allocationIdNotFoundException(message: message)
-        case "AvailabilityZoneNotSupportedException":
+        case "AvailabilityZoneNotSupported":
             self = .availabilityZoneNotSupportedException(message: message)
-        case "CertificateNotFoundException":
+        case "CertificateNotFound":
             self = .certificateNotFoundException(message: message)
-        case "DuplicateListenerException":
+        case "DuplicateListener":
             self = .duplicateListenerException(message: message)
-        case "DuplicateLoadBalancerNameException":
+        case "DuplicateLoadBalancerName":
             self = .duplicateLoadBalancerNameException(message: message)
-        case "DuplicateTagKeysException":
+        case "DuplicateTagKeys":
             self = .duplicateTagKeysException(message: message)
-        case "DuplicateTargetGroupNameException":
+        case "DuplicateTargetGroupName":
             self = .duplicateTargetGroupNameException(message: message)
-        case "HealthUnavailableException":
+        case "HealthUnavailable":
             self = .healthUnavailableException(message: message)
-        case "IncompatibleProtocolsException":
+        case "IncompatibleProtocols":
             self = .incompatibleProtocolsException(message: message)
-        case "InvalidConfigurationRequestException":
+        case "InvalidConfigurationRequest":
             self = .invalidConfigurationRequestException(message: message)
-        case "InvalidLoadBalancerActionException":
+        case "InvalidLoadBalancerAction":
             self = .invalidLoadBalancerActionException(message: message)
-        case "InvalidSchemeException":
+        case "InvalidScheme":
             self = .invalidSchemeException(message: message)
-        case "InvalidSecurityGroupException":
+        case "InvalidSecurityGroup":
             self = .invalidSecurityGroupException(message: message)
-        case "InvalidSubnetException":
+        case "InvalidSubnet":
             self = .invalidSubnetException(message: message)
-        case "InvalidTargetException":
+        case "InvalidTarget":
             self = .invalidTargetException(message: message)
-        case "ListenerNotFoundException":
+        case "ListenerNotFound":
             self = .listenerNotFoundException(message: message)
-        case "LoadBalancerNotFoundException":
+        case "LoadBalancerNotFound":
             self = .loadBalancerNotFoundException(message: message)
-        case "OperationNotPermittedException":
+        case "OperationNotPermitted":
             self = .operationNotPermittedException(message: message)
-        case "PriorityInUseException":
+        case "PriorityInUse":
             self = .priorityInUseException(message: message)
-        case "ResourceInUseException":
+        case "ResourceInUse":
             self = .resourceInUseException(message: message)
-        case "RuleNotFoundException":
+        case "RuleNotFound":
             self = .ruleNotFoundException(message: message)
-        case "SSLPolicyNotFoundException":
+        case "SSLPolicyNotFound":
             self = .sSLPolicyNotFoundException(message: message)
-        case "SubnetNotFoundException":
+        case "SubnetNotFound":
             self = .subnetNotFoundException(message: message)
-        case "TargetGroupAssociationLimitException":
+        case "TargetGroupAssociationLimit":
             self = .targetGroupAssociationLimitException(message: message)
-        case "TargetGroupNotFoundException":
+        case "TargetGroupNotFound":
             self = .targetGroupNotFoundException(message: message)
-        case "TooManyActionsException":
+        case "TooManyActions":
             self = .tooManyActionsException(message: message)
-        case "TooManyCertificatesException":
+        case "TooManyCertificates":
             self = .tooManyCertificatesException(message: message)
-        case "TooManyListenersException":
+        case "TooManyListeners":
             self = .tooManyListenersException(message: message)
-        case "TooManyLoadBalancersException":
+        case "TooManyLoadBalancers":
             self = .tooManyLoadBalancersException(message: message)
-        case "TooManyRegistrationsForTargetIdException":
+        case "TooManyRegistrationsForTargetId":
             self = .tooManyRegistrationsForTargetIdException(message: message)
-        case "TooManyRulesException":
+        case "TooManyRules":
             self = .tooManyRulesException(message: message)
-        case "TooManyTagsException":
+        case "TooManyTags":
             self = .tooManyTagsException(message: message)
-        case "TooManyTargetGroupsException":
+        case "TooManyTargetGroups":
             self = .tooManyTargetGroupsException(message: message)
-        case "TooManyTargetsException":
+        case "TooManyTargets":
             self = .tooManyTargetsException(message: message)
-        case "UnsupportedProtocolException":
+        case "UnsupportedProtocol":
             self = .unsupportedProtocolException(message: message)
         default:
             return nil
@@ -128,75 +128,75 @@ extension ELBV2ErrorType : CustomStringConvertible {
     public var description : String {
         switch self {
         case .allocationIdNotFoundException(let message):
-            return "AllocationIdNotFoundException: \(message ?? "")"
+            return "AllocationIdNotFound: \(message ?? "")"
         case .availabilityZoneNotSupportedException(let message):
-            return "AvailabilityZoneNotSupportedException: \(message ?? "")"
+            return "AvailabilityZoneNotSupported: \(message ?? "")"
         case .certificateNotFoundException(let message):
-            return "CertificateNotFoundException: \(message ?? "")"
+            return "CertificateNotFound: \(message ?? "")"
         case .duplicateListenerException(let message):
-            return "DuplicateListenerException: \(message ?? "")"
+            return "DuplicateListener: \(message ?? "")"
         case .duplicateLoadBalancerNameException(let message):
-            return "DuplicateLoadBalancerNameException: \(message ?? "")"
+            return "DuplicateLoadBalancerName: \(message ?? "")"
         case .duplicateTagKeysException(let message):
-            return "DuplicateTagKeysException: \(message ?? "")"
+            return "DuplicateTagKeys: \(message ?? "")"
         case .duplicateTargetGroupNameException(let message):
-            return "DuplicateTargetGroupNameException: \(message ?? "")"
+            return "DuplicateTargetGroupName: \(message ?? "")"
         case .healthUnavailableException(let message):
-            return "HealthUnavailableException: \(message ?? "")"
+            return "HealthUnavailable: \(message ?? "")"
         case .incompatibleProtocolsException(let message):
-            return "IncompatibleProtocolsException: \(message ?? "")"
+            return "IncompatibleProtocols: \(message ?? "")"
         case .invalidConfigurationRequestException(let message):
-            return "InvalidConfigurationRequestException: \(message ?? "")"
+            return "InvalidConfigurationRequest: \(message ?? "")"
         case .invalidLoadBalancerActionException(let message):
-            return "InvalidLoadBalancerActionException: \(message ?? "")"
+            return "InvalidLoadBalancerAction: \(message ?? "")"
         case .invalidSchemeException(let message):
-            return "InvalidSchemeException: \(message ?? "")"
+            return "InvalidScheme: \(message ?? "")"
         case .invalidSecurityGroupException(let message):
-            return "InvalidSecurityGroupException: \(message ?? "")"
+            return "InvalidSecurityGroup: \(message ?? "")"
         case .invalidSubnetException(let message):
-            return "InvalidSubnetException: \(message ?? "")"
+            return "InvalidSubnet: \(message ?? "")"
         case .invalidTargetException(let message):
-            return "InvalidTargetException: \(message ?? "")"
+            return "InvalidTarget: \(message ?? "")"
         case .listenerNotFoundException(let message):
-            return "ListenerNotFoundException: \(message ?? "")"
+            return "ListenerNotFound: \(message ?? "")"
         case .loadBalancerNotFoundException(let message):
-            return "LoadBalancerNotFoundException: \(message ?? "")"
+            return "LoadBalancerNotFound: \(message ?? "")"
         case .operationNotPermittedException(let message):
-            return "OperationNotPermittedException: \(message ?? "")"
+            return "OperationNotPermitted: \(message ?? "")"
         case .priorityInUseException(let message):
-            return "PriorityInUseException: \(message ?? "")"
+            return "PriorityInUse: \(message ?? "")"
         case .resourceInUseException(let message):
-            return "ResourceInUseException: \(message ?? "")"
+            return "ResourceInUse: \(message ?? "")"
         case .ruleNotFoundException(let message):
-            return "RuleNotFoundException: \(message ?? "")"
+            return "RuleNotFound: \(message ?? "")"
         case .sSLPolicyNotFoundException(let message):
-            return "SSLPolicyNotFoundException: \(message ?? "")"
+            return "SSLPolicyNotFound: \(message ?? "")"
         case .subnetNotFoundException(let message):
-            return "SubnetNotFoundException: \(message ?? "")"
+            return "SubnetNotFound: \(message ?? "")"
         case .targetGroupAssociationLimitException(let message):
-            return "TargetGroupAssociationLimitException: \(message ?? "")"
+            return "TargetGroupAssociationLimit: \(message ?? "")"
         case .targetGroupNotFoundException(let message):
-            return "TargetGroupNotFoundException: \(message ?? "")"
+            return "TargetGroupNotFound: \(message ?? "")"
         case .tooManyActionsException(let message):
-            return "TooManyActionsException: \(message ?? "")"
+            return "TooManyActions: \(message ?? "")"
         case .tooManyCertificatesException(let message):
-            return "TooManyCertificatesException: \(message ?? "")"
+            return "TooManyCertificates: \(message ?? "")"
         case .tooManyListenersException(let message):
-            return "TooManyListenersException: \(message ?? "")"
+            return "TooManyListeners: \(message ?? "")"
         case .tooManyLoadBalancersException(let message):
-            return "TooManyLoadBalancersException: \(message ?? "")"
+            return "TooManyLoadBalancers: \(message ?? "")"
         case .tooManyRegistrationsForTargetIdException(let message):
-            return "TooManyRegistrationsForTargetIdException: \(message ?? "")"
+            return "TooManyRegistrationsForTargetId: \(message ?? "")"
         case .tooManyRulesException(let message):
-            return "TooManyRulesException: \(message ?? "")"
+            return "TooManyRules: \(message ?? "")"
         case .tooManyTagsException(let message):
-            return "TooManyTagsException: \(message ?? "")"
+            return "TooManyTags: \(message ?? "")"
         case .tooManyTargetGroupsException(let message):
-            return "TooManyTargetGroupsException: \(message ?? "")"
+            return "TooManyTargetGroups: \(message ?? "")"
         case .tooManyTargetsException(let message):
-            return "TooManyTargetsException: \(message ?? "")"
+            return "TooManyTargets: \(message ?? "")"
         case .unsupportedProtocolException(let message):
-            return "UnsupportedProtocolException: \(message ?? "")"
+            return "UnsupportedProtocol: \(message ?? "")"
         }
     }
 }

--- a/Sources/AWSSDKSwift/Services/ElastiCache/ElastiCache_Error.swift
+++ b/Sources/AWSSDKSwift/Services/ElastiCache/ElastiCache_Error.swift
@@ -63,59 +63,59 @@ extension ElastiCacheErrorType {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
         switch errorCode {
-        case "APICallRateForCustomerExceededFault":
+        case "APICallRateForCustomerExceeded":
             self = .aPICallRateForCustomerExceededFault(message: message)
-        case "AuthorizationAlreadyExistsFault":
+        case "AuthorizationAlreadyExists":
             self = .authorizationAlreadyExistsFault(message: message)
-        case "AuthorizationNotFoundFault":
+        case "AuthorizationNotFound":
             self = .authorizationNotFoundFault(message: message)
-        case "CacheClusterAlreadyExistsFault":
+        case "CacheClusterAlreadyExists":
             self = .cacheClusterAlreadyExistsFault(message: message)
-        case "CacheClusterNotFoundFault":
+        case "CacheClusterNotFound":
             self = .cacheClusterNotFoundFault(message: message)
-        case "CacheParameterGroupAlreadyExistsFault":
+        case "CacheParameterGroupAlreadyExists":
             self = .cacheParameterGroupAlreadyExistsFault(message: message)
-        case "CacheParameterGroupNotFoundFault":
+        case "CacheParameterGroupNotFound":
             self = .cacheParameterGroupNotFoundFault(message: message)
-        case "CacheParameterGroupQuotaExceededFault":
+        case "CacheParameterGroupQuotaExceeded":
             self = .cacheParameterGroupQuotaExceededFault(message: message)
-        case "CacheSecurityGroupAlreadyExistsFault":
+        case "CacheSecurityGroupAlreadyExists":
             self = .cacheSecurityGroupAlreadyExistsFault(message: message)
-        case "CacheSecurityGroupNotFoundFault":
+        case "CacheSecurityGroupNotFound":
             self = .cacheSecurityGroupNotFoundFault(message: message)
-        case "CacheSecurityGroupQuotaExceededFault":
+        case "QuotaExceeded.CacheSecurityGroup":
             self = .cacheSecurityGroupQuotaExceededFault(message: message)
-        case "CacheSubnetGroupAlreadyExistsFault":
+        case "CacheSubnetGroupAlreadyExists":
             self = .cacheSubnetGroupAlreadyExistsFault(message: message)
         case "CacheSubnetGroupInUse":
             self = .cacheSubnetGroupInUse(message: message)
         case "CacheSubnetGroupNotFoundFault":
             self = .cacheSubnetGroupNotFoundFault(message: message)
-        case "CacheSubnetGroupQuotaExceededFault":
+        case "CacheSubnetGroupQuotaExceeded":
             self = .cacheSubnetGroupQuotaExceededFault(message: message)
         case "CacheSubnetQuotaExceededFault":
             self = .cacheSubnetQuotaExceededFault(message: message)
-        case "ClusterQuotaForCustomerExceededFault":
+        case "ClusterQuotaForCustomerExceeded":
             self = .clusterQuotaForCustomerExceededFault(message: message)
-        case "InsufficientCacheClusterCapacityFault":
+        case "InsufficientCacheClusterCapacity":
             self = .insufficientCacheClusterCapacityFault(message: message)
-        case "InvalidARNFault":
+        case "InvalidARN":
             self = .invalidARNFault(message: message)
-        case "InvalidCacheClusterStateFault":
+        case "InvalidCacheClusterState":
             self = .invalidCacheClusterStateFault(message: message)
-        case "InvalidCacheParameterGroupStateFault":
+        case "InvalidCacheParameterGroupState":
             self = .invalidCacheParameterGroupStateFault(message: message)
-        case "InvalidCacheSecurityGroupStateFault":
+        case "InvalidCacheSecurityGroupState":
             self = .invalidCacheSecurityGroupStateFault(message: message)
         case "InvalidKMSKeyFault":
             self = .invalidKMSKeyFault(message: message)
-        case "InvalidParameterCombinationException":
+        case "InvalidParameterCombination":
             self = .invalidParameterCombinationException(message: message)
-        case "InvalidParameterValueException":
+        case "InvalidParameterValue":
             self = .invalidParameterValueException(message: message)
-        case "InvalidReplicationGroupStateFault":
+        case "InvalidReplicationGroupState":
             self = .invalidReplicationGroupStateFault(message: message)
-        case "InvalidSnapshotStateFault":
+        case "InvalidSnapshotState":
             self = .invalidSnapshotStateFault(message: message)
         case "InvalidSubnet":
             self = .invalidSubnet(message: message)
@@ -125,23 +125,23 @@ extension ElastiCacheErrorType {
             self = .noOperationFault(message: message)
         case "NodeGroupNotFoundFault":
             self = .nodeGroupNotFoundFault(message: message)
-        case "NodeGroupsPerReplicationGroupQuotaExceededFault":
+        case "NodeGroupsPerReplicationGroupQuotaExceeded":
             self = .nodeGroupsPerReplicationGroupQuotaExceededFault(message: message)
-        case "NodeQuotaForClusterExceededFault":
+        case "NodeQuotaForClusterExceeded":
             self = .nodeQuotaForClusterExceededFault(message: message)
-        case "NodeQuotaForCustomerExceededFault":
+        case "NodeQuotaForCustomerExceeded":
             self = .nodeQuotaForCustomerExceededFault(message: message)
-        case "ReplicationGroupAlreadyExistsFault":
+        case "ReplicationGroupAlreadyExists":
             self = .replicationGroupAlreadyExistsFault(message: message)
         case "ReplicationGroupNotFoundFault":
             self = .replicationGroupNotFoundFault(message: message)
-        case "ReservedCacheNodeAlreadyExistsFault":
+        case "ReservedCacheNodeAlreadyExists":
             self = .reservedCacheNodeAlreadyExistsFault(message: message)
-        case "ReservedCacheNodeNotFoundFault":
+        case "ReservedCacheNodeNotFound":
             self = .reservedCacheNodeNotFoundFault(message: message)
-        case "ReservedCacheNodeQuotaExceededFault":
+        case "ReservedCacheNodeQuotaExceeded":
             self = .reservedCacheNodeQuotaExceededFault(message: message)
-        case "ReservedCacheNodesOfferingNotFoundFault":
+        case "ReservedCacheNodesOfferingNotFound":
             self = .reservedCacheNodesOfferingNotFoundFault(message: message)
         case "ServiceLinkedRoleNotFoundFault":
             self = .serviceLinkedRoleNotFoundFault(message: message)
@@ -157,7 +157,7 @@ extension ElastiCacheErrorType {
             self = .snapshotQuotaExceededFault(message: message)
         case "SubnetInUse":
             self = .subnetInUse(message: message)
-        case "TagNotFoundFault":
+        case "TagNotFound":
             self = .tagNotFoundFault(message: message)
         case "TagQuotaPerResourceExceeded":
             self = .tagQuotaPerResourceExceeded(message: message)
@@ -173,59 +173,59 @@ extension ElastiCacheErrorType : CustomStringConvertible {
     public var description : String {
         switch self {
         case .aPICallRateForCustomerExceededFault(let message):
-            return "APICallRateForCustomerExceededFault: \(message ?? "")"
+            return "APICallRateForCustomerExceeded: \(message ?? "")"
         case .authorizationAlreadyExistsFault(let message):
-            return "AuthorizationAlreadyExistsFault: \(message ?? "")"
+            return "AuthorizationAlreadyExists: \(message ?? "")"
         case .authorizationNotFoundFault(let message):
-            return "AuthorizationNotFoundFault: \(message ?? "")"
+            return "AuthorizationNotFound: \(message ?? "")"
         case .cacheClusterAlreadyExistsFault(let message):
-            return "CacheClusterAlreadyExistsFault: \(message ?? "")"
+            return "CacheClusterAlreadyExists: \(message ?? "")"
         case .cacheClusterNotFoundFault(let message):
-            return "CacheClusterNotFoundFault: \(message ?? "")"
+            return "CacheClusterNotFound: \(message ?? "")"
         case .cacheParameterGroupAlreadyExistsFault(let message):
-            return "CacheParameterGroupAlreadyExistsFault: \(message ?? "")"
+            return "CacheParameterGroupAlreadyExists: \(message ?? "")"
         case .cacheParameterGroupNotFoundFault(let message):
-            return "CacheParameterGroupNotFoundFault: \(message ?? "")"
+            return "CacheParameterGroupNotFound: \(message ?? "")"
         case .cacheParameterGroupQuotaExceededFault(let message):
-            return "CacheParameterGroupQuotaExceededFault: \(message ?? "")"
+            return "CacheParameterGroupQuotaExceeded: \(message ?? "")"
         case .cacheSecurityGroupAlreadyExistsFault(let message):
-            return "CacheSecurityGroupAlreadyExistsFault: \(message ?? "")"
+            return "CacheSecurityGroupAlreadyExists: \(message ?? "")"
         case .cacheSecurityGroupNotFoundFault(let message):
-            return "CacheSecurityGroupNotFoundFault: \(message ?? "")"
+            return "CacheSecurityGroupNotFound: \(message ?? "")"
         case .cacheSecurityGroupQuotaExceededFault(let message):
-            return "CacheSecurityGroupQuotaExceededFault: \(message ?? "")"
+            return "QuotaExceeded.CacheSecurityGroup: \(message ?? "")"
         case .cacheSubnetGroupAlreadyExistsFault(let message):
-            return "CacheSubnetGroupAlreadyExistsFault: \(message ?? "")"
+            return "CacheSubnetGroupAlreadyExists: \(message ?? "")"
         case .cacheSubnetGroupInUse(let message):
             return "CacheSubnetGroupInUse: \(message ?? "")"
         case .cacheSubnetGroupNotFoundFault(let message):
             return "CacheSubnetGroupNotFoundFault: \(message ?? "")"
         case .cacheSubnetGroupQuotaExceededFault(let message):
-            return "CacheSubnetGroupQuotaExceededFault: \(message ?? "")"
+            return "CacheSubnetGroupQuotaExceeded: \(message ?? "")"
         case .cacheSubnetQuotaExceededFault(let message):
             return "CacheSubnetQuotaExceededFault: \(message ?? "")"
         case .clusterQuotaForCustomerExceededFault(let message):
-            return "ClusterQuotaForCustomerExceededFault: \(message ?? "")"
+            return "ClusterQuotaForCustomerExceeded: \(message ?? "")"
         case .insufficientCacheClusterCapacityFault(let message):
-            return "InsufficientCacheClusterCapacityFault: \(message ?? "")"
+            return "InsufficientCacheClusterCapacity: \(message ?? "")"
         case .invalidARNFault(let message):
-            return "InvalidARNFault: \(message ?? "")"
+            return "InvalidARN: \(message ?? "")"
         case .invalidCacheClusterStateFault(let message):
-            return "InvalidCacheClusterStateFault: \(message ?? "")"
+            return "InvalidCacheClusterState: \(message ?? "")"
         case .invalidCacheParameterGroupStateFault(let message):
-            return "InvalidCacheParameterGroupStateFault: \(message ?? "")"
+            return "InvalidCacheParameterGroupState: \(message ?? "")"
         case .invalidCacheSecurityGroupStateFault(let message):
-            return "InvalidCacheSecurityGroupStateFault: \(message ?? "")"
+            return "InvalidCacheSecurityGroupState: \(message ?? "")"
         case .invalidKMSKeyFault(let message):
             return "InvalidKMSKeyFault: \(message ?? "")"
         case .invalidParameterCombinationException(let message):
-            return "InvalidParameterCombinationException: \(message ?? "")"
+            return "InvalidParameterCombination: \(message ?? "")"
         case .invalidParameterValueException(let message):
-            return "InvalidParameterValueException: \(message ?? "")"
+            return "InvalidParameterValue: \(message ?? "")"
         case .invalidReplicationGroupStateFault(let message):
-            return "InvalidReplicationGroupStateFault: \(message ?? "")"
+            return "InvalidReplicationGroupState: \(message ?? "")"
         case .invalidSnapshotStateFault(let message):
-            return "InvalidSnapshotStateFault: \(message ?? "")"
+            return "InvalidSnapshotState: \(message ?? "")"
         case .invalidSubnet(let message):
             return "InvalidSubnet: \(message ?? "")"
         case .invalidVPCNetworkStateFault(let message):
@@ -235,23 +235,23 @@ extension ElastiCacheErrorType : CustomStringConvertible {
         case .nodeGroupNotFoundFault(let message):
             return "NodeGroupNotFoundFault: \(message ?? "")"
         case .nodeGroupsPerReplicationGroupQuotaExceededFault(let message):
-            return "NodeGroupsPerReplicationGroupQuotaExceededFault: \(message ?? "")"
+            return "NodeGroupsPerReplicationGroupQuotaExceeded: \(message ?? "")"
         case .nodeQuotaForClusterExceededFault(let message):
-            return "NodeQuotaForClusterExceededFault: \(message ?? "")"
+            return "NodeQuotaForClusterExceeded: \(message ?? "")"
         case .nodeQuotaForCustomerExceededFault(let message):
-            return "NodeQuotaForCustomerExceededFault: \(message ?? "")"
+            return "NodeQuotaForCustomerExceeded: \(message ?? "")"
         case .replicationGroupAlreadyExistsFault(let message):
-            return "ReplicationGroupAlreadyExistsFault: \(message ?? "")"
+            return "ReplicationGroupAlreadyExists: \(message ?? "")"
         case .replicationGroupNotFoundFault(let message):
             return "ReplicationGroupNotFoundFault: \(message ?? "")"
         case .reservedCacheNodeAlreadyExistsFault(let message):
-            return "ReservedCacheNodeAlreadyExistsFault: \(message ?? "")"
+            return "ReservedCacheNodeAlreadyExists: \(message ?? "")"
         case .reservedCacheNodeNotFoundFault(let message):
-            return "ReservedCacheNodeNotFoundFault: \(message ?? "")"
+            return "ReservedCacheNodeNotFound: \(message ?? "")"
         case .reservedCacheNodeQuotaExceededFault(let message):
-            return "ReservedCacheNodeQuotaExceededFault: \(message ?? "")"
+            return "ReservedCacheNodeQuotaExceeded: \(message ?? "")"
         case .reservedCacheNodesOfferingNotFoundFault(let message):
-            return "ReservedCacheNodesOfferingNotFoundFault: \(message ?? "")"
+            return "ReservedCacheNodesOfferingNotFound: \(message ?? "")"
         case .serviceLinkedRoleNotFoundFault(let message):
             return "ServiceLinkedRoleNotFoundFault: \(message ?? "")"
         case .serviceUpdateNotFoundFault(let message):
@@ -267,7 +267,7 @@ extension ElastiCacheErrorType : CustomStringConvertible {
         case .subnetInUse(let message):
             return "SubnetInUse: \(message ?? "")"
         case .tagNotFoundFault(let message):
-            return "TagNotFoundFault: \(message ?? "")"
+            return "TagNotFound: \(message ?? "")"
         case .tagQuotaPerResourceExceeded(let message):
             return "TagQuotaPerResourceExceeded: \(message ?? "")"
         case .testFailoverNotAvailableFault(let message):

--- a/Sources/AWSSDKSwift/Services/ElasticBeanstalk/ElasticBeanstalk_Error.swift
+++ b/Sources/AWSSDKSwift/Services/ElasticBeanstalk/ElasticBeanstalk_Error.swift
@@ -42,7 +42,7 @@ extension ElasticBeanstalkErrorType {
             self = .invalidRequestException(message: message)
         case "ManagedActionInvalidStateException":
             self = .managedActionInvalidStateException(message: message)
-        case "OperationInProgressException":
+        case "OperationInProgressFailure":
             self = .operationInProgressException(message: message)
         case "PlatformVersionStillReferencedException":
             self = .platformVersionStillReferencedException(message: message)
@@ -54,7 +54,7 @@ extension ElasticBeanstalkErrorType {
             self = .s3LocationNotInServiceRegionException(message: message)
         case "S3SubscriptionRequiredException":
             self = .s3SubscriptionRequiredException(message: message)
-        case "SourceBundleDeletionException":
+        case "SourceBundleDeletionFailure":
             self = .sourceBundleDeletionException(message: message)
         case "TooManyApplicationVersionsException":
             self = .tooManyApplicationVersionsException(message: message)
@@ -90,7 +90,7 @@ extension ElasticBeanstalkErrorType : CustomStringConvertible {
         case .managedActionInvalidStateException(let message):
             return "ManagedActionInvalidStateException: \(message ?? "")"
         case .operationInProgressException(let message):
-            return "OperationInProgressException: \(message ?? "")"
+            return "OperationInProgressFailure: \(message ?? "")"
         case .platformVersionStillReferencedException(let message):
             return "PlatformVersionStillReferencedException: \(message ?? "")"
         case .resourceNotFoundException(let message):
@@ -102,7 +102,7 @@ extension ElasticBeanstalkErrorType : CustomStringConvertible {
         case .s3SubscriptionRequiredException(let message):
             return "S3SubscriptionRequiredException: \(message ?? "")"
         case .sourceBundleDeletionException(let message):
-            return "SourceBundleDeletionException: \(message ?? "")"
+            return "SourceBundleDeletionFailure: \(message ?? "")"
         case .tooManyApplicationVersionsException(let message):
             return "TooManyApplicationVersionsException: \(message ?? "")"
         case .tooManyApplicationsException(let message):

--- a/Sources/AWSSDKSwift/Services/IAM/IAM_Error.swift
+++ b/Sources/AWSSDKSwift/Services/IAM/IAM_Error.swift
@@ -40,59 +40,59 @@ extension IAMErrorType {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
         switch errorCode {
-        case "ConcurrentModificationException":
+        case "ConcurrentModification":
             self = .concurrentModificationException(message: message)
-        case "CredentialReportExpiredException":
+        case "ReportExpired":
             self = .credentialReportExpiredException(message: message)
-        case "CredentialReportNotPresentException":
+        case "ReportNotPresent":
             self = .credentialReportNotPresentException(message: message)
-        case "CredentialReportNotReadyException":
+        case "ReportInProgress":
             self = .credentialReportNotReadyException(message: message)
-        case "DeleteConflictException":
+        case "DeleteConflict":
             self = .deleteConflictException(message: message)
-        case "DuplicateCertificateException":
+        case "DuplicateCertificate":
             self = .duplicateCertificateException(message: message)
-        case "DuplicateSSHPublicKeyException":
+        case "DuplicateSSHPublicKey":
             self = .duplicateSSHPublicKeyException(message: message)
-        case "EntityAlreadyExistsException":
+        case "EntityAlreadyExists":
             self = .entityAlreadyExistsException(message: message)
-        case "EntityTemporarilyUnmodifiableException":
+        case "EntityTemporarilyUnmodifiable":
             self = .entityTemporarilyUnmodifiableException(message: message)
-        case "InvalidAuthenticationCodeException":
+        case "InvalidAuthenticationCode":
             self = .invalidAuthenticationCodeException(message: message)
-        case "InvalidCertificateException":
+        case "InvalidCertificate":
             self = .invalidCertificateException(message: message)
-        case "InvalidInputException":
+        case "InvalidInput":
             self = .invalidInputException(message: message)
-        case "InvalidPublicKeyException":
+        case "InvalidPublicKey":
             self = .invalidPublicKeyException(message: message)
-        case "InvalidUserTypeException":
+        case "InvalidUserType":
             self = .invalidUserTypeException(message: message)
-        case "KeyPairMismatchException":
+        case "KeyPairMismatch":
             self = .keyPairMismatchException(message: message)
-        case "LimitExceededException":
+        case "LimitExceeded":
             self = .limitExceededException(message: message)
-        case "MalformedCertificateException":
+        case "MalformedCertificate":
             self = .malformedCertificateException(message: message)
-        case "MalformedPolicyDocumentException":
+        case "MalformedPolicyDocument":
             self = .malformedPolicyDocumentException(message: message)
-        case "NoSuchEntityException":
+        case "NoSuchEntity":
             self = .noSuchEntityException(message: message)
-        case "PasswordPolicyViolationException":
+        case "PasswordPolicyViolation":
             self = .passwordPolicyViolationException(message: message)
-        case "PolicyEvaluationException":
+        case "PolicyEvaluation":
             self = .policyEvaluationException(message: message)
-        case "PolicyNotAttachableException":
+        case "PolicyNotAttachable":
             self = .policyNotAttachableException(message: message)
-        case "ReportGenerationLimitExceededException":
+        case "ReportGenerationLimitExceeded":
             self = .reportGenerationLimitExceededException(message: message)
-        case "ServiceFailureException":
+        case "ServiceFailure":
             self = .serviceFailureException(message: message)
-        case "ServiceNotSupportedException":
+        case "NotSupportedService":
             self = .serviceNotSupportedException(message: message)
-        case "UnmodifiableEntityException":
+        case "UnmodifiableEntity":
             self = .unmodifiableEntityException(message: message)
-        case "UnrecognizedPublicKeyEncodingException":
+        case "UnrecognizedPublicKeyEncoding":
             self = .unrecognizedPublicKeyEncodingException(message: message)
         default:
             return nil
@@ -104,59 +104,59 @@ extension IAMErrorType : CustomStringConvertible {
     public var description : String {
         switch self {
         case .concurrentModificationException(let message):
-            return "ConcurrentModificationException: \(message ?? "")"
+            return "ConcurrentModification: \(message ?? "")"
         case .credentialReportExpiredException(let message):
-            return "CredentialReportExpiredException: \(message ?? "")"
+            return "ReportExpired: \(message ?? "")"
         case .credentialReportNotPresentException(let message):
-            return "CredentialReportNotPresentException: \(message ?? "")"
+            return "ReportNotPresent: \(message ?? "")"
         case .credentialReportNotReadyException(let message):
-            return "CredentialReportNotReadyException: \(message ?? "")"
+            return "ReportInProgress: \(message ?? "")"
         case .deleteConflictException(let message):
-            return "DeleteConflictException: \(message ?? "")"
+            return "DeleteConflict: \(message ?? "")"
         case .duplicateCertificateException(let message):
-            return "DuplicateCertificateException: \(message ?? "")"
+            return "DuplicateCertificate: \(message ?? "")"
         case .duplicateSSHPublicKeyException(let message):
-            return "DuplicateSSHPublicKeyException: \(message ?? "")"
+            return "DuplicateSSHPublicKey: \(message ?? "")"
         case .entityAlreadyExistsException(let message):
-            return "EntityAlreadyExistsException: \(message ?? "")"
+            return "EntityAlreadyExists: \(message ?? "")"
         case .entityTemporarilyUnmodifiableException(let message):
-            return "EntityTemporarilyUnmodifiableException: \(message ?? "")"
+            return "EntityTemporarilyUnmodifiable: \(message ?? "")"
         case .invalidAuthenticationCodeException(let message):
-            return "InvalidAuthenticationCodeException: \(message ?? "")"
+            return "InvalidAuthenticationCode: \(message ?? "")"
         case .invalidCertificateException(let message):
-            return "InvalidCertificateException: \(message ?? "")"
+            return "InvalidCertificate: \(message ?? "")"
         case .invalidInputException(let message):
-            return "InvalidInputException: \(message ?? "")"
+            return "InvalidInput: \(message ?? "")"
         case .invalidPublicKeyException(let message):
-            return "InvalidPublicKeyException: \(message ?? "")"
+            return "InvalidPublicKey: \(message ?? "")"
         case .invalidUserTypeException(let message):
-            return "InvalidUserTypeException: \(message ?? "")"
+            return "InvalidUserType: \(message ?? "")"
         case .keyPairMismatchException(let message):
-            return "KeyPairMismatchException: \(message ?? "")"
+            return "KeyPairMismatch: \(message ?? "")"
         case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
+            return "LimitExceeded: \(message ?? "")"
         case .malformedCertificateException(let message):
-            return "MalformedCertificateException: \(message ?? "")"
+            return "MalformedCertificate: \(message ?? "")"
         case .malformedPolicyDocumentException(let message):
-            return "MalformedPolicyDocumentException: \(message ?? "")"
+            return "MalformedPolicyDocument: \(message ?? "")"
         case .noSuchEntityException(let message):
-            return "NoSuchEntityException: \(message ?? "")"
+            return "NoSuchEntity: \(message ?? "")"
         case .passwordPolicyViolationException(let message):
-            return "PasswordPolicyViolationException: \(message ?? "")"
+            return "PasswordPolicyViolation: \(message ?? "")"
         case .policyEvaluationException(let message):
-            return "PolicyEvaluationException: \(message ?? "")"
+            return "PolicyEvaluation: \(message ?? "")"
         case .policyNotAttachableException(let message):
-            return "PolicyNotAttachableException: \(message ?? "")"
+            return "PolicyNotAttachable: \(message ?? "")"
         case .reportGenerationLimitExceededException(let message):
-            return "ReportGenerationLimitExceededException: \(message ?? "")"
+            return "ReportGenerationLimitExceeded: \(message ?? "")"
         case .serviceFailureException(let message):
-            return "ServiceFailureException: \(message ?? "")"
+            return "ServiceFailure: \(message ?? "")"
         case .serviceNotSupportedException(let message):
-            return "ServiceNotSupportedException: \(message ?? "")"
+            return "NotSupportedService: \(message ?? "")"
         case .unmodifiableEntityException(let message):
-            return "UnmodifiableEntityException: \(message ?? "")"
+            return "UnmodifiableEntity: \(message ?? "")"
         case .unrecognizedPublicKeyEncodingException(let message):
-            return "UnrecognizedPublicKeyEncodingException: \(message ?? "")"
+            return "UnrecognizedPublicKeyEncoding: \(message ?? "")"
         }
     }
 }

--- a/Sources/AWSSDKSwift/Services/Kafka/Kafka_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/Kafka/Kafka_Shapes.swift
@@ -12,15 +12,15 @@ extension Kafka {
 
     public struct BrokerEBSVolumeInfo: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "KafkaBrokerNodeId", location: .body(locationName: "kafkaBrokerNodeId"), required: true, type: .string),
+            AWSShapeMember(label: "KafkaBrokerNodeId", location: .body(locationName: "kafkaBrokerNodeId"), required: true, type: .string), 
             AWSShapeMember(label: "VolumeSizeGB", location: .body(locationName: "volumeSizeGB"), required: true, type: .integer)
         ]
 
         ///             The ID of the broker to update.
-        ///
+        ///          
         public let kafkaBrokerNodeId: String
         ///             Size of the EBS volume to update.
-        ///
+        ///          
         public let volumeSizeGB: Int
 
         public init(kafkaBrokerNodeId: String, volumeSizeGB: Int) {
@@ -36,29 +36,29 @@ extension Kafka {
 
     public struct BrokerNodeGroupInfo: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "BrokerAZDistribution", location: .body(locationName: "brokerAZDistribution"), required: false, type: .enum),
-            AWSShapeMember(label: "ClientSubnets", location: .body(locationName: "clientSubnets"), required: true, type: .list),
-            AWSShapeMember(label: "InstanceType", location: .body(locationName: "instanceType"), required: true, type: .string),
-            AWSShapeMember(label: "SecurityGroups", location: .body(locationName: "securityGroups"), required: false, type: .list),
+            AWSShapeMember(label: "BrokerAZDistribution", location: .body(locationName: "brokerAZDistribution"), required: false, type: .enum), 
+            AWSShapeMember(label: "ClientSubnets", location: .body(locationName: "clientSubnets"), required: true, type: .list), 
+            AWSShapeMember(label: "InstanceType", location: .body(locationName: "instanceType"), required: true, type: .string), 
+            AWSShapeMember(label: "SecurityGroups", location: .body(locationName: "securityGroups"), required: false, type: .list), 
             AWSShapeMember(label: "StorageInfo", location: .body(locationName: "storageInfo"), required: false, type: .structure)
         ]
 
         ///             The distribution of broker nodes across Availability Zones. This is an optional parameter. If you don't specify it, Amazon MSK gives it the value DEFAULT. You can also explicitly set this parameter to the value DEFAULT. No other values are currently allowed.
         ///          Amazon MSK distributes the broker nodes evenly across the Availability Zones that correspond to the subnets you provide when you create the cluster.
-        ///
+        ///          
         public let brokerAZDistribution: BrokerAZDistribution?
         ///             The list of subnets to connect to in the client virtual private cloud (VPC). AWS creates elastic network interfaces inside these subnets. Client applications use elastic network interfaces to produce and consume data. Client subnets can't be in Availability Zone us-east-1e.
-        ///
+        ///          
         public let clientSubnets: [String]
         ///             The type of Amazon EC2 instances to use for Kafka brokers. The following instance types are allowed: kafka.m5.large, kafka.m5.xlarge, kafka.m5.2xlarge,
         /// kafka.m5.4xlarge, kafka.m5.12xlarge, and kafka.m5.24xlarge.
-        ///
+        ///          
         public let instanceType: String
         ///             The AWS security groups to associate with the elastic network interfaces in order to specify who can connect to and communicate with the Amazon MSK cluster. If you don't specify a security group, Amazon MSK uses the default security group associated with the VPC.
-        ///
+        ///          
         public let securityGroups: [String]?
         ///             Contains information about storage volumes attached to MSK broker nodes.
-        ///
+        ///          
         public let storageInfo: StorageInfo?
 
         public init(brokerAZDistribution: BrokerAZDistribution? = nil, clientSubnets: [String], instanceType: String, securityGroups: [String]? = nil, storageInfo: StorageInfo? = nil) {
@@ -86,31 +86,31 @@ extension Kafka {
 
     public struct BrokerNodeInfo: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "AttachedENIId", location: .body(locationName: "attachedENIId"), required: false, type: .string),
-            AWSShapeMember(label: "BrokerId", location: .body(locationName: "brokerId"), required: false, type: .double),
-            AWSShapeMember(label: "ClientSubnet", location: .body(locationName: "clientSubnet"), required: false, type: .string),
-            AWSShapeMember(label: "ClientVpcIpAddress", location: .body(locationName: "clientVpcIpAddress"), required: false, type: .string),
-            AWSShapeMember(label: "CurrentBrokerSoftwareInfo", location: .body(locationName: "currentBrokerSoftwareInfo"), required: false, type: .structure),
+            AWSShapeMember(label: "AttachedENIId", location: .body(locationName: "attachedENIId"), required: false, type: .string), 
+            AWSShapeMember(label: "BrokerId", location: .body(locationName: "brokerId"), required: false, type: .double), 
+            AWSShapeMember(label: "ClientSubnet", location: .body(locationName: "clientSubnet"), required: false, type: .string), 
+            AWSShapeMember(label: "ClientVpcIpAddress", location: .body(locationName: "clientVpcIpAddress"), required: false, type: .string), 
+            AWSShapeMember(label: "CurrentBrokerSoftwareInfo", location: .body(locationName: "currentBrokerSoftwareInfo"), required: false, type: .structure), 
             AWSShapeMember(label: "Endpoints", location: .body(locationName: "endpoints"), required: false, type: .list)
         ]
 
         ///             The attached elastic network interface of the broker.
-        ///
+        ///          
         public let attachedENIId: String?
         ///             The ID of the broker.
-        ///
+        ///          
         public let brokerId: Double?
         ///             The client subnet to which this broker node belongs.
-        ///
+        ///          
         public let clientSubnet: String?
         ///             The virtual private cloud (VPC) of the client.
-        ///
+        ///          
         public let clientVpcIpAddress: String?
         ///             Information about the version of software currently deployed on the Kafka brokers in the cluster.
-        ///
+        ///          
         public let currentBrokerSoftwareInfo: BrokerSoftwareInfo?
         ///             Endpoints for accessing the broker.
-        ///
+        ///          
         public let endpoints: [String]?
 
         public init(attachedENIId: String? = nil, brokerId: Double? = nil, clientSubnet: String? = nil, clientVpcIpAddress: String? = nil, currentBrokerSoftwareInfo: BrokerSoftwareInfo? = nil, endpoints: [String]? = nil) {
@@ -134,19 +134,19 @@ extension Kafka {
 
     public struct BrokerSoftwareInfo: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "ConfigurationArn", location: .body(locationName: "configurationArn"), required: false, type: .string),
-            AWSShapeMember(label: "ConfigurationRevision", location: .body(locationName: "configurationRevision"), required: false, type: .long),
+            AWSShapeMember(label: "ConfigurationArn", location: .body(locationName: "configurationArn"), required: false, type: .string), 
+            AWSShapeMember(label: "ConfigurationRevision", location: .body(locationName: "configurationRevision"), required: false, type: .long), 
             AWSShapeMember(label: "KafkaVersion", location: .body(locationName: "kafkaVersion"), required: false, type: .string)
         ]
 
         ///             The Amazon Resource Name (ARN) of the configuration used for the cluster. This field isn't visible in this preview release.
-        ///
+        ///          
         public let configurationArn: String?
         ///             The revision of the configuration to use. This field isn't visible in this preview release.
-        ///
+        ///          
         public let configurationRevision: Int64?
         ///             The version of Apache Kafka.
-        ///
+        ///          
         public let kafkaVersion: String?
 
         public init(configurationArn: String? = nil, configurationRevision: Int64? = nil, kafkaVersion: String? = nil) {
@@ -168,7 +168,7 @@ extension Kafka {
         ]
 
         ///             Details for ClientAuthentication using TLS.
-        ///
+        ///          
         public let tls: Tls?
 
         public init(tls: Tls? = nil) {
@@ -189,62 +189,62 @@ extension Kafka {
 
     public struct ClusterInfo: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "ActiveOperationArn", location: .body(locationName: "activeOperationArn"), required: false, type: .string),
-            AWSShapeMember(label: "BrokerNodeGroupInfo", location: .body(locationName: "brokerNodeGroupInfo"), required: false, type: .structure),
-            AWSShapeMember(label: "ClientAuthentication", location: .body(locationName: "clientAuthentication"), required: false, type: .structure),
-            AWSShapeMember(label: "ClusterArn", location: .body(locationName: "clusterArn"), required: false, type: .string),
-            AWSShapeMember(label: "ClusterName", location: .body(locationName: "clusterName"), required: false, type: .string),
-            AWSShapeMember(label: "CreationTime", location: .body(locationName: "creationTime"), required: false, type: .timestamp),
-            AWSShapeMember(label: "CurrentBrokerSoftwareInfo", location: .body(locationName: "currentBrokerSoftwareInfo"), required: false, type: .structure),
-            AWSShapeMember(label: "CurrentVersion", location: .body(locationName: "currentVersion"), required: false, type: .string),
-            AWSShapeMember(label: "EncryptionInfo", location: .body(locationName: "encryptionInfo"), required: false, type: .structure),
-            AWSShapeMember(label: "EnhancedMonitoring", location: .body(locationName: "enhancedMonitoring"), required: false, type: .enum),
-            AWSShapeMember(label: "NumberOfBrokerNodes", location: .body(locationName: "numberOfBrokerNodes"), required: false, type: .integer),
-            AWSShapeMember(label: "State", location: .body(locationName: "state"), required: false, type: .enum),
-            AWSShapeMember(label: "Tags", location: .body(locationName: "tags"), required: false, type: .map),
+            AWSShapeMember(label: "ActiveOperationArn", location: .body(locationName: "activeOperationArn"), required: false, type: .string), 
+            AWSShapeMember(label: "BrokerNodeGroupInfo", location: .body(locationName: "brokerNodeGroupInfo"), required: false, type: .structure), 
+            AWSShapeMember(label: "ClientAuthentication", location: .body(locationName: "clientAuthentication"), required: false, type: .structure), 
+            AWSShapeMember(label: "ClusterArn", location: .body(locationName: "clusterArn"), required: false, type: .string), 
+            AWSShapeMember(label: "ClusterName", location: .body(locationName: "clusterName"), required: false, type: .string), 
+            AWSShapeMember(label: "CreationTime", location: .body(locationName: "creationTime"), required: false, type: .timestamp), 
+            AWSShapeMember(label: "CurrentBrokerSoftwareInfo", location: .body(locationName: "currentBrokerSoftwareInfo"), required: false, type: .structure), 
+            AWSShapeMember(label: "CurrentVersion", location: .body(locationName: "currentVersion"), required: false, type: .string), 
+            AWSShapeMember(label: "EncryptionInfo", location: .body(locationName: "encryptionInfo"), required: false, type: .structure), 
+            AWSShapeMember(label: "EnhancedMonitoring", location: .body(locationName: "enhancedMonitoring"), required: false, type: .enum), 
+            AWSShapeMember(label: "NumberOfBrokerNodes", location: .body(locationName: "numberOfBrokerNodes"), required: false, type: .integer), 
+            AWSShapeMember(label: "State", location: .body(locationName: "state"), required: false, type: .enum), 
+            AWSShapeMember(label: "Tags", location: .body(locationName: "tags"), required: false, type: .map), 
             AWSShapeMember(label: "ZookeeperConnectString", location: .body(locationName: "zookeeperConnectString"), required: false, type: .string)
         ]
 
         ///             Arn of active cluster operation.
-        ///
+        ///          
         public let activeOperationArn: String?
         ///             Information about the broker nodes.
-        ///
+        ///          
         public let brokerNodeGroupInfo: BrokerNodeGroupInfo?
         ///             Includes all client authentication information.
-        ///
+        ///          
         public let clientAuthentication: ClientAuthentication?
         ///             The Amazon Resource Name (ARN) that uniquely identifies the cluster.
-        ///
+        ///          
         public let clusterArn: String?
         ///             The name of the cluster.
-        ///
+        ///          
         public let clusterName: String?
         /// The time when the cluster was created.
         public let creationTime: TimeStamp?
         ///             Information about the version of software currently deployed on the Kafka brokers in the cluster.
-        ///
+        ///          
         public let currentBrokerSoftwareInfo: BrokerSoftwareInfo?
         ///             The current version of the MSK cluster.
-        ///
+        ///          
         public let currentVersion: String?
         ///             Includes all encryption-related information.
-        ///
+        ///          
         public let encryptionInfo: EncryptionInfo?
         ///             Specifies which metrics are gathered for the MSK cluster. This property has three possible values: DEFAULT, PER_BROKER, and PER_TOPIC_PER_BROKER. For a list of the metrics associated with each of these three levels of monitoring, see Monitoring.
-        ///
+        ///          
         public let enhancedMonitoring: EnhancedMonitoring?
         ///             The number of broker nodes in the cluster.
-        ///
+        ///          
         public let numberOfBrokerNodes: Int?
         ///             The state of the cluster. The possible states are CREATING, ACTIVE, and FAILED.
-        ///
+        ///          
         public let state: ClusterState?
         ///             Tags attached to the cluster.
-        ///
+        ///          
         public let tags: [String: String]?
         ///             The connection string to use to connect to the Apache ZooKeeper cluster.
-        ///
+        ///          
         public let zookeeperConnectString: String?
 
         public init(activeOperationArn: String? = nil, brokerNodeGroupInfo: BrokerNodeGroupInfo? = nil, clientAuthentication: ClientAuthentication? = nil, clusterArn: String? = nil, clusterName: String? = nil, creationTime: TimeStamp? = nil, currentBrokerSoftwareInfo: BrokerSoftwareInfo? = nil, currentVersion: String? = nil, encryptionInfo: EncryptionInfo? = nil, enhancedMonitoring: EnhancedMonitoring? = nil, numberOfBrokerNodes: Int? = nil, state: ClusterState? = nil, tags: [String: String]? = nil, zookeeperConnectString: String? = nil) {
@@ -284,45 +284,45 @@ extension Kafka {
 
     public struct ClusterOperationInfo: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "ClientRequestId", location: .body(locationName: "clientRequestId"), required: false, type: .string),
-            AWSShapeMember(label: "ClusterArn", location: .body(locationName: "clusterArn"), required: false, type: .string),
-            AWSShapeMember(label: "CreationTime", location: .body(locationName: "creationTime"), required: false, type: .timestamp),
-            AWSShapeMember(label: "EndTime", location: .body(locationName: "endTime"), required: false, type: .timestamp),
-            AWSShapeMember(label: "ErrorInfo", location: .body(locationName: "errorInfo"), required: false, type: .structure),
-            AWSShapeMember(label: "OperationArn", location: .body(locationName: "operationArn"), required: false, type: .string),
-            AWSShapeMember(label: "OperationState", location: .body(locationName: "operationState"), required: false, type: .string),
-            AWSShapeMember(label: "OperationType", location: .body(locationName: "operationType"), required: false, type: .string),
-            AWSShapeMember(label: "SourceClusterInfo", location: .body(locationName: "sourceClusterInfo"), required: false, type: .structure),
+            AWSShapeMember(label: "ClientRequestId", location: .body(locationName: "clientRequestId"), required: false, type: .string), 
+            AWSShapeMember(label: "ClusterArn", location: .body(locationName: "clusterArn"), required: false, type: .string), 
+            AWSShapeMember(label: "CreationTime", location: .body(locationName: "creationTime"), required: false, type: .timestamp), 
+            AWSShapeMember(label: "EndTime", location: .body(locationName: "endTime"), required: false, type: .timestamp), 
+            AWSShapeMember(label: "ErrorInfo", location: .body(locationName: "errorInfo"), required: false, type: .structure), 
+            AWSShapeMember(label: "OperationArn", location: .body(locationName: "operationArn"), required: false, type: .string), 
+            AWSShapeMember(label: "OperationState", location: .body(locationName: "operationState"), required: false, type: .string), 
+            AWSShapeMember(label: "OperationType", location: .body(locationName: "operationType"), required: false, type: .string), 
+            AWSShapeMember(label: "SourceClusterInfo", location: .body(locationName: "sourceClusterInfo"), required: false, type: .structure), 
             AWSShapeMember(label: "TargetClusterInfo", location: .body(locationName: "targetClusterInfo"), required: false, type: .structure)
         ]
 
         ///             The ID of the API request that triggered this operation.
-        ///
+        ///          
         public let clientRequestId: String?
         ///             ARN of the cluster.
-        ///
+        ///          
         public let clusterArn: String?
         /// The time at which operation was created.
         public let creationTime: TimeStamp?
         /// The time at which the operation finished.
         public let endTime: TimeStamp?
         ///             Describes the error if the operation fails.
-        ///
+        ///          
         public let errorInfo: ErrorInfo?
         ///             ARN of the cluster operation.
-        ///
+        ///          
         public let operationArn: String?
         ///             State of the cluster operation.
-        ///
+        ///          
         public let operationState: String?
         ///             Type of the cluster operation.
-        ///
+        ///          
         public let operationType: String?
         ///             Information about cluster attributes before a cluster is updated.
-        ///
+        ///          
         public let sourceClusterInfo: MutableClusterInfo?
         ///             Information about cluster attributes after a cluster is updated.
-        ///
+        ///          
         public let targetClusterInfo: MutableClusterInfo?
 
         public init(clientRequestId: String? = nil, clusterArn: String? = nil, creationTime: TimeStamp? = nil, endTime: TimeStamp? = nil, errorInfo: ErrorInfo? = nil, operationArn: String? = nil, operationState: String? = nil, operationType: String? = nil, sourceClusterInfo: MutableClusterInfo? = nil, targetClusterInfo: MutableClusterInfo? = nil) {
@@ -363,29 +363,29 @@ extension Kafka {
 
     public struct Configuration: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "Arn", location: .body(locationName: "arn"), required: true, type: .string),
-            AWSShapeMember(label: "CreationTime", location: .body(locationName: "creationTime"), required: true, type: .timestamp),
-            AWSShapeMember(label: "Description", location: .body(locationName: "description"), required: true, type: .string),
-            AWSShapeMember(label: "KafkaVersions", location: .body(locationName: "kafkaVersions"), required: true, type: .list),
-            AWSShapeMember(label: "LatestRevision", location: .body(locationName: "latestRevision"), required: true, type: .structure),
+            AWSShapeMember(label: "Arn", location: .body(locationName: "arn"), required: true, type: .string), 
+            AWSShapeMember(label: "CreationTime", location: .body(locationName: "creationTime"), required: true, type: .timestamp), 
+            AWSShapeMember(label: "Description", location: .body(locationName: "description"), required: true, type: .string), 
+            AWSShapeMember(label: "KafkaVersions", location: .body(locationName: "kafkaVersions"), required: true, type: .list), 
+            AWSShapeMember(label: "LatestRevision", location: .body(locationName: "latestRevision"), required: true, type: .structure), 
             AWSShapeMember(label: "Name", location: .body(locationName: "name"), required: true, type: .string)
         ]
 
         ///             The Amazon Resource Name (ARN) of the configuration.
-        ///
+        ///          
         public let arn: String
         public let creationTime: TimeStamp
         ///             The description of the configuration.
-        ///
+        ///          
         public let description: String
         ///             An array of the versions of Apache Kafka with which you can use this MSK configuration. You can use this configuration for an MSK cluster only if the Apache Kafka version specified for the cluster appears in this array.
-        ///
+        ///          
         public let kafkaVersions: [String]
         ///             Latest revision of the configuration.
-        ///
+        ///          
         public let latestRevision: ConfigurationRevision
         ///             The name of the configuration.
-        ///
+        ///          
         public let name: String
 
         public init(arn: String, creationTime: TimeStamp, description: String, kafkaVersions: [String], latestRevision: ConfigurationRevision, name: String) {
@@ -409,15 +409,15 @@ extension Kafka {
 
     public struct ConfigurationInfo: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "Arn", location: .body(locationName: "arn"), required: true, type: .string),
+            AWSShapeMember(label: "Arn", location: .body(locationName: "arn"), required: true, type: .string), 
             AWSShapeMember(label: "Revision", location: .body(locationName: "revision"), required: true, type: .long)
         ]
 
         ///             ARN of the configuration to use.
-        ///
+        ///          
         public let arn: String
         ///             The revision of the configuration to use.
-        ///
+        ///          
         public let revision: Int64
 
         public init(arn: String, revision: Int64) {
@@ -433,18 +433,18 @@ extension Kafka {
 
     public struct ConfigurationRevision: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "CreationTime", location: .body(locationName: "creationTime"), required: true, type: .timestamp),
-            AWSShapeMember(label: "Description", location: .body(locationName: "description"), required: false, type: .string),
+            AWSShapeMember(label: "CreationTime", location: .body(locationName: "creationTime"), required: true, type: .timestamp), 
+            AWSShapeMember(label: "Description", location: .body(locationName: "description"), required: false, type: .string), 
             AWSShapeMember(label: "Revision", location: .body(locationName: "revision"), required: true, type: .long)
         ]
 
         /// The time when the configuration revision was created.
         public let creationTime: TimeStamp
         ///             The description of the configuration revision.
-        ///
+        ///          
         public let description: String?
         ///             The revision number.
-        ///
+        ///          
         public let revision: Int64
 
         public init(creationTime: TimeStamp, description: String? = nil, revision: Int64) {
@@ -462,43 +462,43 @@ extension Kafka {
 
     public struct CreateClusterRequest: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "BrokerNodeGroupInfo", location: .body(locationName: "brokerNodeGroupInfo"), required: true, type: .structure),
-            AWSShapeMember(label: "ClientAuthentication", location: .body(locationName: "clientAuthentication"), required: false, type: .structure),
-            AWSShapeMember(label: "ClusterName", location: .body(locationName: "clusterName"), required: true, type: .string),
-            AWSShapeMember(label: "ConfigurationInfo", location: .body(locationName: "configurationInfo"), required: false, type: .structure),
-            AWSShapeMember(label: "EncryptionInfo", location: .body(locationName: "encryptionInfo"), required: false, type: .structure),
-            AWSShapeMember(label: "EnhancedMonitoring", location: .body(locationName: "enhancedMonitoring"), required: false, type: .enum),
-            AWSShapeMember(label: "KafkaVersion", location: .body(locationName: "kafkaVersion"), required: true, type: .string),
-            AWSShapeMember(label: "NumberOfBrokerNodes", location: .body(locationName: "numberOfBrokerNodes"), required: true, type: .integer),
+            AWSShapeMember(label: "BrokerNodeGroupInfo", location: .body(locationName: "brokerNodeGroupInfo"), required: true, type: .structure), 
+            AWSShapeMember(label: "ClientAuthentication", location: .body(locationName: "clientAuthentication"), required: false, type: .structure), 
+            AWSShapeMember(label: "ClusterName", location: .body(locationName: "clusterName"), required: true, type: .string), 
+            AWSShapeMember(label: "ConfigurationInfo", location: .body(locationName: "configurationInfo"), required: false, type: .structure), 
+            AWSShapeMember(label: "EncryptionInfo", location: .body(locationName: "encryptionInfo"), required: false, type: .structure), 
+            AWSShapeMember(label: "EnhancedMonitoring", location: .body(locationName: "enhancedMonitoring"), required: false, type: .enum), 
+            AWSShapeMember(label: "KafkaVersion", location: .body(locationName: "kafkaVersion"), required: true, type: .string), 
+            AWSShapeMember(label: "NumberOfBrokerNodes", location: .body(locationName: "numberOfBrokerNodes"), required: true, type: .integer), 
             AWSShapeMember(label: "Tags", location: .body(locationName: "tags"), required: false, type: .map)
         ]
 
         ///             Information about the broker nodes in the cluster.
-        ///
+        ///          
         public let brokerNodeGroupInfo: BrokerNodeGroupInfo
         ///             Includes all client authentication related information.
-        ///
+        ///          
         public let clientAuthentication: ClientAuthentication?
         ///             The name of the cluster.
-        ///
+        ///          
         public let clusterName: String
         ///             Represents the configuration that you want MSK to use for the brokers in a cluster.
-        ///
+        ///          
         public let configurationInfo: ConfigurationInfo?
         ///             Includes all encryption-related information.
-        ///
+        ///          
         public let encryptionInfo: EncryptionInfo?
         ///             Specifies the level of monitoring for the MSK cluster. The possible values are DEFAULT, PER_BROKER, and PER_TOPIC_PER_BROKER.
-        ///
+        ///          
         public let enhancedMonitoring: EnhancedMonitoring?
         ///             The version of Apache Kafka.
-        ///
+        ///          
         public let kafkaVersion: String
         ///             The number of broker nodes in the cluster.
-        ///
+        ///          
         public let numberOfBrokerNodes: Int
         ///             Create tags when creating the cluster.
-        ///
+        ///          
         public let tags: [String: String]?
 
         public init(brokerNodeGroupInfo: BrokerNodeGroupInfo, clientAuthentication: ClientAuthentication? = nil, clusterName: String, configurationInfo: ConfigurationInfo? = nil, encryptionInfo: EncryptionInfo? = nil, enhancedMonitoring: EnhancedMonitoring? = nil, kafkaVersion: String, numberOfBrokerNodes: Int, tags: [String: String]? = nil) {
@@ -538,19 +538,19 @@ extension Kafka {
 
     public struct CreateClusterResponse: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "ClusterArn", location: .body(locationName: "clusterArn"), required: false, type: .string),
-            AWSShapeMember(label: "ClusterName", location: .body(locationName: "clusterName"), required: false, type: .string),
+            AWSShapeMember(label: "ClusterArn", location: .body(locationName: "clusterArn"), required: false, type: .string), 
+            AWSShapeMember(label: "ClusterName", location: .body(locationName: "clusterName"), required: false, type: .string), 
             AWSShapeMember(label: "State", location: .body(locationName: "state"), required: false, type: .enum)
         ]
 
         ///             The Amazon Resource Name (ARN) of the cluster.
-        ///
+        ///          
         public let clusterArn: String?
         ///             The name of the MSK cluster.
-        ///
+        ///          
         public let clusterName: String?
         ///             The state of the cluster. The possible states are CREATING, ACTIVE, and FAILED.
-        ///
+        ///          
         public let state: ClusterState?
 
         public init(clusterArn: String? = nil, clusterName: String? = nil, state: ClusterState? = nil) {
@@ -568,20 +568,20 @@ extension Kafka {
 
     public struct CreateConfigurationRequest: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "Description", location: .body(locationName: "description"), required: false, type: .string),
-            AWSShapeMember(label: "KafkaVersions", location: .body(locationName: "kafkaVersions"), required: true, type: .list),
-            AWSShapeMember(label: "Name", location: .body(locationName: "name"), required: true, type: .string),
+            AWSShapeMember(label: "Description", location: .body(locationName: "description"), required: false, type: .string), 
+            AWSShapeMember(label: "KafkaVersions", location: .body(locationName: "kafkaVersions"), required: true, type: .list), 
+            AWSShapeMember(label: "Name", location: .body(locationName: "name"), required: true, type: .string), 
             AWSShapeMember(label: "ServerProperties", location: .body(locationName: "serverProperties"), required: true, type: .blob)
         ]
 
         ///             The description of the configuration.
-        ///
+        ///          
         public let description: String?
         ///             The versions of Apache Kafka with which you can use this MSK configuration.
-        ///
+        ///          
         public let kafkaVersions: [String]
         ///             The name of the configuration.
-        ///
+        ///          
         public let name: String
         public let serverProperties: Data
 
@@ -602,22 +602,22 @@ extension Kafka {
 
     public struct CreateConfigurationResponse: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "Arn", location: .body(locationName: "arn"), required: false, type: .string),
-            AWSShapeMember(label: "CreationTime", location: .body(locationName: "creationTime"), required: false, type: .timestamp),
-            AWSShapeMember(label: "LatestRevision", location: .body(locationName: "latestRevision"), required: false, type: .structure),
+            AWSShapeMember(label: "Arn", location: .body(locationName: "arn"), required: false, type: .string), 
+            AWSShapeMember(label: "CreationTime", location: .body(locationName: "creationTime"), required: false, type: .timestamp), 
+            AWSShapeMember(label: "LatestRevision", location: .body(locationName: "latestRevision"), required: false, type: .structure), 
             AWSShapeMember(label: "Name", location: .body(locationName: "name"), required: false, type: .string)
         ]
 
         ///             The Amazon Resource Name (ARN) of the configuration.
-        ///
+        ///          
         public let arn: String?
         /// The time when the configuration was created.
         public let creationTime: TimeStamp?
         ///             Latest revision of the configuration.
-        ///
+        ///          
         public let latestRevision: ConfigurationRevision?
         ///             The name of the configuration.
-        ///
+        ///          
         public let name: String?
 
         public init(arn: String? = nil, creationTime: TimeStamp? = nil, latestRevision: ConfigurationRevision? = nil, name: String? = nil) {
@@ -637,7 +637,7 @@ extension Kafka {
 
     public struct DeleteClusterRequest: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "ClusterArn", location: .uri(locationName: "clusterArn"), required: true, type: .string),
+            AWSShapeMember(label: "ClusterArn", location: .uri(locationName: "clusterArn"), required: true, type: .string), 
             AWSShapeMember(label: "CurrentVersion", location: .querystring(locationName: "currentVersion"), required: false, type: .string)
         ]
 
@@ -657,15 +657,15 @@ extension Kafka {
 
     public struct DeleteClusterResponse: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "ClusterArn", location: .body(locationName: "clusterArn"), required: false, type: .string),
+            AWSShapeMember(label: "ClusterArn", location: .body(locationName: "clusterArn"), required: false, type: .string), 
             AWSShapeMember(label: "State", location: .body(locationName: "state"), required: false, type: .enum)
         ]
 
         ///             The Amazon Resource Name (ARN) of the cluster.
-        ///
+        ///          
         public let clusterArn: String?
         ///             The state of the cluster. The possible states are CREATING, ACTIVE, and FAILED.
-        ///
+        ///          
         public let state: ClusterState?
 
         public init(clusterArn: String? = nil, state: ClusterState? = nil) {
@@ -701,7 +701,7 @@ extension Kafka {
         ]
 
         ///             Cluster operation information
-        ///
+        ///          
         public let clusterOperationInfo: ClusterOperationInfo?
 
         public init(clusterOperationInfo: ClusterOperationInfo? = nil) {
@@ -735,7 +735,7 @@ extension Kafka {
         ]
 
         ///             The cluster information.
-        ///
+        ///          
         public let clusterInfo: ClusterInfo?
 
         public init(clusterInfo: ClusterInfo? = nil) {
@@ -765,30 +765,30 @@ extension Kafka {
 
     public struct DescribeConfigurationResponse: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "Arn", location: .body(locationName: "arn"), required: false, type: .string),
-            AWSShapeMember(label: "CreationTime", location: .body(locationName: "creationTime"), required: false, type: .timestamp),
-            AWSShapeMember(label: "Description", location: .body(locationName: "description"), required: false, type: .string),
-            AWSShapeMember(label: "KafkaVersions", location: .body(locationName: "kafkaVersions"), required: false, type: .list),
-            AWSShapeMember(label: "LatestRevision", location: .body(locationName: "latestRevision"), required: false, type: .structure),
+            AWSShapeMember(label: "Arn", location: .body(locationName: "arn"), required: false, type: .string), 
+            AWSShapeMember(label: "CreationTime", location: .body(locationName: "creationTime"), required: false, type: .timestamp), 
+            AWSShapeMember(label: "Description", location: .body(locationName: "description"), required: false, type: .string), 
+            AWSShapeMember(label: "KafkaVersions", location: .body(locationName: "kafkaVersions"), required: false, type: .list), 
+            AWSShapeMember(label: "LatestRevision", location: .body(locationName: "latestRevision"), required: false, type: .structure), 
             AWSShapeMember(label: "Name", location: .body(locationName: "name"), required: false, type: .string)
         ]
 
         ///             The Amazon Resource Name (ARN) of the configuration.
-        ///
+        ///          
         public let arn: String?
         /// The time when the configuration was created.
         public let creationTime: TimeStamp?
         ///             The description of the configuration.
-        ///
+        ///          
         public let description: String?
         ///             The versions of Apache Kafka with which you can use this MSK configuration.
-        ///
+        ///          
         public let kafkaVersions: [String]?
         ///             Latest revision of the configuration.
-        ///
+        ///          
         public let latestRevision: ConfigurationRevision?
         ///             The name of the configuration.
-        ///
+        ///          
         public let name: String?
 
         public init(arn: String? = nil, creationTime: TimeStamp? = nil, description: String? = nil, kafkaVersions: [String]? = nil, latestRevision: ConfigurationRevision? = nil, name: String? = nil) {
@@ -812,7 +812,7 @@ extension Kafka {
 
     public struct DescribeConfigurationRevisionRequest: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "Arn", location: .uri(locationName: "arn"), required: true, type: .string),
+            AWSShapeMember(label: "Arn", location: .uri(locationName: "arn"), required: true, type: .string), 
             AWSShapeMember(label: "Revision", location: .uri(locationName: "revision"), required: true, type: .long)
         ]
 
@@ -832,23 +832,23 @@ extension Kafka {
 
     public struct DescribeConfigurationRevisionResponse: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "Arn", location: .body(locationName: "arn"), required: false, type: .string),
-            AWSShapeMember(label: "CreationTime", location: .body(locationName: "creationTime"), required: false, type: .timestamp),
-            AWSShapeMember(label: "Description", location: .body(locationName: "description"), required: false, type: .string),
-            AWSShapeMember(label: "Revision", location: .body(locationName: "revision"), required: false, type: .long),
+            AWSShapeMember(label: "Arn", location: .body(locationName: "arn"), required: false, type: .string), 
+            AWSShapeMember(label: "CreationTime", location: .body(locationName: "creationTime"), required: false, type: .timestamp), 
+            AWSShapeMember(label: "Description", location: .body(locationName: "description"), required: false, type: .string), 
+            AWSShapeMember(label: "Revision", location: .body(locationName: "revision"), required: false, type: .long), 
             AWSShapeMember(label: "ServerProperties", location: .body(locationName: "serverProperties"), required: false, type: .blob)
         ]
 
         ///             The Amazon Resource Name (ARN) of the configuration.
-        ///
+        ///          
         public let arn: String?
         /// The time when the configuration was created.
         public let creationTime: TimeStamp?
         ///             The description of the configuration.
-        ///
+        ///          
         public let description: String?
         ///             The revision number.
-        ///
+        ///          
         public let revision: Int64?
         public let serverProperties: Data?
 
@@ -875,7 +875,7 @@ extension Kafka {
         ]
 
         ///             The size in GiB of the EBS volume for the data drive on each broker node.
-        ///
+        ///          
         public let volumeSize: Int?
 
         public init(volumeSize: Int? = nil) {
@@ -898,7 +898,7 @@ extension Kafka {
         ]
 
         ///             The ARN of the AWS KMS key for encrypting data at rest. If you don't specify a KMS key, MSK creates one for you and uses it.
-        ///
+        ///          
         public let dataVolumeKMSKeyId: String
 
         public init(dataVolumeKMSKeyId: String) {
@@ -912,23 +912,23 @@ extension Kafka {
 
     public struct EncryptionInTransit: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "ClientBroker", location: .body(locationName: "clientBroker"), required: false, type: .enum),
+            AWSShapeMember(label: "ClientBroker", location: .body(locationName: "clientBroker"), required: false, type: .enum), 
             AWSShapeMember(label: "InCluster", location: .body(locationName: "inCluster"), required: false, type: .boolean)
         ]
 
         ///             Indicates the encryption setting for data in transit between clients and brokers. The following are the possible values.
-        ///
+        ///             
         ///                TLS means that client-broker communication is enabled with TLS only.
-        ///
+        ///             
         ///                TLS_PLAINTEXT means that client-broker communication is enabled for both TLS-encrypted, as well as plaintext data.
-        ///
+        ///             
         ///                PLAINTEXT means that client-broker communication is enabled in plaintext only.
         ///             The default value is TLS_PLAINTEXT.
-        ///
+        ///          
         public let clientBroker: ClientBroker?
         ///             When set to true, it indicates that data communication among the broker nodes of the cluster is encrypted. When set to false, the communication happens in plaintext.
         ///             The default value is true.
-        ///
+        ///          
         public let inCluster: Bool?
 
         public init(clientBroker: ClientBroker? = nil, inCluster: Bool? = nil) {
@@ -944,15 +944,15 @@ extension Kafka {
 
     public struct EncryptionInfo: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "EncryptionAtRest", location: .body(locationName: "encryptionAtRest"), required: false, type: .structure),
+            AWSShapeMember(label: "EncryptionAtRest", location: .body(locationName: "encryptionAtRest"), required: false, type: .structure), 
             AWSShapeMember(label: "EncryptionInTransit", location: .body(locationName: "encryptionInTransit"), required: false, type: .structure)
         ]
 
         ///             The data-volume encryption details.
-        ///
+        ///          
         public let encryptionAtRest: EncryptionAtRest?
         ///             The details for encryption in transit.
-        ///
+        ///          
         public let encryptionInTransit: EncryptionInTransit?
 
         public init(encryptionAtRest: EncryptionAtRest? = nil, encryptionInTransit: EncryptionInTransit? = nil) {
@@ -975,15 +975,15 @@ extension Kafka {
 
     public struct ErrorInfo: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "ErrorCode", location: .body(locationName: "errorCode"), required: false, type: .string),
+            AWSShapeMember(label: "ErrorCode", location: .body(locationName: "errorCode"), required: false, type: .string), 
             AWSShapeMember(label: "ErrorString", location: .body(locationName: "errorString"), required: false, type: .string)
         ]
 
         ///             A number describing the error programmatically.
-        ///
+        ///          
         public let errorCode: String?
         ///             An optional field to provide more details about the error.
-        ///
+        ///          
         public let errorString: String?
 
         public init(errorCode: String? = nil, errorString: String? = nil) {
@@ -1015,15 +1015,15 @@ extension Kafka {
 
     public struct GetBootstrapBrokersResponse: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "BootstrapBrokerString", location: .body(locationName: "bootstrapBrokerString"), required: false, type: .string),
+            AWSShapeMember(label: "BootstrapBrokerString", location: .body(locationName: "bootstrapBrokerString"), required: false, type: .string), 
             AWSShapeMember(label: "BootstrapBrokerStringTls", location: .body(locationName: "bootstrapBrokerStringTls"), required: false, type: .string)
         ]
 
         ///             A string containing one or more hostname:port pairs.
-        ///
+        ///          
         public let bootstrapBrokerString: String?
         ///             A string containing one or more DNS names (or IP) and TLS port pairs.
-        ///
+        ///          
         public let bootstrapBrokerStringTls: String?
 
         public init(bootstrapBrokerString: String? = nil, bootstrapBrokerStringTls: String? = nil) {
@@ -1039,8 +1039,8 @@ extension Kafka {
 
     public struct ListClusterOperationsRequest: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "ClusterArn", location: .uri(locationName: "clusterArn"), required: true, type: .string),
-            AWSShapeMember(label: "MaxResults", location: .querystring(locationName: "maxResults"), required: false, type: .integer),
+            AWSShapeMember(label: "ClusterArn", location: .uri(locationName: "clusterArn"), required: true, type: .string), 
+            AWSShapeMember(label: "MaxResults", location: .querystring(locationName: "maxResults"), required: false, type: .integer), 
             AWSShapeMember(label: "NextToken", location: .querystring(locationName: "nextToken"), required: false, type: .string)
         ]
 
@@ -1068,15 +1068,15 @@ extension Kafka {
 
     public struct ListClusterOperationsResponse: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "ClusterOperationInfoList", location: .body(locationName: "clusterOperationInfoList"), required: false, type: .list),
+            AWSShapeMember(label: "ClusterOperationInfoList", location: .body(locationName: "clusterOperationInfoList"), required: false, type: .list), 
             AWSShapeMember(label: "NextToken", location: .body(locationName: "nextToken"), required: false, type: .string)
         ]
 
         ///             An array of cluster operation information objects.
-        ///
+        ///          
         public let clusterOperationInfoList: [ClusterOperationInfo]?
         ///             If the response of ListClusterOperations is truncated, it returns a NextToken in the response. This Nexttoken should be sent in the subsequent request to ListClusterOperations.
-        ///
+        ///          
         public let nextToken: String?
 
         public init(clusterOperationInfoList: [ClusterOperationInfo]? = nil, nextToken: String? = nil) {
@@ -1092,8 +1092,8 @@ extension Kafka {
 
     public struct ListClustersRequest: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "ClusterNameFilter", location: .querystring(locationName: "clusterNameFilter"), required: false, type: .string),
-            AWSShapeMember(label: "MaxResults", location: .querystring(locationName: "maxResults"), required: false, type: .integer),
+            AWSShapeMember(label: "ClusterNameFilter", location: .querystring(locationName: "clusterNameFilter"), required: false, type: .string), 
+            AWSShapeMember(label: "MaxResults", location: .querystring(locationName: "maxResults"), required: false, type: .integer), 
             AWSShapeMember(label: "NextToken", location: .querystring(locationName: "nextToken"), required: false, type: .string)
         ]
 
@@ -1121,16 +1121,16 @@ extension Kafka {
 
     public struct ListClustersResponse: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "ClusterInfoList", location: .body(locationName: "clusterInfoList"), required: false, type: .list),
+            AWSShapeMember(label: "ClusterInfoList", location: .body(locationName: "clusterInfoList"), required: false, type: .list), 
             AWSShapeMember(label: "NextToken", location: .body(locationName: "nextToken"), required: false, type: .string)
         ]
 
         ///             Information on each of the MSK clusters in the response.
-        ///
+        ///          
         public let clusterInfoList: [ClusterInfo]?
-        ///             The paginated results marker. When the result of a ListClusters operation is truncated, the call returns NextToken in the response.
+        ///             The paginated results marker. When the result of a ListClusters operation is truncated, the call returns NextToken in the response. 
         ///                To get another batch of clusters, provide this token in your next request.
-        ///
+        ///          
         public let nextToken: String?
 
         public init(clusterInfoList: [ClusterInfo]? = nil, nextToken: String? = nil) {
@@ -1146,8 +1146,8 @@ extension Kafka {
 
     public struct ListConfigurationRevisionsRequest: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "Arn", location: .uri(locationName: "arn"), required: true, type: .string),
-            AWSShapeMember(label: "MaxResults", location: .querystring(locationName: "maxResults"), required: false, type: .integer),
+            AWSShapeMember(label: "Arn", location: .uri(locationName: "arn"), required: true, type: .string), 
+            AWSShapeMember(label: "MaxResults", location: .querystring(locationName: "maxResults"), required: false, type: .integer), 
             AWSShapeMember(label: "NextToken", location: .querystring(locationName: "nextToken"), required: false, type: .string)
         ]
 
@@ -1175,15 +1175,15 @@ extension Kafka {
 
     public struct ListConfigurationRevisionsResponse: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "NextToken", location: .body(locationName: "nextToken"), required: false, type: .string),
+            AWSShapeMember(label: "NextToken", location: .body(locationName: "nextToken"), required: false, type: .string), 
             AWSShapeMember(label: "Revisions", location: .body(locationName: "revisions"), required: false, type: .list)
         ]
 
         ///             Paginated results marker.
-        ///
+        ///          
         public let nextToken: String?
         ///             List of ConfigurationRevision objects.
-        ///
+        ///          
         public let revisions: [ConfigurationRevision]?
 
         public init(nextToken: String? = nil, revisions: [ConfigurationRevision]? = nil) {
@@ -1199,7 +1199,7 @@ extension Kafka {
 
     public struct ListConfigurationsRequest: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "MaxResults", location: .querystring(locationName: "maxResults"), required: false, type: .integer),
+            AWSShapeMember(label: "MaxResults", location: .querystring(locationName: "maxResults"), required: false, type: .integer), 
             AWSShapeMember(label: "NextToken", location: .querystring(locationName: "nextToken"), required: false, type: .string)
         ]
 
@@ -1224,16 +1224,16 @@ extension Kafka {
 
     public struct ListConfigurationsResponse: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "Configurations", location: .body(locationName: "configurations"), required: false, type: .list),
+            AWSShapeMember(label: "Configurations", location: .body(locationName: "configurations"), required: false, type: .list), 
             AWSShapeMember(label: "NextToken", location: .body(locationName: "nextToken"), required: false, type: .string)
         ]
 
         ///             An array of MSK configurations.
-        ///
+        ///          
         public let configurations: [Configuration]?
-        ///             The paginated results marker. When the result of a ListConfigurations operation is truncated, the call returns NextToken in the response.
+        ///             The paginated results marker. When the result of a ListConfigurations operation is truncated, the call returns NextToken in the response. 
         ///                To get another batch of configurations, provide this token in your next request.
-        ///
+        ///          
         public let nextToken: String?
 
         public init(configurations: [Configuration]? = nil, nextToken: String? = nil) {
@@ -1249,8 +1249,8 @@ extension Kafka {
 
     public struct ListNodesRequest: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "ClusterArn", location: .uri(locationName: "clusterArn"), required: true, type: .string),
-            AWSShapeMember(label: "MaxResults", location: .querystring(locationName: "maxResults"), required: false, type: .integer),
+            AWSShapeMember(label: "ClusterArn", location: .uri(locationName: "clusterArn"), required: true, type: .string), 
+            AWSShapeMember(label: "MaxResults", location: .querystring(locationName: "maxResults"), required: false, type: .integer), 
             AWSShapeMember(label: "NextToken", location: .querystring(locationName: "nextToken"), required: false, type: .string)
         ]
 
@@ -1278,16 +1278,16 @@ extension Kafka {
 
     public struct ListNodesResponse: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "NextToken", location: .body(locationName: "nextToken"), required: false, type: .string),
+            AWSShapeMember(label: "NextToken", location: .body(locationName: "nextToken"), required: false, type: .string), 
             AWSShapeMember(label: "NodeInfoList", location: .body(locationName: "nodeInfoList"), required: false, type: .list)
         ]
 
-        ///             The paginated results marker. When the result of a ListNodes operation is truncated, the call returns NextToken in the response.
+        ///             The paginated results marker. When the result of a ListNodes operation is truncated, the call returns NextToken in the response. 
         ///                To get another batch of nodes, provide this token in your next request.
-        ///
+        ///          
         public let nextToken: String?
         ///             List containing a NodeInfo object.
-        ///
+        ///          
         public let nodeInfoList: [NodeInfo]?
 
         public init(nextToken: String? = nil, nodeInfoList: [NodeInfo]? = nil) {
@@ -1323,7 +1323,7 @@ extension Kafka {
         ]
 
         ///             The key-value pair for the resource tag.
-        ///
+        ///          
         public let tags: [String: String]?
 
         public init(tags: [String: String]? = nil) {
@@ -1337,19 +1337,19 @@ extension Kafka {
 
     public struct MutableClusterInfo: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "BrokerEBSVolumeInfo", location: .body(locationName: "brokerEBSVolumeInfo"), required: false, type: .list),
-            AWSShapeMember(label: "ConfigurationInfo", location: .body(locationName: "configurationInfo"), required: false, type: .structure),
+            AWSShapeMember(label: "BrokerEBSVolumeInfo", location: .body(locationName: "brokerEBSVolumeInfo"), required: false, type: .list), 
+            AWSShapeMember(label: "ConfigurationInfo", location: .body(locationName: "configurationInfo"), required: false, type: .structure), 
             AWSShapeMember(label: "NumberOfBrokerNodes", location: .body(locationName: "numberOfBrokerNodes"), required: false, type: .integer)
         ]
 
         ///             Specifies the size of the EBS volume and the ID of the associated broker.
-        ///
+        ///          
         public let brokerEBSVolumeInfo: [BrokerEBSVolumeInfo]?
         ///             Information about the changes in the configuration of the brokers.
-        ///
+        ///          
         public let configurationInfo: ConfigurationInfo?
         ///             The number of broker nodes in the cluster.
-        ///
+        ///          
         public let numberOfBrokerNodes: Int?
 
         public init(brokerEBSVolumeInfo: [BrokerEBSVolumeInfo]? = nil, configurationInfo: ConfigurationInfo? = nil, numberOfBrokerNodes: Int? = nil) {
@@ -1367,31 +1367,31 @@ extension Kafka {
 
     public struct NodeInfo: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "AddedToClusterTime", location: .body(locationName: "addedToClusterTime"), required: false, type: .string),
-            AWSShapeMember(label: "BrokerNodeInfo", location: .body(locationName: "brokerNodeInfo"), required: false, type: .structure),
-            AWSShapeMember(label: "InstanceType", location: .body(locationName: "instanceType"), required: false, type: .string),
-            AWSShapeMember(label: "NodeARN", location: .body(locationName: "nodeARN"), required: false, type: .string),
-            AWSShapeMember(label: "NodeType", location: .body(locationName: "nodeType"), required: false, type: .enum),
+            AWSShapeMember(label: "AddedToClusterTime", location: .body(locationName: "addedToClusterTime"), required: false, type: .string), 
+            AWSShapeMember(label: "BrokerNodeInfo", location: .body(locationName: "brokerNodeInfo"), required: false, type: .structure), 
+            AWSShapeMember(label: "InstanceType", location: .body(locationName: "instanceType"), required: false, type: .string), 
+            AWSShapeMember(label: "NodeARN", location: .body(locationName: "nodeARN"), required: false, type: .string), 
+            AWSShapeMember(label: "NodeType", location: .body(locationName: "nodeType"), required: false, type: .enum), 
             AWSShapeMember(label: "ZookeeperNodeInfo", location: .body(locationName: "zookeeperNodeInfo"), required: false, type: .structure)
         ]
 
         ///             The start time.
-        ///
+        ///          
         public let addedToClusterTime: String?
         ///             The broker node info.
-        ///
+        ///          
         public let brokerNodeInfo: BrokerNodeInfo?
         ///             The instance type.
-        ///
+        ///          
         public let instanceType: String?
         ///             The Amazon Resource Name (ARN) of the node.
-        ///
+        ///          
         public let nodeARN: String?
         ///             The node type.
-        ///
+        ///          
         public let nodeType: NodeType?
         ///             The ZookeeperNodeInfo.
-        ///
+        ///          
         public let zookeeperNodeInfo: ZookeeperNodeInfo?
 
         public init(addedToClusterTime: String? = nil, brokerNodeInfo: BrokerNodeInfo? = nil, instanceType: String? = nil, nodeARN: String? = nil, nodeType: NodeType? = nil, zookeeperNodeInfo: ZookeeperNodeInfo? = nil) {
@@ -1424,7 +1424,7 @@ extension Kafka {
         ]
 
         ///             EBS volume information.
-        ///
+        ///          
         public let ebsStorageInfo: EBSStorageInfo?
 
         public init(ebsStorageInfo: EBSStorageInfo? = nil) {
@@ -1442,13 +1442,13 @@ extension Kafka {
 
     public struct TagResourceRequest: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "ResourceArn", location: .uri(locationName: "resourceArn"), required: true, type: .string),
+            AWSShapeMember(label: "ResourceArn", location: .uri(locationName: "resourceArn"), required: true, type: .string), 
             AWSShapeMember(label: "Tags", location: .body(locationName: "tags"), required: true, type: .map)
         ]
 
         public let resourceArn: String
         ///             The key-value pair for the resource tag.
-        ///
+        ///          
         public let tags: [String: String]
 
         public init(resourceArn: String, tags: [String: String]) {
@@ -1468,7 +1468,7 @@ extension Kafka {
         ]
 
         ///             List of ACM Certificate Authority ARNs.
-        ///
+        ///          
         public let certificateAuthorityArnList: [String]?
 
         public init(certificateAuthorityArnList: [String]? = nil) {
@@ -1482,7 +1482,7 @@ extension Kafka {
 
     public struct UntagResourceRequest: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "ResourceArn", location: .uri(locationName: "resourceArn"), required: true, type: .string),
+            AWSShapeMember(label: "ResourceArn", location: .uri(locationName: "resourceArn"), required: true, type: .string), 
             AWSShapeMember(label: "TagKeys", location: .querystring(locationName: "tagKeys"), required: true, type: .list)
         ]
 
@@ -1502,17 +1502,17 @@ extension Kafka {
 
     public struct UpdateBrokerStorageRequest: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "ClusterArn", location: .uri(locationName: "clusterArn"), required: true, type: .string),
-            AWSShapeMember(label: "CurrentVersion", location: .body(locationName: "currentVersion"), required: true, type: .string),
+            AWSShapeMember(label: "ClusterArn", location: .uri(locationName: "clusterArn"), required: true, type: .string), 
+            AWSShapeMember(label: "CurrentVersion", location: .body(locationName: "currentVersion"), required: true, type: .string), 
             AWSShapeMember(label: "TargetBrokerEBSVolumeInfo", location: .body(locationName: "targetBrokerEBSVolumeInfo"), required: true, type: .list)
         ]
 
         public let clusterArn: String
         ///             The version of cluster to update from. A successful operation will then generate a new version.
-        ///
+        ///          
         public let currentVersion: String
         ///             Describes the target volume size and the ID of the broker to apply the update to.
-        ///
+        ///          
         public let targetBrokerEBSVolumeInfo: [BrokerEBSVolumeInfo]
 
         public init(clusterArn: String, currentVersion: String, targetBrokerEBSVolumeInfo: [BrokerEBSVolumeInfo]) {
@@ -1530,15 +1530,15 @@ extension Kafka {
 
     public struct UpdateBrokerStorageResponse: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "ClusterArn", location: .body(locationName: "clusterArn"), required: false, type: .string),
+            AWSShapeMember(label: "ClusterArn", location: .body(locationName: "clusterArn"), required: false, type: .string), 
             AWSShapeMember(label: "ClusterOperationArn", location: .body(locationName: "clusterOperationArn"), required: false, type: .string)
         ]
 
         ///             The Amazon Resource Name (ARN) of the cluster.
-        ///
+        ///          
         public let clusterArn: String?
         ///             The Amazon Resource Name (ARN) of the cluster operation.
-        ///
+        ///          
         public let clusterOperationArn: String?
 
         public init(clusterArn: String? = nil, clusterOperationArn: String? = nil) {
@@ -1554,17 +1554,17 @@ extension Kafka {
 
     public struct UpdateClusterConfigurationRequest: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "ClusterArn", location: .uri(locationName: "clusterArn"), required: true, type: .string),
-            AWSShapeMember(label: "ConfigurationInfo", location: .body(locationName: "configurationInfo"), required: true, type: .structure),
+            AWSShapeMember(label: "ClusterArn", location: .uri(locationName: "clusterArn"), required: true, type: .string), 
+            AWSShapeMember(label: "ConfigurationInfo", location: .body(locationName: "configurationInfo"), required: true, type: .structure), 
             AWSShapeMember(label: "CurrentVersion", location: .body(locationName: "currentVersion"), required: true, type: .string)
         ]
 
         public let clusterArn: String
         ///             Represents the configuration that you want MSK to use for the brokers in a cluster.
-        ///
+        ///          
         public let configurationInfo: ConfigurationInfo
         ///             The version of the cluster that needs to be updated.
-        ///
+        ///          
         public let currentVersion: String
 
         public init(clusterArn: String, configurationInfo: ConfigurationInfo, currentVersion: String) {
@@ -1582,15 +1582,15 @@ extension Kafka {
 
     public struct UpdateClusterConfigurationResponse: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "ClusterArn", location: .body(locationName: "clusterArn"), required: false, type: .string),
+            AWSShapeMember(label: "ClusterArn", location: .body(locationName: "clusterArn"), required: false, type: .string), 
             AWSShapeMember(label: "ClusterOperationArn", location: .body(locationName: "clusterOperationArn"), required: false, type: .string)
         ]
 
         ///             The Amazon Resource Name (ARN) of the cluster.
-        ///
+        ///          
         public let clusterArn: String?
         ///             The Amazon Resource Name (ARN) of the cluster operation.
-        ///
+        ///          
         public let clusterOperationArn: String?
 
         public init(clusterArn: String? = nil, clusterOperationArn: String? = nil) {
@@ -1606,27 +1606,27 @@ extension Kafka {
 
     public struct ZookeeperNodeInfo: AWSShape {
         public static var _members: [AWSShapeMember] = [
-            AWSShapeMember(label: "AttachedENIId", location: .body(locationName: "attachedENIId"), required: false, type: .string),
-            AWSShapeMember(label: "ClientVpcIpAddress", location: .body(locationName: "clientVpcIpAddress"), required: false, type: .string),
-            AWSShapeMember(label: "Endpoints", location: .body(locationName: "endpoints"), required: false, type: .list),
-            AWSShapeMember(label: "ZookeeperId", location: .body(locationName: "zookeeperId"), required: false, type: .double),
+            AWSShapeMember(label: "AttachedENIId", location: .body(locationName: "attachedENIId"), required: false, type: .string), 
+            AWSShapeMember(label: "ClientVpcIpAddress", location: .body(locationName: "clientVpcIpAddress"), required: false, type: .string), 
+            AWSShapeMember(label: "Endpoints", location: .body(locationName: "endpoints"), required: false, type: .list), 
+            AWSShapeMember(label: "ZookeeperId", location: .body(locationName: "zookeeperId"), required: false, type: .double), 
             AWSShapeMember(label: "ZookeeperVersion", location: .body(locationName: "zookeeperVersion"), required: false, type: .string)
         ]
 
         ///             The attached elastic network interface of the broker.
-        ///
+        ///          
         public let attachedENIId: String?
         ///             The virtual private cloud (VPC) IP address of the client.
-        ///
+        ///          
         public let clientVpcIpAddress: String?
         ///             Endpoints for accessing the ZooKeeper.
-        ///
+        ///          
         public let endpoints: [String]?
         ///             The role-specific ID for Zookeeper.
-        ///
+        ///          
         public let zookeeperId: Double?
         ///             The version of Zookeeper.
-        ///
+        ///          
         public let zookeeperVersion: String?
 
         public init(attachedENIId: String? = nil, clientVpcIpAddress: String? = nil, endpoints: [String]? = nil, zookeeperId: Double? = nil, zookeeperVersion: String? = nil) {

--- a/Sources/AWSSDKSwift/Services/Neptune/Neptune_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Neptune/Neptune_Error.swift
@@ -72,85 +72,85 @@ extension NeptuneErrorType {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
         switch errorCode {
-        case "AuthorizationNotFoundFault":
+        case "AuthorizationNotFound":
             self = .authorizationNotFoundFault(message: message)
-        case "CertificateNotFoundFault":
+        case "CertificateNotFound":
             self = .certificateNotFoundFault(message: message)
         case "DBClusterAlreadyExistsFault":
             self = .dBClusterAlreadyExistsFault(message: message)
         case "DBClusterNotFoundFault":
             self = .dBClusterNotFoundFault(message: message)
-        case "DBClusterParameterGroupNotFoundFault":
+        case "DBClusterParameterGroupNotFound":
             self = .dBClusterParameterGroupNotFoundFault(message: message)
         case "DBClusterQuotaExceededFault":
             self = .dBClusterQuotaExceededFault(message: message)
-        case "DBClusterRoleAlreadyExistsFault":
+        case "DBClusterRoleAlreadyExists":
             self = .dBClusterRoleAlreadyExistsFault(message: message)
-        case "DBClusterRoleNotFoundFault":
+        case "DBClusterRoleNotFound":
             self = .dBClusterRoleNotFoundFault(message: message)
-        case "DBClusterRoleQuotaExceededFault":
+        case "DBClusterRoleQuotaExceeded":
             self = .dBClusterRoleQuotaExceededFault(message: message)
         case "DBClusterSnapshotAlreadyExistsFault":
             self = .dBClusterSnapshotAlreadyExistsFault(message: message)
         case "DBClusterSnapshotNotFoundFault":
             self = .dBClusterSnapshotNotFoundFault(message: message)
-        case "DBInstanceAlreadyExistsFault":
+        case "DBInstanceAlreadyExists":
             self = .dBInstanceAlreadyExistsFault(message: message)
-        case "DBInstanceNotFoundFault":
+        case "DBInstanceNotFound":
             self = .dBInstanceNotFoundFault(message: message)
-        case "DBParameterGroupAlreadyExistsFault":
+        case "DBParameterGroupAlreadyExists":
             self = .dBParameterGroupAlreadyExistsFault(message: message)
-        case "DBParameterGroupNotFoundFault":
+        case "DBParameterGroupNotFound":
             self = .dBParameterGroupNotFoundFault(message: message)
-        case "DBParameterGroupQuotaExceededFault":
+        case "DBParameterGroupQuotaExceeded":
             self = .dBParameterGroupQuotaExceededFault(message: message)
-        case "DBSecurityGroupNotFoundFault":
+        case "DBSecurityGroupNotFound":
             self = .dBSecurityGroupNotFoundFault(message: message)
-        case "DBSnapshotAlreadyExistsFault":
+        case "DBSnapshotAlreadyExists":
             self = .dBSnapshotAlreadyExistsFault(message: message)
-        case "DBSnapshotNotFoundFault":
+        case "DBSnapshotNotFound":
             self = .dBSnapshotNotFoundFault(message: message)
-        case "DBSubnetGroupAlreadyExistsFault":
+        case "DBSubnetGroupAlreadyExists":
             self = .dBSubnetGroupAlreadyExistsFault(message: message)
         case "DBSubnetGroupDoesNotCoverEnoughAZs":
             self = .dBSubnetGroupDoesNotCoverEnoughAZs(message: message)
         case "DBSubnetGroupNotFoundFault":
             self = .dBSubnetGroupNotFoundFault(message: message)
-        case "DBSubnetGroupQuotaExceededFault":
+        case "DBSubnetGroupQuotaExceeded":
             self = .dBSubnetGroupQuotaExceededFault(message: message)
         case "DBSubnetQuotaExceededFault":
             self = .dBSubnetQuotaExceededFault(message: message)
-        case "DBUpgradeDependencyFailureFault":
+        case "DBUpgradeDependencyFailure":
             self = .dBUpgradeDependencyFailureFault(message: message)
         case "DomainNotFoundFault":
             self = .domainNotFoundFault(message: message)
-        case "EventSubscriptionQuotaExceededFault":
+        case "EventSubscriptionQuotaExceeded":
             self = .eventSubscriptionQuotaExceededFault(message: message)
-        case "InstanceQuotaExceededFault":
+        case "InstanceQuotaExceeded":
             self = .instanceQuotaExceededFault(message: message)
         case "InsufficientDBClusterCapacityFault":
             self = .insufficientDBClusterCapacityFault(message: message)
-        case "InsufficientDBInstanceCapacityFault":
+        case "InsufficientDBInstanceCapacity":
             self = .insufficientDBInstanceCapacityFault(message: message)
-        case "InsufficientStorageClusterCapacityFault":
+        case "InsufficientStorageClusterCapacity":
             self = .insufficientStorageClusterCapacityFault(message: message)
         case "InvalidDBClusterSnapshotStateFault":
             self = .invalidDBClusterSnapshotStateFault(message: message)
         case "InvalidDBClusterStateFault":
             self = .invalidDBClusterStateFault(message: message)
-        case "InvalidDBInstanceStateFault":
+        case "InvalidDBInstanceState":
             self = .invalidDBInstanceStateFault(message: message)
-        case "InvalidDBParameterGroupStateFault":
+        case "InvalidDBParameterGroupState":
             self = .invalidDBParameterGroupStateFault(message: message)
-        case "InvalidDBSecurityGroupStateFault":
+        case "InvalidDBSecurityGroupState":
             self = .invalidDBSecurityGroupStateFault(message: message)
-        case "InvalidDBSnapshotStateFault":
+        case "InvalidDBSnapshotState":
             self = .invalidDBSnapshotStateFault(message: message)
         case "InvalidDBSubnetGroupStateFault":
             self = .invalidDBSubnetGroupStateFault(message: message)
         case "InvalidDBSubnetStateFault":
             self = .invalidDBSubnetStateFault(message: message)
-        case "InvalidEventSubscriptionStateFault":
+        case "InvalidEventSubscriptionState":
             self = .invalidEventSubscriptionStateFault(message: message)
         case "InvalidRestoreFault":
             self = .invalidRestoreFault(message: message)
@@ -166,29 +166,29 @@ extension NeptuneErrorType {
             self = .provisionedIopsNotAvailableInAZFault(message: message)
         case "ResourceNotFoundFault":
             self = .resourceNotFoundFault(message: message)
-        case "SNSInvalidTopicFault":
+        case "SNSInvalidTopic":
             self = .sNSInvalidTopicFault(message: message)
-        case "SNSNoAuthorizationFault":
+        case "SNSNoAuthorization":
             self = .sNSNoAuthorizationFault(message: message)
-        case "SNSTopicArnNotFoundFault":
+        case "SNSTopicArnNotFound":
             self = .sNSTopicArnNotFoundFault(message: message)
-        case "SharedSnapshotQuotaExceededFault":
+        case "SharedSnapshotQuotaExceeded":
             self = .sharedSnapshotQuotaExceededFault(message: message)
-        case "SnapshotQuotaExceededFault":
+        case "SnapshotQuotaExceeded":
             self = .snapshotQuotaExceededFault(message: message)
-        case "SourceNotFoundFault":
+        case "SourceNotFound":
             self = .sourceNotFoundFault(message: message)
-        case "StorageQuotaExceededFault":
+        case "StorageQuotaExceeded":
             self = .storageQuotaExceededFault(message: message)
-        case "StorageTypeNotSupportedFault":
+        case "StorageTypeNotSupported":
             self = .storageTypeNotSupportedFault(message: message)
         case "SubnetAlreadyInUse":
             self = .subnetAlreadyInUse(message: message)
-        case "SubscriptionAlreadyExistFault":
+        case "SubscriptionAlreadyExist":
             self = .subscriptionAlreadyExistFault(message: message)
-        case "SubscriptionCategoryNotFoundFault":
+        case "SubscriptionCategoryNotFound":
             self = .subscriptionCategoryNotFoundFault(message: message)
-        case "SubscriptionNotFoundFault":
+        case "SubscriptionNotFound":
             self = .subscriptionNotFoundFault(message: message)
         default:
             return nil
@@ -200,85 +200,85 @@ extension NeptuneErrorType : CustomStringConvertible {
     public var description : String {
         switch self {
         case .authorizationNotFoundFault(let message):
-            return "AuthorizationNotFoundFault: \(message ?? "")"
+            return "AuthorizationNotFound: \(message ?? "")"
         case .certificateNotFoundFault(let message):
-            return "CertificateNotFoundFault: \(message ?? "")"
+            return "CertificateNotFound: \(message ?? "")"
         case .dBClusterAlreadyExistsFault(let message):
             return "DBClusterAlreadyExistsFault: \(message ?? "")"
         case .dBClusterNotFoundFault(let message):
             return "DBClusterNotFoundFault: \(message ?? "")"
         case .dBClusterParameterGroupNotFoundFault(let message):
-            return "DBClusterParameterGroupNotFoundFault: \(message ?? "")"
+            return "DBClusterParameterGroupNotFound: \(message ?? "")"
         case .dBClusterQuotaExceededFault(let message):
             return "DBClusterQuotaExceededFault: \(message ?? "")"
         case .dBClusterRoleAlreadyExistsFault(let message):
-            return "DBClusterRoleAlreadyExistsFault: \(message ?? "")"
+            return "DBClusterRoleAlreadyExists: \(message ?? "")"
         case .dBClusterRoleNotFoundFault(let message):
-            return "DBClusterRoleNotFoundFault: \(message ?? "")"
+            return "DBClusterRoleNotFound: \(message ?? "")"
         case .dBClusterRoleQuotaExceededFault(let message):
-            return "DBClusterRoleQuotaExceededFault: \(message ?? "")"
+            return "DBClusterRoleQuotaExceeded: \(message ?? "")"
         case .dBClusterSnapshotAlreadyExistsFault(let message):
             return "DBClusterSnapshotAlreadyExistsFault: \(message ?? "")"
         case .dBClusterSnapshotNotFoundFault(let message):
             return "DBClusterSnapshotNotFoundFault: \(message ?? "")"
         case .dBInstanceAlreadyExistsFault(let message):
-            return "DBInstanceAlreadyExistsFault: \(message ?? "")"
+            return "DBInstanceAlreadyExists: \(message ?? "")"
         case .dBInstanceNotFoundFault(let message):
-            return "DBInstanceNotFoundFault: \(message ?? "")"
+            return "DBInstanceNotFound: \(message ?? "")"
         case .dBParameterGroupAlreadyExistsFault(let message):
-            return "DBParameterGroupAlreadyExistsFault: \(message ?? "")"
+            return "DBParameterGroupAlreadyExists: \(message ?? "")"
         case .dBParameterGroupNotFoundFault(let message):
-            return "DBParameterGroupNotFoundFault: \(message ?? "")"
+            return "DBParameterGroupNotFound: \(message ?? "")"
         case .dBParameterGroupQuotaExceededFault(let message):
-            return "DBParameterGroupQuotaExceededFault: \(message ?? "")"
+            return "DBParameterGroupQuotaExceeded: \(message ?? "")"
         case .dBSecurityGroupNotFoundFault(let message):
-            return "DBSecurityGroupNotFoundFault: \(message ?? "")"
+            return "DBSecurityGroupNotFound: \(message ?? "")"
         case .dBSnapshotAlreadyExistsFault(let message):
-            return "DBSnapshotAlreadyExistsFault: \(message ?? "")"
+            return "DBSnapshotAlreadyExists: \(message ?? "")"
         case .dBSnapshotNotFoundFault(let message):
-            return "DBSnapshotNotFoundFault: \(message ?? "")"
+            return "DBSnapshotNotFound: \(message ?? "")"
         case .dBSubnetGroupAlreadyExistsFault(let message):
-            return "DBSubnetGroupAlreadyExistsFault: \(message ?? "")"
+            return "DBSubnetGroupAlreadyExists: \(message ?? "")"
         case .dBSubnetGroupDoesNotCoverEnoughAZs(let message):
             return "DBSubnetGroupDoesNotCoverEnoughAZs: \(message ?? "")"
         case .dBSubnetGroupNotFoundFault(let message):
             return "DBSubnetGroupNotFoundFault: \(message ?? "")"
         case .dBSubnetGroupQuotaExceededFault(let message):
-            return "DBSubnetGroupQuotaExceededFault: \(message ?? "")"
+            return "DBSubnetGroupQuotaExceeded: \(message ?? "")"
         case .dBSubnetQuotaExceededFault(let message):
             return "DBSubnetQuotaExceededFault: \(message ?? "")"
         case .dBUpgradeDependencyFailureFault(let message):
-            return "DBUpgradeDependencyFailureFault: \(message ?? "")"
+            return "DBUpgradeDependencyFailure: \(message ?? "")"
         case .domainNotFoundFault(let message):
             return "DomainNotFoundFault: \(message ?? "")"
         case .eventSubscriptionQuotaExceededFault(let message):
-            return "EventSubscriptionQuotaExceededFault: \(message ?? "")"
+            return "EventSubscriptionQuotaExceeded: \(message ?? "")"
         case .instanceQuotaExceededFault(let message):
-            return "InstanceQuotaExceededFault: \(message ?? "")"
+            return "InstanceQuotaExceeded: \(message ?? "")"
         case .insufficientDBClusterCapacityFault(let message):
             return "InsufficientDBClusterCapacityFault: \(message ?? "")"
         case .insufficientDBInstanceCapacityFault(let message):
-            return "InsufficientDBInstanceCapacityFault: \(message ?? "")"
+            return "InsufficientDBInstanceCapacity: \(message ?? "")"
         case .insufficientStorageClusterCapacityFault(let message):
-            return "InsufficientStorageClusterCapacityFault: \(message ?? "")"
+            return "InsufficientStorageClusterCapacity: \(message ?? "")"
         case .invalidDBClusterSnapshotStateFault(let message):
             return "InvalidDBClusterSnapshotStateFault: \(message ?? "")"
         case .invalidDBClusterStateFault(let message):
             return "InvalidDBClusterStateFault: \(message ?? "")"
         case .invalidDBInstanceStateFault(let message):
-            return "InvalidDBInstanceStateFault: \(message ?? "")"
+            return "InvalidDBInstanceState: \(message ?? "")"
         case .invalidDBParameterGroupStateFault(let message):
-            return "InvalidDBParameterGroupStateFault: \(message ?? "")"
+            return "InvalidDBParameterGroupState: \(message ?? "")"
         case .invalidDBSecurityGroupStateFault(let message):
-            return "InvalidDBSecurityGroupStateFault: \(message ?? "")"
+            return "InvalidDBSecurityGroupState: \(message ?? "")"
         case .invalidDBSnapshotStateFault(let message):
-            return "InvalidDBSnapshotStateFault: \(message ?? "")"
+            return "InvalidDBSnapshotState: \(message ?? "")"
         case .invalidDBSubnetGroupStateFault(let message):
             return "InvalidDBSubnetGroupStateFault: \(message ?? "")"
         case .invalidDBSubnetStateFault(let message):
             return "InvalidDBSubnetStateFault: \(message ?? "")"
         case .invalidEventSubscriptionStateFault(let message):
-            return "InvalidEventSubscriptionStateFault: \(message ?? "")"
+            return "InvalidEventSubscriptionState: \(message ?? "")"
         case .invalidRestoreFault(let message):
             return "InvalidRestoreFault: \(message ?? "")"
         case .invalidSubnet(let message):
@@ -294,29 +294,29 @@ extension NeptuneErrorType : CustomStringConvertible {
         case .resourceNotFoundFault(let message):
             return "ResourceNotFoundFault: \(message ?? "")"
         case .sNSInvalidTopicFault(let message):
-            return "SNSInvalidTopicFault: \(message ?? "")"
+            return "SNSInvalidTopic: \(message ?? "")"
         case .sNSNoAuthorizationFault(let message):
-            return "SNSNoAuthorizationFault: \(message ?? "")"
+            return "SNSNoAuthorization: \(message ?? "")"
         case .sNSTopicArnNotFoundFault(let message):
-            return "SNSTopicArnNotFoundFault: \(message ?? "")"
+            return "SNSTopicArnNotFound: \(message ?? "")"
         case .sharedSnapshotQuotaExceededFault(let message):
-            return "SharedSnapshotQuotaExceededFault: \(message ?? "")"
+            return "SharedSnapshotQuotaExceeded: \(message ?? "")"
         case .snapshotQuotaExceededFault(let message):
-            return "SnapshotQuotaExceededFault: \(message ?? "")"
+            return "SnapshotQuotaExceeded: \(message ?? "")"
         case .sourceNotFoundFault(let message):
-            return "SourceNotFoundFault: \(message ?? "")"
+            return "SourceNotFound: \(message ?? "")"
         case .storageQuotaExceededFault(let message):
-            return "StorageQuotaExceededFault: \(message ?? "")"
+            return "StorageQuotaExceeded: \(message ?? "")"
         case .storageTypeNotSupportedFault(let message):
-            return "StorageTypeNotSupportedFault: \(message ?? "")"
+            return "StorageTypeNotSupported: \(message ?? "")"
         case .subnetAlreadyInUse(let message):
             return "SubnetAlreadyInUse: \(message ?? "")"
         case .subscriptionAlreadyExistFault(let message):
-            return "SubscriptionAlreadyExistFault: \(message ?? "")"
+            return "SubscriptionAlreadyExist: \(message ?? "")"
         case .subscriptionCategoryNotFoundFault(let message):
-            return "SubscriptionCategoryNotFoundFault: \(message ?? "")"
+            return "SubscriptionCategoryNotFound: \(message ?? "")"
         case .subscriptionNotFoundFault(let message):
-            return "SubscriptionNotFoundFault: \(message ?? "")"
+            return "SubscriptionNotFound: \(message ?? "")"
         }
     }
 }

--- a/Sources/AWSSDKSwift/Services/RDS/RDS_Error.swift
+++ b/Sources/AWSSDKSwift/Services/RDS/RDS_Error.swift
@@ -106,15 +106,15 @@ extension RDSErrorType {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
         switch errorCode {
-        case "AuthorizationAlreadyExistsFault":
+        case "AuthorizationAlreadyExists":
             self = .authorizationAlreadyExistsFault(message: message)
-        case "AuthorizationNotFoundFault":
+        case "AuthorizationNotFound":
             self = .authorizationNotFoundFault(message: message)
-        case "AuthorizationQuotaExceededFault":
+        case "AuthorizationQuotaExceeded":
             self = .authorizationQuotaExceededFault(message: message)
         case "BackupPolicyNotFoundFault":
             self = .backupPolicyNotFoundFault(message: message)
-        case "CertificateNotFoundFault":
+        case "CertificateNotFound":
             self = .certificateNotFoundFault(message: message)
         case "DBClusterAlreadyExistsFault":
             self = .dBClusterAlreadyExistsFault(message: message)
@@ -128,55 +128,55 @@ extension RDSErrorType {
             self = .dBClusterEndpointQuotaExceededFault(message: message)
         case "DBClusterNotFoundFault":
             self = .dBClusterNotFoundFault(message: message)
-        case "DBClusterParameterGroupNotFoundFault":
+        case "DBClusterParameterGroupNotFound":
             self = .dBClusterParameterGroupNotFoundFault(message: message)
         case "DBClusterQuotaExceededFault":
             self = .dBClusterQuotaExceededFault(message: message)
-        case "DBClusterRoleAlreadyExistsFault":
+        case "DBClusterRoleAlreadyExists":
             self = .dBClusterRoleAlreadyExistsFault(message: message)
-        case "DBClusterRoleNotFoundFault":
+        case "DBClusterRoleNotFound":
             self = .dBClusterRoleNotFoundFault(message: message)
-        case "DBClusterRoleQuotaExceededFault":
+        case "DBClusterRoleQuotaExceeded":
             self = .dBClusterRoleQuotaExceededFault(message: message)
         case "DBClusterSnapshotAlreadyExistsFault":
             self = .dBClusterSnapshotAlreadyExistsFault(message: message)
         case "DBClusterSnapshotNotFoundFault":
             self = .dBClusterSnapshotNotFoundFault(message: message)
-        case "DBInstanceAlreadyExistsFault":
+        case "DBInstanceAlreadyExists":
             self = .dBInstanceAlreadyExistsFault(message: message)
-        case "DBInstanceAutomatedBackupNotFoundFault":
+        case "DBInstanceAutomatedBackupNotFound":
             self = .dBInstanceAutomatedBackupNotFoundFault(message: message)
-        case "DBInstanceAutomatedBackupQuotaExceededFault":
+        case "DBInstanceAutomatedBackupQuotaExceeded":
             self = .dBInstanceAutomatedBackupQuotaExceededFault(message: message)
-        case "DBInstanceNotFoundFault":
+        case "DBInstanceNotFound":
             self = .dBInstanceNotFoundFault(message: message)
-        case "DBInstanceRoleAlreadyExistsFault":
+        case "DBInstanceRoleAlreadyExists":
             self = .dBInstanceRoleAlreadyExistsFault(message: message)
-        case "DBInstanceRoleNotFoundFault":
+        case "DBInstanceRoleNotFound":
             self = .dBInstanceRoleNotFoundFault(message: message)
-        case "DBInstanceRoleQuotaExceededFault":
+        case "DBInstanceRoleQuotaExceeded":
             self = .dBInstanceRoleQuotaExceededFault(message: message)
         case "DBLogFileNotFoundFault":
             self = .dBLogFileNotFoundFault(message: message)
-        case "DBParameterGroupAlreadyExistsFault":
+        case "DBParameterGroupAlreadyExists":
             self = .dBParameterGroupAlreadyExistsFault(message: message)
-        case "DBParameterGroupNotFoundFault":
+        case "DBParameterGroupNotFound":
             self = .dBParameterGroupNotFoundFault(message: message)
-        case "DBParameterGroupQuotaExceededFault":
+        case "DBParameterGroupQuotaExceeded":
             self = .dBParameterGroupQuotaExceededFault(message: message)
-        case "DBSecurityGroupAlreadyExistsFault":
+        case "DBSecurityGroupAlreadyExists":
             self = .dBSecurityGroupAlreadyExistsFault(message: message)
-        case "DBSecurityGroupNotFoundFault":
+        case "DBSecurityGroupNotFound":
             self = .dBSecurityGroupNotFoundFault(message: message)
-        case "DBSecurityGroupNotSupportedFault":
+        case "DBSecurityGroupNotSupported":
             self = .dBSecurityGroupNotSupportedFault(message: message)
-        case "DBSecurityGroupQuotaExceededFault":
+        case "QuotaExceeded.DBSecurityGroup":
             self = .dBSecurityGroupQuotaExceededFault(message: message)
-        case "DBSnapshotAlreadyExistsFault":
+        case "DBSnapshotAlreadyExists":
             self = .dBSnapshotAlreadyExistsFault(message: message)
-        case "DBSnapshotNotFoundFault":
+        case "DBSnapshotNotFound":
             self = .dBSnapshotNotFoundFault(message: message)
-        case "DBSubnetGroupAlreadyExistsFault":
+        case "DBSubnetGroupAlreadyExists":
             self = .dBSubnetGroupAlreadyExistsFault(message: message)
         case "DBSubnetGroupDoesNotCoverEnoughAZs":
             self = .dBSubnetGroupDoesNotCoverEnoughAZs(message: message)
@@ -184,15 +184,15 @@ extension RDSErrorType {
             self = .dBSubnetGroupNotAllowedFault(message: message)
         case "DBSubnetGroupNotFoundFault":
             self = .dBSubnetGroupNotFoundFault(message: message)
-        case "DBSubnetGroupQuotaExceededFault":
+        case "DBSubnetGroupQuotaExceeded":
             self = .dBSubnetGroupQuotaExceededFault(message: message)
         case "DBSubnetQuotaExceededFault":
             self = .dBSubnetQuotaExceededFault(message: message)
-        case "DBUpgradeDependencyFailureFault":
+        case "DBUpgradeDependencyFailure":
             self = .dBUpgradeDependencyFailureFault(message: message)
         case "DomainNotFoundFault":
             self = .domainNotFoundFault(message: message)
-        case "EventSubscriptionQuotaExceededFault":
+        case "EventSubscriptionQuotaExceeded":
             self = .eventSubscriptionQuotaExceededFault(message: message)
         case "GlobalClusterAlreadyExistsFault":
             self = .globalClusterAlreadyExistsFault(message: message)
@@ -200,13 +200,13 @@ extension RDSErrorType {
             self = .globalClusterNotFoundFault(message: message)
         case "GlobalClusterQuotaExceededFault":
             self = .globalClusterQuotaExceededFault(message: message)
-        case "InstanceQuotaExceededFault":
+        case "InstanceQuotaExceeded":
             self = .instanceQuotaExceededFault(message: message)
         case "InsufficientDBClusterCapacityFault":
             self = .insufficientDBClusterCapacityFault(message: message)
-        case "InsufficientDBInstanceCapacityFault":
+        case "InsufficientDBInstanceCapacity":
             self = .insufficientDBInstanceCapacityFault(message: message)
-        case "InsufficientStorageClusterCapacityFault":
+        case "InsufficientStorageClusterCapacity":
             self = .insufficientStorageClusterCapacityFault(message: message)
         case "InvalidDBClusterCapacityFault":
             self = .invalidDBClusterCapacityFault(message: message)
@@ -216,15 +216,15 @@ extension RDSErrorType {
             self = .invalidDBClusterSnapshotStateFault(message: message)
         case "InvalidDBClusterStateFault":
             self = .invalidDBClusterStateFault(message: message)
-        case "InvalidDBInstanceAutomatedBackupStateFault":
+        case "InvalidDBInstanceAutomatedBackupState":
             self = .invalidDBInstanceAutomatedBackupStateFault(message: message)
-        case "InvalidDBInstanceStateFault":
+        case "InvalidDBInstanceState":
             self = .invalidDBInstanceStateFault(message: message)
-        case "InvalidDBParameterGroupStateFault":
+        case "InvalidDBParameterGroupState":
             self = .invalidDBParameterGroupStateFault(message: message)
-        case "InvalidDBSecurityGroupStateFault":
+        case "InvalidDBSecurityGroupState":
             self = .invalidDBSecurityGroupStateFault(message: message)
-        case "InvalidDBSnapshotStateFault":
+        case "InvalidDBSnapshotState":
             self = .invalidDBSnapshotStateFault(message: message)
         case "InvalidDBSubnetGroupFault":
             self = .invalidDBSubnetGroupFault(message: message)
@@ -232,7 +232,7 @@ extension RDSErrorType {
             self = .invalidDBSubnetGroupStateFault(message: message)
         case "InvalidDBSubnetStateFault":
             self = .invalidDBSubnetStateFault(message: message)
-        case "InvalidEventSubscriptionStateFault":
+        case "InvalidEventSubscriptionState":
             self = .invalidEventSubscriptionStateFault(message: message)
         case "InvalidGlobalClusterStateFault":
             self = .invalidGlobalClusterStateFault(message: message)
@@ -254,43 +254,43 @@ extension RDSErrorType {
             self = .optionGroupNotFoundFault(message: message)
         case "OptionGroupQuotaExceededFault":
             self = .optionGroupQuotaExceededFault(message: message)
-        case "PointInTimeRestoreNotEnabledFault":
+        case "PointInTimeRestoreNotEnabled":
             self = .pointInTimeRestoreNotEnabledFault(message: message)
         case "ProvisionedIopsNotAvailableInAZFault":
             self = .provisionedIopsNotAvailableInAZFault(message: message)
-        case "ReservedDBInstanceAlreadyExistsFault":
+        case "ReservedDBInstanceAlreadyExists":
             self = .reservedDBInstanceAlreadyExistsFault(message: message)
-        case "ReservedDBInstanceNotFoundFault":
+        case "ReservedDBInstanceNotFound":
             self = .reservedDBInstanceNotFoundFault(message: message)
-        case "ReservedDBInstanceQuotaExceededFault":
+        case "ReservedDBInstanceQuotaExceeded":
             self = .reservedDBInstanceQuotaExceededFault(message: message)
-        case "ReservedDBInstancesOfferingNotFoundFault":
+        case "ReservedDBInstancesOfferingNotFound":
             self = .reservedDBInstancesOfferingNotFoundFault(message: message)
         case "ResourceNotFoundFault":
             self = .resourceNotFoundFault(message: message)
-        case "SNSInvalidTopicFault":
+        case "SNSInvalidTopic":
             self = .sNSInvalidTopicFault(message: message)
-        case "SNSNoAuthorizationFault":
+        case "SNSNoAuthorization":
             self = .sNSNoAuthorizationFault(message: message)
-        case "SNSTopicArnNotFoundFault":
+        case "SNSTopicArnNotFound":
             self = .sNSTopicArnNotFoundFault(message: message)
-        case "SharedSnapshotQuotaExceededFault":
+        case "SharedSnapshotQuotaExceeded":
             self = .sharedSnapshotQuotaExceededFault(message: message)
-        case "SnapshotQuotaExceededFault":
+        case "SnapshotQuotaExceeded":
             self = .snapshotQuotaExceededFault(message: message)
-        case "SourceNotFoundFault":
+        case "SourceNotFound":
             self = .sourceNotFoundFault(message: message)
-        case "StorageQuotaExceededFault":
+        case "StorageQuotaExceeded":
             self = .storageQuotaExceededFault(message: message)
-        case "StorageTypeNotSupportedFault":
+        case "StorageTypeNotSupported":
             self = .storageTypeNotSupportedFault(message: message)
         case "SubnetAlreadyInUse":
             self = .subnetAlreadyInUse(message: message)
-        case "SubscriptionAlreadyExistFault":
+        case "SubscriptionAlreadyExist":
             self = .subscriptionAlreadyExistFault(message: message)
-        case "SubscriptionCategoryNotFoundFault":
+        case "SubscriptionCategoryNotFound":
             self = .subscriptionCategoryNotFoundFault(message: message)
-        case "SubscriptionNotFoundFault":
+        case "SubscriptionNotFound":
             self = .subscriptionNotFoundFault(message: message)
         default:
             return nil
@@ -302,15 +302,15 @@ extension RDSErrorType : CustomStringConvertible {
     public var description : String {
         switch self {
         case .authorizationAlreadyExistsFault(let message):
-            return "AuthorizationAlreadyExistsFault: \(message ?? "")"
+            return "AuthorizationAlreadyExists: \(message ?? "")"
         case .authorizationNotFoundFault(let message):
-            return "AuthorizationNotFoundFault: \(message ?? "")"
+            return "AuthorizationNotFound: \(message ?? "")"
         case .authorizationQuotaExceededFault(let message):
-            return "AuthorizationQuotaExceededFault: \(message ?? "")"
+            return "AuthorizationQuotaExceeded: \(message ?? "")"
         case .backupPolicyNotFoundFault(let message):
             return "BackupPolicyNotFoundFault: \(message ?? "")"
         case .certificateNotFoundFault(let message):
-            return "CertificateNotFoundFault: \(message ?? "")"
+            return "CertificateNotFound: \(message ?? "")"
         case .dBClusterAlreadyExistsFault(let message):
             return "DBClusterAlreadyExistsFault: \(message ?? "")"
         case .dBClusterBacktrackNotFoundFault(let message):
@@ -324,55 +324,55 @@ extension RDSErrorType : CustomStringConvertible {
         case .dBClusterNotFoundFault(let message):
             return "DBClusterNotFoundFault: \(message ?? "")"
         case .dBClusterParameterGroupNotFoundFault(let message):
-            return "DBClusterParameterGroupNotFoundFault: \(message ?? "")"
+            return "DBClusterParameterGroupNotFound: \(message ?? "")"
         case .dBClusterQuotaExceededFault(let message):
             return "DBClusterQuotaExceededFault: \(message ?? "")"
         case .dBClusterRoleAlreadyExistsFault(let message):
-            return "DBClusterRoleAlreadyExistsFault: \(message ?? "")"
+            return "DBClusterRoleAlreadyExists: \(message ?? "")"
         case .dBClusterRoleNotFoundFault(let message):
-            return "DBClusterRoleNotFoundFault: \(message ?? "")"
+            return "DBClusterRoleNotFound: \(message ?? "")"
         case .dBClusterRoleQuotaExceededFault(let message):
-            return "DBClusterRoleQuotaExceededFault: \(message ?? "")"
+            return "DBClusterRoleQuotaExceeded: \(message ?? "")"
         case .dBClusterSnapshotAlreadyExistsFault(let message):
             return "DBClusterSnapshotAlreadyExistsFault: \(message ?? "")"
         case .dBClusterSnapshotNotFoundFault(let message):
             return "DBClusterSnapshotNotFoundFault: \(message ?? "")"
         case .dBInstanceAlreadyExistsFault(let message):
-            return "DBInstanceAlreadyExistsFault: \(message ?? "")"
+            return "DBInstanceAlreadyExists: \(message ?? "")"
         case .dBInstanceAutomatedBackupNotFoundFault(let message):
-            return "DBInstanceAutomatedBackupNotFoundFault: \(message ?? "")"
+            return "DBInstanceAutomatedBackupNotFound: \(message ?? "")"
         case .dBInstanceAutomatedBackupQuotaExceededFault(let message):
-            return "DBInstanceAutomatedBackupQuotaExceededFault: \(message ?? "")"
+            return "DBInstanceAutomatedBackupQuotaExceeded: \(message ?? "")"
         case .dBInstanceNotFoundFault(let message):
-            return "DBInstanceNotFoundFault: \(message ?? "")"
+            return "DBInstanceNotFound: \(message ?? "")"
         case .dBInstanceRoleAlreadyExistsFault(let message):
-            return "DBInstanceRoleAlreadyExistsFault: \(message ?? "")"
+            return "DBInstanceRoleAlreadyExists: \(message ?? "")"
         case .dBInstanceRoleNotFoundFault(let message):
-            return "DBInstanceRoleNotFoundFault: \(message ?? "")"
+            return "DBInstanceRoleNotFound: \(message ?? "")"
         case .dBInstanceRoleQuotaExceededFault(let message):
-            return "DBInstanceRoleQuotaExceededFault: \(message ?? "")"
+            return "DBInstanceRoleQuotaExceeded: \(message ?? "")"
         case .dBLogFileNotFoundFault(let message):
             return "DBLogFileNotFoundFault: \(message ?? "")"
         case .dBParameterGroupAlreadyExistsFault(let message):
-            return "DBParameterGroupAlreadyExistsFault: \(message ?? "")"
+            return "DBParameterGroupAlreadyExists: \(message ?? "")"
         case .dBParameterGroupNotFoundFault(let message):
-            return "DBParameterGroupNotFoundFault: \(message ?? "")"
+            return "DBParameterGroupNotFound: \(message ?? "")"
         case .dBParameterGroupQuotaExceededFault(let message):
-            return "DBParameterGroupQuotaExceededFault: \(message ?? "")"
+            return "DBParameterGroupQuotaExceeded: \(message ?? "")"
         case .dBSecurityGroupAlreadyExistsFault(let message):
-            return "DBSecurityGroupAlreadyExistsFault: \(message ?? "")"
+            return "DBSecurityGroupAlreadyExists: \(message ?? "")"
         case .dBSecurityGroupNotFoundFault(let message):
-            return "DBSecurityGroupNotFoundFault: \(message ?? "")"
+            return "DBSecurityGroupNotFound: \(message ?? "")"
         case .dBSecurityGroupNotSupportedFault(let message):
-            return "DBSecurityGroupNotSupportedFault: \(message ?? "")"
+            return "DBSecurityGroupNotSupported: \(message ?? "")"
         case .dBSecurityGroupQuotaExceededFault(let message):
-            return "DBSecurityGroupQuotaExceededFault: \(message ?? "")"
+            return "QuotaExceeded.DBSecurityGroup: \(message ?? "")"
         case .dBSnapshotAlreadyExistsFault(let message):
-            return "DBSnapshotAlreadyExistsFault: \(message ?? "")"
+            return "DBSnapshotAlreadyExists: \(message ?? "")"
         case .dBSnapshotNotFoundFault(let message):
-            return "DBSnapshotNotFoundFault: \(message ?? "")"
+            return "DBSnapshotNotFound: \(message ?? "")"
         case .dBSubnetGroupAlreadyExistsFault(let message):
-            return "DBSubnetGroupAlreadyExistsFault: \(message ?? "")"
+            return "DBSubnetGroupAlreadyExists: \(message ?? "")"
         case .dBSubnetGroupDoesNotCoverEnoughAZs(let message):
             return "DBSubnetGroupDoesNotCoverEnoughAZs: \(message ?? "")"
         case .dBSubnetGroupNotAllowedFault(let message):
@@ -380,15 +380,15 @@ extension RDSErrorType : CustomStringConvertible {
         case .dBSubnetGroupNotFoundFault(let message):
             return "DBSubnetGroupNotFoundFault: \(message ?? "")"
         case .dBSubnetGroupQuotaExceededFault(let message):
-            return "DBSubnetGroupQuotaExceededFault: \(message ?? "")"
+            return "DBSubnetGroupQuotaExceeded: \(message ?? "")"
         case .dBSubnetQuotaExceededFault(let message):
             return "DBSubnetQuotaExceededFault: \(message ?? "")"
         case .dBUpgradeDependencyFailureFault(let message):
-            return "DBUpgradeDependencyFailureFault: \(message ?? "")"
+            return "DBUpgradeDependencyFailure: \(message ?? "")"
         case .domainNotFoundFault(let message):
             return "DomainNotFoundFault: \(message ?? "")"
         case .eventSubscriptionQuotaExceededFault(let message):
-            return "EventSubscriptionQuotaExceededFault: \(message ?? "")"
+            return "EventSubscriptionQuotaExceeded: \(message ?? "")"
         case .globalClusterAlreadyExistsFault(let message):
             return "GlobalClusterAlreadyExistsFault: \(message ?? "")"
         case .globalClusterNotFoundFault(let message):
@@ -396,13 +396,13 @@ extension RDSErrorType : CustomStringConvertible {
         case .globalClusterQuotaExceededFault(let message):
             return "GlobalClusterQuotaExceededFault: \(message ?? "")"
         case .instanceQuotaExceededFault(let message):
-            return "InstanceQuotaExceededFault: \(message ?? "")"
+            return "InstanceQuotaExceeded: \(message ?? "")"
         case .insufficientDBClusterCapacityFault(let message):
             return "InsufficientDBClusterCapacityFault: \(message ?? "")"
         case .insufficientDBInstanceCapacityFault(let message):
-            return "InsufficientDBInstanceCapacityFault: \(message ?? "")"
+            return "InsufficientDBInstanceCapacity: \(message ?? "")"
         case .insufficientStorageClusterCapacityFault(let message):
-            return "InsufficientStorageClusterCapacityFault: \(message ?? "")"
+            return "InsufficientStorageClusterCapacity: \(message ?? "")"
         case .invalidDBClusterCapacityFault(let message):
             return "InvalidDBClusterCapacityFault: \(message ?? "")"
         case .invalidDBClusterEndpointStateFault(let message):
@@ -412,15 +412,15 @@ extension RDSErrorType : CustomStringConvertible {
         case .invalidDBClusterStateFault(let message):
             return "InvalidDBClusterStateFault: \(message ?? "")"
         case .invalidDBInstanceAutomatedBackupStateFault(let message):
-            return "InvalidDBInstanceAutomatedBackupStateFault: \(message ?? "")"
+            return "InvalidDBInstanceAutomatedBackupState: \(message ?? "")"
         case .invalidDBInstanceStateFault(let message):
-            return "InvalidDBInstanceStateFault: \(message ?? "")"
+            return "InvalidDBInstanceState: \(message ?? "")"
         case .invalidDBParameterGroupStateFault(let message):
-            return "InvalidDBParameterGroupStateFault: \(message ?? "")"
+            return "InvalidDBParameterGroupState: \(message ?? "")"
         case .invalidDBSecurityGroupStateFault(let message):
-            return "InvalidDBSecurityGroupStateFault: \(message ?? "")"
+            return "InvalidDBSecurityGroupState: \(message ?? "")"
         case .invalidDBSnapshotStateFault(let message):
-            return "InvalidDBSnapshotStateFault: \(message ?? "")"
+            return "InvalidDBSnapshotState: \(message ?? "")"
         case .invalidDBSubnetGroupFault(let message):
             return "InvalidDBSubnetGroupFault: \(message ?? "")"
         case .invalidDBSubnetGroupStateFault(let message):
@@ -428,7 +428,7 @@ extension RDSErrorType : CustomStringConvertible {
         case .invalidDBSubnetStateFault(let message):
             return "InvalidDBSubnetStateFault: \(message ?? "")"
         case .invalidEventSubscriptionStateFault(let message):
-            return "InvalidEventSubscriptionStateFault: \(message ?? "")"
+            return "InvalidEventSubscriptionState: \(message ?? "")"
         case .invalidGlobalClusterStateFault(let message):
             return "InvalidGlobalClusterStateFault: \(message ?? "")"
         case .invalidOptionGroupStateFault(let message):
@@ -450,43 +450,43 @@ extension RDSErrorType : CustomStringConvertible {
         case .optionGroupQuotaExceededFault(let message):
             return "OptionGroupQuotaExceededFault: \(message ?? "")"
         case .pointInTimeRestoreNotEnabledFault(let message):
-            return "PointInTimeRestoreNotEnabledFault: \(message ?? "")"
+            return "PointInTimeRestoreNotEnabled: \(message ?? "")"
         case .provisionedIopsNotAvailableInAZFault(let message):
             return "ProvisionedIopsNotAvailableInAZFault: \(message ?? "")"
         case .reservedDBInstanceAlreadyExistsFault(let message):
-            return "ReservedDBInstanceAlreadyExistsFault: \(message ?? "")"
+            return "ReservedDBInstanceAlreadyExists: \(message ?? "")"
         case .reservedDBInstanceNotFoundFault(let message):
-            return "ReservedDBInstanceNotFoundFault: \(message ?? "")"
+            return "ReservedDBInstanceNotFound: \(message ?? "")"
         case .reservedDBInstanceQuotaExceededFault(let message):
-            return "ReservedDBInstanceQuotaExceededFault: \(message ?? "")"
+            return "ReservedDBInstanceQuotaExceeded: \(message ?? "")"
         case .reservedDBInstancesOfferingNotFoundFault(let message):
-            return "ReservedDBInstancesOfferingNotFoundFault: \(message ?? "")"
+            return "ReservedDBInstancesOfferingNotFound: \(message ?? "")"
         case .resourceNotFoundFault(let message):
             return "ResourceNotFoundFault: \(message ?? "")"
         case .sNSInvalidTopicFault(let message):
-            return "SNSInvalidTopicFault: \(message ?? "")"
+            return "SNSInvalidTopic: \(message ?? "")"
         case .sNSNoAuthorizationFault(let message):
-            return "SNSNoAuthorizationFault: \(message ?? "")"
+            return "SNSNoAuthorization: \(message ?? "")"
         case .sNSTopicArnNotFoundFault(let message):
-            return "SNSTopicArnNotFoundFault: \(message ?? "")"
+            return "SNSTopicArnNotFound: \(message ?? "")"
         case .sharedSnapshotQuotaExceededFault(let message):
-            return "SharedSnapshotQuotaExceededFault: \(message ?? "")"
+            return "SharedSnapshotQuotaExceeded: \(message ?? "")"
         case .snapshotQuotaExceededFault(let message):
-            return "SnapshotQuotaExceededFault: \(message ?? "")"
+            return "SnapshotQuotaExceeded: \(message ?? "")"
         case .sourceNotFoundFault(let message):
-            return "SourceNotFoundFault: \(message ?? "")"
+            return "SourceNotFound: \(message ?? "")"
         case .storageQuotaExceededFault(let message):
-            return "StorageQuotaExceededFault: \(message ?? "")"
+            return "StorageQuotaExceeded: \(message ?? "")"
         case .storageTypeNotSupportedFault(let message):
-            return "StorageTypeNotSupportedFault: \(message ?? "")"
+            return "StorageTypeNotSupported: \(message ?? "")"
         case .subnetAlreadyInUse(let message):
             return "SubnetAlreadyInUse: \(message ?? "")"
         case .subscriptionAlreadyExistFault(let message):
-            return "SubscriptionAlreadyExistFault: \(message ?? "")"
+            return "SubscriptionAlreadyExist: \(message ?? "")"
         case .subscriptionCategoryNotFoundFault(let message):
-            return "SubscriptionCategoryNotFoundFault: \(message ?? "")"
+            return "SubscriptionCategoryNotFound: \(message ?? "")"
         case .subscriptionNotFoundFault(let message):
-            return "SubscriptionNotFoundFault: \(message ?? "")"
+            return "SubscriptionNotFound: \(message ?? "")"
         }
     }
 }

--- a/Sources/AWSSDKSwift/Services/Redshift/Redshift_Error.swift
+++ b/Sources/AWSSDKSwift/Services/Redshift/Redshift_Error.swift
@@ -112,51 +112,51 @@ extension RedshiftErrorType {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
         switch errorCode {
-        case "AccessToSnapshotDeniedFault":
+        case "AccessToSnapshotDenied":
             self = .accessToSnapshotDeniedFault(message: message)
-        case "AuthorizationAlreadyExistsFault":
+        case "AuthorizationAlreadyExists":
             self = .authorizationAlreadyExistsFault(message: message)
-        case "AuthorizationNotFoundFault":
+        case "AuthorizationNotFound":
             self = .authorizationNotFoundFault(message: message)
-        case "AuthorizationQuotaExceededFault":
+        case "AuthorizationQuotaExceeded":
             self = .authorizationQuotaExceededFault(message: message)
-        case "BatchDeleteRequestSizeExceededFault":
+        case "BatchDeleteRequestSizeExceeded":
             self = .batchDeleteRequestSizeExceededFault(message: message)
         case "BatchModifyClusterSnapshotsLimitExceededFault":
             self = .batchModifyClusterSnapshotsLimitExceededFault(message: message)
         case "BucketNotFoundFault":
             self = .bucketNotFoundFault(message: message)
-        case "ClusterAlreadyExistsFault":
+        case "ClusterAlreadyExists":
             self = .clusterAlreadyExistsFault(message: message)
-        case "ClusterNotFoundFault":
+        case "ClusterNotFound":
             self = .clusterNotFoundFault(message: message)
-        case "ClusterOnLatestRevisionFault":
+        case "ClusterOnLatestRevision":
             self = .clusterOnLatestRevisionFault(message: message)
-        case "ClusterParameterGroupAlreadyExistsFault":
+        case "ClusterParameterGroupAlreadyExists":
             self = .clusterParameterGroupAlreadyExistsFault(message: message)
-        case "ClusterParameterGroupNotFoundFault":
+        case "ClusterParameterGroupNotFound":
             self = .clusterParameterGroupNotFoundFault(message: message)
-        case "ClusterParameterGroupQuotaExceededFault":
+        case "ClusterParameterGroupQuotaExceeded":
             self = .clusterParameterGroupQuotaExceededFault(message: message)
-        case "ClusterQuotaExceededFault":
+        case "ClusterQuotaExceeded":
             self = .clusterQuotaExceededFault(message: message)
-        case "ClusterSecurityGroupAlreadyExistsFault":
+        case "ClusterSecurityGroupAlreadyExists":
             self = .clusterSecurityGroupAlreadyExistsFault(message: message)
-        case "ClusterSecurityGroupNotFoundFault":
+        case "ClusterSecurityGroupNotFound":
             self = .clusterSecurityGroupNotFoundFault(message: message)
-        case "ClusterSecurityGroupQuotaExceededFault":
+        case "QuotaExceeded.ClusterSecurityGroup":
             self = .clusterSecurityGroupQuotaExceededFault(message: message)
-        case "ClusterSnapshotAlreadyExistsFault":
+        case "ClusterSnapshotAlreadyExists":
             self = .clusterSnapshotAlreadyExistsFault(message: message)
-        case "ClusterSnapshotNotFoundFault":
+        case "ClusterSnapshotNotFound":
             self = .clusterSnapshotNotFoundFault(message: message)
-        case "ClusterSnapshotQuotaExceededFault":
+        case "ClusterSnapshotQuotaExceeded":
             self = .clusterSnapshotQuotaExceededFault(message: message)
-        case "ClusterSubnetGroupAlreadyExistsFault":
+        case "ClusterSubnetGroupAlreadyExists":
             self = .clusterSubnetGroupAlreadyExistsFault(message: message)
         case "ClusterSubnetGroupNotFoundFault":
             self = .clusterSubnetGroupNotFoundFault(message: message)
-        case "ClusterSubnetGroupQuotaExceededFault":
+        case "ClusterSubnetGroupQuotaExceeded":
             self = .clusterSubnetGroupQuotaExceededFault(message: message)
         case "ClusterSubnetQuotaExceededFault":
             self = .clusterSubnetQuotaExceededFault(message: message)
@@ -166,7 +166,7 @@ extension RedshiftErrorType {
             self = .dependentServiceRequestThrottlingFault(message: message)
         case "DependentServiceUnavailableFault":
             self = .dependentServiceUnavailableFault(message: message)
-        case "EventSubscriptionQuotaExceededFault":
+        case "EventSubscriptionQuotaExceeded":
             self = .eventSubscriptionQuotaExceededFault(message: message)
         case "HsmClientCertificateAlreadyExistsFault":
             self = .hsmClientCertificateAlreadyExistsFault(message: message)
@@ -184,25 +184,25 @@ extension RedshiftErrorType {
             self = .inProgressTableRestoreQuotaExceededFault(message: message)
         case "IncompatibleOrderableOptions":
             self = .incompatibleOrderableOptions(message: message)
-        case "InsufficientClusterCapacityFault":
+        case "InsufficientClusterCapacity":
             self = .insufficientClusterCapacityFault(message: message)
         case "InsufficientS3BucketPolicyFault":
             self = .insufficientS3BucketPolicyFault(message: message)
-        case "InvalidClusterParameterGroupStateFault":
+        case "InvalidClusterParameterGroupState":
             self = .invalidClusterParameterGroupStateFault(message: message)
-        case "InvalidClusterSecurityGroupStateFault":
+        case "InvalidClusterSecurityGroupState":
             self = .invalidClusterSecurityGroupStateFault(message: message)
-        case "InvalidClusterSnapshotScheduleStateFault":
+        case "InvalidClusterSnapshotScheduleState":
             self = .invalidClusterSnapshotScheduleStateFault(message: message)
-        case "InvalidClusterSnapshotStateFault":
+        case "InvalidClusterSnapshotState":
             self = .invalidClusterSnapshotStateFault(message: message)
-        case "InvalidClusterStateFault":
+        case "InvalidClusterState":
             self = .invalidClusterStateFault(message: message)
         case "InvalidClusterSubnetGroupStateFault":
             self = .invalidClusterSubnetGroupStateFault(message: message)
         case "InvalidClusterSubnetStateFault":
             self = .invalidClusterSubnetStateFault(message: message)
-        case "InvalidClusterTrackFault":
+        case "InvalidClusterTrack":
             self = .invalidClusterTrackFault(message: message)
         case "InvalidElasticIpFault":
             self = .invalidElasticIpFault(message: message)
@@ -210,9 +210,9 @@ extension RedshiftErrorType {
             self = .invalidHsmClientCertificateStateFault(message: message)
         case "InvalidHsmConfigurationStateFault":
             self = .invalidHsmConfigurationStateFault(message: message)
-        case "InvalidReservedNodeStateFault":
+        case "InvalidReservedNodeState":
             self = .invalidReservedNodeStateFault(message: message)
-        case "InvalidRestoreFault":
+        case "InvalidRestore":
             self = .invalidRestoreFault(message: message)
         case "InvalidRetentionPeriodFault":
             self = .invalidRetentionPeriodFault(message: message)
@@ -220,7 +220,7 @@ extension RedshiftErrorType {
             self = .invalidS3BucketNameFault(message: message)
         case "InvalidS3KeyPrefixFault":
             self = .invalidS3KeyPrefixFault(message: message)
-        case "InvalidScheduleFault":
+        case "InvalidSchedule":
             self = .invalidScheduleFault(message: message)
         case "InvalidSnapshotCopyGrantStateFault":
             self = .invalidSnapshotCopyGrantStateFault(message: message)
@@ -228,7 +228,7 @@ extension RedshiftErrorType {
             self = .invalidSubnet(message: message)
         case "InvalidSubscriptionStateFault":
             self = .invalidSubscriptionStateFault(message: message)
-        case "InvalidTableRestoreArgumentFault":
+        case "InvalidTableRestoreArgument":
             self = .invalidTableRestoreArgumentFault(message: message)
         case "InvalidTagFault":
             self = .invalidTagFault(message: message)
@@ -236,31 +236,31 @@ extension RedshiftErrorType {
             self = .invalidVPCNetworkStateFault(message: message)
         case "LimitExceededFault":
             self = .limitExceededFault(message: message)
-        case "NumberOfNodesPerClusterLimitExceededFault":
+        case "NumberOfNodesPerClusterLimitExceeded":
             self = .numberOfNodesPerClusterLimitExceededFault(message: message)
-        case "NumberOfNodesQuotaExceededFault":
+        case "NumberOfNodesQuotaExceeded":
             self = .numberOfNodesQuotaExceededFault(message: message)
-        case "ReservedNodeAlreadyExistsFault":
+        case "ReservedNodeAlreadyExists":
             self = .reservedNodeAlreadyExistsFault(message: message)
-        case "ReservedNodeAlreadyMigratedFault":
+        case "ReservedNodeAlreadyMigrated":
             self = .reservedNodeAlreadyMigratedFault(message: message)
-        case "ReservedNodeNotFoundFault":
+        case "ReservedNodeNotFound":
             self = .reservedNodeNotFoundFault(message: message)
-        case "ReservedNodeOfferingNotFoundFault":
+        case "ReservedNodeOfferingNotFound":
             self = .reservedNodeOfferingNotFoundFault(message: message)
-        case "ReservedNodeQuotaExceededFault":
+        case "ReservedNodeQuotaExceeded":
             self = .reservedNodeQuotaExceededFault(message: message)
-        case "ResizeNotFoundFault":
+        case "ResizeNotFound":
             self = .resizeNotFoundFault(message: message)
         case "ResourceNotFoundFault":
             self = .resourceNotFoundFault(message: message)
-        case "SNSInvalidTopicFault":
+        case "SNSInvalidTopic":
             self = .sNSInvalidTopicFault(message: message)
-        case "SNSNoAuthorizationFault":
+        case "SNSNoAuthorization":
             self = .sNSNoAuthorizationFault(message: message)
-        case "SNSTopicArnNotFoundFault":
+        case "SNSTopicArnNotFound":
             self = .sNSTopicArnNotFoundFault(message: message)
-        case "ScheduleDefinitionTypeUnsupportedFault":
+        case "ScheduleDefinitionTypeUnsupported":
             self = .scheduleDefinitionTypeUnsupportedFault(message: message)
         case "SnapshotCopyAlreadyDisabledFault":
             self = .snapshotCopyAlreadyDisabledFault(message: message)
@@ -274,29 +274,29 @@ extension RedshiftErrorType {
             self = .snapshotCopyGrantNotFoundFault(message: message)
         case "SnapshotCopyGrantQuotaExceededFault":
             self = .snapshotCopyGrantQuotaExceededFault(message: message)
-        case "SnapshotScheduleAlreadyExistsFault":
+        case "SnapshotScheduleAlreadyExists":
             self = .snapshotScheduleAlreadyExistsFault(message: message)
-        case "SnapshotScheduleNotFoundFault":
+        case "SnapshotScheduleNotFound":
             self = .snapshotScheduleNotFoundFault(message: message)
-        case "SnapshotScheduleQuotaExceededFault":
+        case "SnapshotScheduleQuotaExceeded":
             self = .snapshotScheduleQuotaExceededFault(message: message)
-        case "SnapshotScheduleUpdateInProgressFault":
+        case "SnapshotScheduleUpdateInProgress":
             self = .snapshotScheduleUpdateInProgressFault(message: message)
-        case "SourceNotFoundFault":
+        case "SourceNotFound":
             self = .sourceNotFoundFault(message: message)
         case "SubnetAlreadyInUse":
             self = .subnetAlreadyInUse(message: message)
-        case "SubscriptionAlreadyExistFault":
+        case "SubscriptionAlreadyExist":
             self = .subscriptionAlreadyExistFault(message: message)
-        case "SubscriptionCategoryNotFoundFault":
+        case "SubscriptionCategoryNotFound":
             self = .subscriptionCategoryNotFoundFault(message: message)
-        case "SubscriptionEventIdNotFoundFault":
+        case "SubscriptionEventIdNotFound":
             self = .subscriptionEventIdNotFoundFault(message: message)
-        case "SubscriptionNotFoundFault":
+        case "SubscriptionNotFound":
             self = .subscriptionNotFoundFault(message: message)
-        case "SubscriptionSeverityNotFoundFault":
+        case "SubscriptionSeverityNotFound":
             self = .subscriptionSeverityNotFoundFault(message: message)
-        case "TableLimitExceededFault":
+        case "TableLimitExceeded":
             self = .tableLimitExceededFault(message: message)
         case "TableRestoreNotFoundFault":
             self = .tableRestoreNotFoundFault(message: message)
@@ -306,7 +306,7 @@ extension RedshiftErrorType {
             self = .unauthorizedOperation(message: message)
         case "UnknownSnapshotCopyRegionFault":
             self = .unknownSnapshotCopyRegionFault(message: message)
-        case "UnsupportedOperationFault":
+        case "UnsupportedOperation":
             self = .unsupportedOperationFault(message: message)
         case "UnsupportedOptionFault":
             self = .unsupportedOptionFault(message: message)
@@ -320,51 +320,51 @@ extension RedshiftErrorType : CustomStringConvertible {
     public var description : String {
         switch self {
         case .accessToSnapshotDeniedFault(let message):
-            return "AccessToSnapshotDeniedFault: \(message ?? "")"
+            return "AccessToSnapshotDenied: \(message ?? "")"
         case .authorizationAlreadyExistsFault(let message):
-            return "AuthorizationAlreadyExistsFault: \(message ?? "")"
+            return "AuthorizationAlreadyExists: \(message ?? "")"
         case .authorizationNotFoundFault(let message):
-            return "AuthorizationNotFoundFault: \(message ?? "")"
+            return "AuthorizationNotFound: \(message ?? "")"
         case .authorizationQuotaExceededFault(let message):
-            return "AuthorizationQuotaExceededFault: \(message ?? "")"
+            return "AuthorizationQuotaExceeded: \(message ?? "")"
         case .batchDeleteRequestSizeExceededFault(let message):
-            return "BatchDeleteRequestSizeExceededFault: \(message ?? "")"
+            return "BatchDeleteRequestSizeExceeded: \(message ?? "")"
         case .batchModifyClusterSnapshotsLimitExceededFault(let message):
             return "BatchModifyClusterSnapshotsLimitExceededFault: \(message ?? "")"
         case .bucketNotFoundFault(let message):
             return "BucketNotFoundFault: \(message ?? "")"
         case .clusterAlreadyExistsFault(let message):
-            return "ClusterAlreadyExistsFault: \(message ?? "")"
+            return "ClusterAlreadyExists: \(message ?? "")"
         case .clusterNotFoundFault(let message):
-            return "ClusterNotFoundFault: \(message ?? "")"
+            return "ClusterNotFound: \(message ?? "")"
         case .clusterOnLatestRevisionFault(let message):
-            return "ClusterOnLatestRevisionFault: \(message ?? "")"
+            return "ClusterOnLatestRevision: \(message ?? "")"
         case .clusterParameterGroupAlreadyExistsFault(let message):
-            return "ClusterParameterGroupAlreadyExistsFault: \(message ?? "")"
+            return "ClusterParameterGroupAlreadyExists: \(message ?? "")"
         case .clusterParameterGroupNotFoundFault(let message):
-            return "ClusterParameterGroupNotFoundFault: \(message ?? "")"
+            return "ClusterParameterGroupNotFound: \(message ?? "")"
         case .clusterParameterGroupQuotaExceededFault(let message):
-            return "ClusterParameterGroupQuotaExceededFault: \(message ?? "")"
+            return "ClusterParameterGroupQuotaExceeded: \(message ?? "")"
         case .clusterQuotaExceededFault(let message):
-            return "ClusterQuotaExceededFault: \(message ?? "")"
+            return "ClusterQuotaExceeded: \(message ?? "")"
         case .clusterSecurityGroupAlreadyExistsFault(let message):
-            return "ClusterSecurityGroupAlreadyExistsFault: \(message ?? "")"
+            return "ClusterSecurityGroupAlreadyExists: \(message ?? "")"
         case .clusterSecurityGroupNotFoundFault(let message):
-            return "ClusterSecurityGroupNotFoundFault: \(message ?? "")"
+            return "ClusterSecurityGroupNotFound: \(message ?? "")"
         case .clusterSecurityGroupQuotaExceededFault(let message):
-            return "ClusterSecurityGroupQuotaExceededFault: \(message ?? "")"
+            return "QuotaExceeded.ClusterSecurityGroup: \(message ?? "")"
         case .clusterSnapshotAlreadyExistsFault(let message):
-            return "ClusterSnapshotAlreadyExistsFault: \(message ?? "")"
+            return "ClusterSnapshotAlreadyExists: \(message ?? "")"
         case .clusterSnapshotNotFoundFault(let message):
-            return "ClusterSnapshotNotFoundFault: \(message ?? "")"
+            return "ClusterSnapshotNotFound: \(message ?? "")"
         case .clusterSnapshotQuotaExceededFault(let message):
-            return "ClusterSnapshotQuotaExceededFault: \(message ?? "")"
+            return "ClusterSnapshotQuotaExceeded: \(message ?? "")"
         case .clusterSubnetGroupAlreadyExistsFault(let message):
-            return "ClusterSubnetGroupAlreadyExistsFault: \(message ?? "")"
+            return "ClusterSubnetGroupAlreadyExists: \(message ?? "")"
         case .clusterSubnetGroupNotFoundFault(let message):
             return "ClusterSubnetGroupNotFoundFault: \(message ?? "")"
         case .clusterSubnetGroupQuotaExceededFault(let message):
-            return "ClusterSubnetGroupQuotaExceededFault: \(message ?? "")"
+            return "ClusterSubnetGroupQuotaExceeded: \(message ?? "")"
         case .clusterSubnetQuotaExceededFault(let message):
             return "ClusterSubnetQuotaExceededFault: \(message ?? "")"
         case .copyToRegionDisabledFault(let message):
@@ -374,7 +374,7 @@ extension RedshiftErrorType : CustomStringConvertible {
         case .dependentServiceUnavailableFault(let message):
             return "DependentServiceUnavailableFault: \(message ?? "")"
         case .eventSubscriptionQuotaExceededFault(let message):
-            return "EventSubscriptionQuotaExceededFault: \(message ?? "")"
+            return "EventSubscriptionQuotaExceeded: \(message ?? "")"
         case .hsmClientCertificateAlreadyExistsFault(let message):
             return "HsmClientCertificateAlreadyExistsFault: \(message ?? "")"
         case .hsmClientCertificateNotFoundFault(let message):
@@ -392,25 +392,25 @@ extension RedshiftErrorType : CustomStringConvertible {
         case .incompatibleOrderableOptions(let message):
             return "IncompatibleOrderableOptions: \(message ?? "")"
         case .insufficientClusterCapacityFault(let message):
-            return "InsufficientClusterCapacityFault: \(message ?? "")"
+            return "InsufficientClusterCapacity: \(message ?? "")"
         case .insufficientS3BucketPolicyFault(let message):
             return "InsufficientS3BucketPolicyFault: \(message ?? "")"
         case .invalidClusterParameterGroupStateFault(let message):
-            return "InvalidClusterParameterGroupStateFault: \(message ?? "")"
+            return "InvalidClusterParameterGroupState: \(message ?? "")"
         case .invalidClusterSecurityGroupStateFault(let message):
-            return "InvalidClusterSecurityGroupStateFault: \(message ?? "")"
+            return "InvalidClusterSecurityGroupState: \(message ?? "")"
         case .invalidClusterSnapshotScheduleStateFault(let message):
-            return "InvalidClusterSnapshotScheduleStateFault: \(message ?? "")"
+            return "InvalidClusterSnapshotScheduleState: \(message ?? "")"
         case .invalidClusterSnapshotStateFault(let message):
-            return "InvalidClusterSnapshotStateFault: \(message ?? "")"
+            return "InvalidClusterSnapshotState: \(message ?? "")"
         case .invalidClusterStateFault(let message):
-            return "InvalidClusterStateFault: \(message ?? "")"
+            return "InvalidClusterState: \(message ?? "")"
         case .invalidClusterSubnetGroupStateFault(let message):
             return "InvalidClusterSubnetGroupStateFault: \(message ?? "")"
         case .invalidClusterSubnetStateFault(let message):
             return "InvalidClusterSubnetStateFault: \(message ?? "")"
         case .invalidClusterTrackFault(let message):
-            return "InvalidClusterTrackFault: \(message ?? "")"
+            return "InvalidClusterTrack: \(message ?? "")"
         case .invalidElasticIpFault(let message):
             return "InvalidElasticIpFault: \(message ?? "")"
         case .invalidHsmClientCertificateStateFault(let message):
@@ -418,9 +418,9 @@ extension RedshiftErrorType : CustomStringConvertible {
         case .invalidHsmConfigurationStateFault(let message):
             return "InvalidHsmConfigurationStateFault: \(message ?? "")"
         case .invalidReservedNodeStateFault(let message):
-            return "InvalidReservedNodeStateFault: \(message ?? "")"
+            return "InvalidReservedNodeState: \(message ?? "")"
         case .invalidRestoreFault(let message):
-            return "InvalidRestoreFault: \(message ?? "")"
+            return "InvalidRestore: \(message ?? "")"
         case .invalidRetentionPeriodFault(let message):
             return "InvalidRetentionPeriodFault: \(message ?? "")"
         case .invalidS3BucketNameFault(let message):
@@ -428,7 +428,7 @@ extension RedshiftErrorType : CustomStringConvertible {
         case .invalidS3KeyPrefixFault(let message):
             return "InvalidS3KeyPrefixFault: \(message ?? "")"
         case .invalidScheduleFault(let message):
-            return "InvalidScheduleFault: \(message ?? "")"
+            return "InvalidSchedule: \(message ?? "")"
         case .invalidSnapshotCopyGrantStateFault(let message):
             return "InvalidSnapshotCopyGrantStateFault: \(message ?? "")"
         case .invalidSubnet(let message):
@@ -436,7 +436,7 @@ extension RedshiftErrorType : CustomStringConvertible {
         case .invalidSubscriptionStateFault(let message):
             return "InvalidSubscriptionStateFault: \(message ?? "")"
         case .invalidTableRestoreArgumentFault(let message):
-            return "InvalidTableRestoreArgumentFault: \(message ?? "")"
+            return "InvalidTableRestoreArgument: \(message ?? "")"
         case .invalidTagFault(let message):
             return "InvalidTagFault: \(message ?? "")"
         case .invalidVPCNetworkStateFault(let message):
@@ -444,31 +444,31 @@ extension RedshiftErrorType : CustomStringConvertible {
         case .limitExceededFault(let message):
             return "LimitExceededFault: \(message ?? "")"
         case .numberOfNodesPerClusterLimitExceededFault(let message):
-            return "NumberOfNodesPerClusterLimitExceededFault: \(message ?? "")"
+            return "NumberOfNodesPerClusterLimitExceeded: \(message ?? "")"
         case .numberOfNodesQuotaExceededFault(let message):
-            return "NumberOfNodesQuotaExceededFault: \(message ?? "")"
+            return "NumberOfNodesQuotaExceeded: \(message ?? "")"
         case .reservedNodeAlreadyExistsFault(let message):
-            return "ReservedNodeAlreadyExistsFault: \(message ?? "")"
+            return "ReservedNodeAlreadyExists: \(message ?? "")"
         case .reservedNodeAlreadyMigratedFault(let message):
-            return "ReservedNodeAlreadyMigratedFault: \(message ?? "")"
+            return "ReservedNodeAlreadyMigrated: \(message ?? "")"
         case .reservedNodeNotFoundFault(let message):
-            return "ReservedNodeNotFoundFault: \(message ?? "")"
+            return "ReservedNodeNotFound: \(message ?? "")"
         case .reservedNodeOfferingNotFoundFault(let message):
-            return "ReservedNodeOfferingNotFoundFault: \(message ?? "")"
+            return "ReservedNodeOfferingNotFound: \(message ?? "")"
         case .reservedNodeQuotaExceededFault(let message):
-            return "ReservedNodeQuotaExceededFault: \(message ?? "")"
+            return "ReservedNodeQuotaExceeded: \(message ?? "")"
         case .resizeNotFoundFault(let message):
-            return "ResizeNotFoundFault: \(message ?? "")"
+            return "ResizeNotFound: \(message ?? "")"
         case .resourceNotFoundFault(let message):
             return "ResourceNotFoundFault: \(message ?? "")"
         case .sNSInvalidTopicFault(let message):
-            return "SNSInvalidTopicFault: \(message ?? "")"
+            return "SNSInvalidTopic: \(message ?? "")"
         case .sNSNoAuthorizationFault(let message):
-            return "SNSNoAuthorizationFault: \(message ?? "")"
+            return "SNSNoAuthorization: \(message ?? "")"
         case .sNSTopicArnNotFoundFault(let message):
-            return "SNSTopicArnNotFoundFault: \(message ?? "")"
+            return "SNSTopicArnNotFound: \(message ?? "")"
         case .scheduleDefinitionTypeUnsupportedFault(let message):
-            return "ScheduleDefinitionTypeUnsupportedFault: \(message ?? "")"
+            return "ScheduleDefinitionTypeUnsupported: \(message ?? "")"
         case .snapshotCopyAlreadyDisabledFault(let message):
             return "SnapshotCopyAlreadyDisabledFault: \(message ?? "")"
         case .snapshotCopyAlreadyEnabledFault(let message):
@@ -482,29 +482,29 @@ extension RedshiftErrorType : CustomStringConvertible {
         case .snapshotCopyGrantQuotaExceededFault(let message):
             return "SnapshotCopyGrantQuotaExceededFault: \(message ?? "")"
         case .snapshotScheduleAlreadyExistsFault(let message):
-            return "SnapshotScheduleAlreadyExistsFault: \(message ?? "")"
+            return "SnapshotScheduleAlreadyExists: \(message ?? "")"
         case .snapshotScheduleNotFoundFault(let message):
-            return "SnapshotScheduleNotFoundFault: \(message ?? "")"
+            return "SnapshotScheduleNotFound: \(message ?? "")"
         case .snapshotScheduleQuotaExceededFault(let message):
-            return "SnapshotScheduleQuotaExceededFault: \(message ?? "")"
+            return "SnapshotScheduleQuotaExceeded: \(message ?? "")"
         case .snapshotScheduleUpdateInProgressFault(let message):
-            return "SnapshotScheduleUpdateInProgressFault: \(message ?? "")"
+            return "SnapshotScheduleUpdateInProgress: \(message ?? "")"
         case .sourceNotFoundFault(let message):
-            return "SourceNotFoundFault: \(message ?? "")"
+            return "SourceNotFound: \(message ?? "")"
         case .subnetAlreadyInUse(let message):
             return "SubnetAlreadyInUse: \(message ?? "")"
         case .subscriptionAlreadyExistFault(let message):
-            return "SubscriptionAlreadyExistFault: \(message ?? "")"
+            return "SubscriptionAlreadyExist: \(message ?? "")"
         case .subscriptionCategoryNotFoundFault(let message):
-            return "SubscriptionCategoryNotFoundFault: \(message ?? "")"
+            return "SubscriptionCategoryNotFound: \(message ?? "")"
         case .subscriptionEventIdNotFoundFault(let message):
-            return "SubscriptionEventIdNotFoundFault: \(message ?? "")"
+            return "SubscriptionEventIdNotFound: \(message ?? "")"
         case .subscriptionNotFoundFault(let message):
-            return "SubscriptionNotFoundFault: \(message ?? "")"
+            return "SubscriptionNotFound: \(message ?? "")"
         case .subscriptionSeverityNotFoundFault(let message):
-            return "SubscriptionSeverityNotFoundFault: \(message ?? "")"
+            return "SubscriptionSeverityNotFound: \(message ?? "")"
         case .tableLimitExceededFault(let message):
-            return "TableLimitExceededFault: \(message ?? "")"
+            return "TableLimitExceeded: \(message ?? "")"
         case .tableRestoreNotFoundFault(let message):
             return "TableRestoreNotFoundFault: \(message ?? "")"
         case .tagLimitExceededFault(let message):
@@ -514,7 +514,7 @@ extension RedshiftErrorType : CustomStringConvertible {
         case .unknownSnapshotCopyRegionFault(let message):
             return "UnknownSnapshotCopyRegionFault: \(message ?? "")"
         case .unsupportedOperationFault(let message):
-            return "UnsupportedOperationFault: \(message ?? "")"
+            return "UnsupportedOperation: \(message ?? "")"
         case .unsupportedOptionFault(let message):
             return "UnsupportedOptionFault: \(message ?? "")"
         }

--- a/Sources/AWSSDKSwift/Services/SES/SES_Error.swift
+++ b/Sources/AWSSDKSwift/Services/SES/SES_Error.swift
@@ -49,67 +49,67 @@ extension SESErrorType {
         switch errorCode {
         case "AccountSendingPausedException":
             self = .accountSendingPausedException(message: message)
-        case "AlreadyExistsException":
+        case "AlreadyExists":
             self = .alreadyExistsException(message: message)
-        case "CannotDeleteException":
+        case "CannotDelete":
             self = .cannotDeleteException(message: message)
-        case "ConfigurationSetAlreadyExistsException":
+        case "ConfigurationSetAlreadyExists":
             self = .configurationSetAlreadyExistsException(message: message)
-        case "ConfigurationSetDoesNotExistException":
+        case "ConfigurationSetDoesNotExist":
             self = .configurationSetDoesNotExistException(message: message)
         case "ConfigurationSetSendingPausedException":
             self = .configurationSetSendingPausedException(message: message)
-        case "CustomVerificationEmailInvalidContentException":
+        case "CustomVerificationEmailInvalidContent":
             self = .customVerificationEmailInvalidContentException(message: message)
-        case "CustomVerificationEmailTemplateAlreadyExistsException":
+        case "CustomVerificationEmailTemplateAlreadyExists":
             self = .customVerificationEmailTemplateAlreadyExistsException(message: message)
-        case "CustomVerificationEmailTemplateDoesNotExistException":
+        case "CustomVerificationEmailTemplateDoesNotExist":
             self = .customVerificationEmailTemplateDoesNotExistException(message: message)
-        case "EventDestinationAlreadyExistsException":
+        case "EventDestinationAlreadyExists":
             self = .eventDestinationAlreadyExistsException(message: message)
-        case "EventDestinationDoesNotExistException":
+        case "EventDestinationDoesNotExist":
             self = .eventDestinationDoesNotExistException(message: message)
-        case "FromEmailAddressNotVerifiedException":
+        case "FromEmailAddressNotVerified":
             self = .fromEmailAddressNotVerifiedException(message: message)
-        case "InvalidCloudWatchDestinationException":
+        case "InvalidCloudWatchDestination":
             self = .invalidCloudWatchDestinationException(message: message)
-        case "InvalidConfigurationSetException":
+        case "InvalidConfigurationSet":
             self = .invalidConfigurationSetException(message: message)
-        case "InvalidDeliveryOptionsException":
+        case "InvalidDeliveryOptions":
             self = .invalidDeliveryOptionsException(message: message)
-        case "InvalidFirehoseDestinationException":
+        case "InvalidFirehoseDestination":
             self = .invalidFirehoseDestinationException(message: message)
-        case "InvalidLambdaFunctionException":
+        case "InvalidLambdaFunction":
             self = .invalidLambdaFunctionException(message: message)
-        case "InvalidPolicyException":
+        case "InvalidPolicy":
             self = .invalidPolicyException(message: message)
-        case "InvalidRenderingParameterException":
+        case "InvalidRenderingParameter":
             self = .invalidRenderingParameterException(message: message)
-        case "InvalidS3ConfigurationException":
+        case "InvalidS3Configuration":
             self = .invalidS3ConfigurationException(message: message)
-        case "InvalidSNSDestinationException":
+        case "InvalidSNSDestination":
             self = .invalidSNSDestinationException(message: message)
-        case "InvalidSnsTopicException":
+        case "InvalidSnsTopic":
             self = .invalidSnsTopicException(message: message)
-        case "InvalidTemplateException":
+        case "InvalidTemplate":
             self = .invalidTemplateException(message: message)
-        case "InvalidTrackingOptionsException":
+        case "InvalidTrackingOptions":
             self = .invalidTrackingOptionsException(message: message)
-        case "LimitExceededException":
+        case "LimitExceeded":
             self = .limitExceededException(message: message)
         case "MailFromDomainNotVerifiedException":
             self = .mailFromDomainNotVerifiedException(message: message)
         case "MessageRejected":
             self = .messageRejected(message: message)
-        case "MissingRenderingAttributeException":
+        case "MissingRenderingAttribute":
             self = .missingRenderingAttributeException(message: message)
-        case "ProductionAccessNotGrantedException":
+        case "ProductionAccessNotGranted":
             self = .productionAccessNotGrantedException(message: message)
-        case "RuleDoesNotExistException":
+        case "RuleDoesNotExist":
             self = .ruleDoesNotExistException(message: message)
-        case "RuleSetDoesNotExistException":
+        case "RuleSetDoesNotExist":
             self = .ruleSetDoesNotExistException(message: message)
-        case "TemplateDoesNotExistException":
+        case "TemplateDoesNotExist":
             self = .templateDoesNotExistException(message: message)
         case "TrackingOptionsAlreadyExistsException":
             self = .trackingOptionsAlreadyExistsException(message: message)
@@ -127,67 +127,67 @@ extension SESErrorType : CustomStringConvertible {
         case .accountSendingPausedException(let message):
             return "AccountSendingPausedException: \(message ?? "")"
         case .alreadyExistsException(let message):
-            return "AlreadyExistsException: \(message ?? "")"
+            return "AlreadyExists: \(message ?? "")"
         case .cannotDeleteException(let message):
-            return "CannotDeleteException: \(message ?? "")"
+            return "CannotDelete: \(message ?? "")"
         case .configurationSetAlreadyExistsException(let message):
-            return "ConfigurationSetAlreadyExistsException: \(message ?? "")"
+            return "ConfigurationSetAlreadyExists: \(message ?? "")"
         case .configurationSetDoesNotExistException(let message):
-            return "ConfigurationSetDoesNotExistException: \(message ?? "")"
+            return "ConfigurationSetDoesNotExist: \(message ?? "")"
         case .configurationSetSendingPausedException(let message):
             return "ConfigurationSetSendingPausedException: \(message ?? "")"
         case .customVerificationEmailInvalidContentException(let message):
-            return "CustomVerificationEmailInvalidContentException: \(message ?? "")"
+            return "CustomVerificationEmailInvalidContent: \(message ?? "")"
         case .customVerificationEmailTemplateAlreadyExistsException(let message):
-            return "CustomVerificationEmailTemplateAlreadyExistsException: \(message ?? "")"
+            return "CustomVerificationEmailTemplateAlreadyExists: \(message ?? "")"
         case .customVerificationEmailTemplateDoesNotExistException(let message):
-            return "CustomVerificationEmailTemplateDoesNotExistException: \(message ?? "")"
+            return "CustomVerificationEmailTemplateDoesNotExist: \(message ?? "")"
         case .eventDestinationAlreadyExistsException(let message):
-            return "EventDestinationAlreadyExistsException: \(message ?? "")"
+            return "EventDestinationAlreadyExists: \(message ?? "")"
         case .eventDestinationDoesNotExistException(let message):
-            return "EventDestinationDoesNotExistException: \(message ?? "")"
+            return "EventDestinationDoesNotExist: \(message ?? "")"
         case .fromEmailAddressNotVerifiedException(let message):
-            return "FromEmailAddressNotVerifiedException: \(message ?? "")"
+            return "FromEmailAddressNotVerified: \(message ?? "")"
         case .invalidCloudWatchDestinationException(let message):
-            return "InvalidCloudWatchDestinationException: \(message ?? "")"
+            return "InvalidCloudWatchDestination: \(message ?? "")"
         case .invalidConfigurationSetException(let message):
-            return "InvalidConfigurationSetException: \(message ?? "")"
+            return "InvalidConfigurationSet: \(message ?? "")"
         case .invalidDeliveryOptionsException(let message):
-            return "InvalidDeliveryOptionsException: \(message ?? "")"
+            return "InvalidDeliveryOptions: \(message ?? "")"
         case .invalidFirehoseDestinationException(let message):
-            return "InvalidFirehoseDestinationException: \(message ?? "")"
+            return "InvalidFirehoseDestination: \(message ?? "")"
         case .invalidLambdaFunctionException(let message):
-            return "InvalidLambdaFunctionException: \(message ?? "")"
+            return "InvalidLambdaFunction: \(message ?? "")"
         case .invalidPolicyException(let message):
-            return "InvalidPolicyException: \(message ?? "")"
+            return "InvalidPolicy: \(message ?? "")"
         case .invalidRenderingParameterException(let message):
-            return "InvalidRenderingParameterException: \(message ?? "")"
+            return "InvalidRenderingParameter: \(message ?? "")"
         case .invalidS3ConfigurationException(let message):
-            return "InvalidS3ConfigurationException: \(message ?? "")"
+            return "InvalidS3Configuration: \(message ?? "")"
         case .invalidSNSDestinationException(let message):
-            return "InvalidSNSDestinationException: \(message ?? "")"
+            return "InvalidSNSDestination: \(message ?? "")"
         case .invalidSnsTopicException(let message):
-            return "InvalidSnsTopicException: \(message ?? "")"
+            return "InvalidSnsTopic: \(message ?? "")"
         case .invalidTemplateException(let message):
-            return "InvalidTemplateException: \(message ?? "")"
+            return "InvalidTemplate: \(message ?? "")"
         case .invalidTrackingOptionsException(let message):
-            return "InvalidTrackingOptionsException: \(message ?? "")"
+            return "InvalidTrackingOptions: \(message ?? "")"
         case .limitExceededException(let message):
-            return "LimitExceededException: \(message ?? "")"
+            return "LimitExceeded: \(message ?? "")"
         case .mailFromDomainNotVerifiedException(let message):
             return "MailFromDomainNotVerifiedException: \(message ?? "")"
         case .messageRejected(let message):
             return "MessageRejected: \(message ?? "")"
         case .missingRenderingAttributeException(let message):
-            return "MissingRenderingAttributeException: \(message ?? "")"
+            return "MissingRenderingAttribute: \(message ?? "")"
         case .productionAccessNotGrantedException(let message):
-            return "ProductionAccessNotGrantedException: \(message ?? "")"
+            return "ProductionAccessNotGranted: \(message ?? "")"
         case .ruleDoesNotExistException(let message):
-            return "RuleDoesNotExistException: \(message ?? "")"
+            return "RuleDoesNotExist: \(message ?? "")"
         case .ruleSetDoesNotExistException(let message):
-            return "RuleSetDoesNotExistException: \(message ?? "")"
+            return "RuleSetDoesNotExist: \(message ?? "")"
         case .templateDoesNotExistException(let message):
-            return "TemplateDoesNotExistException: \(message ?? "")"
+            return "TemplateDoesNotExist: \(message ?? "")"
         case .trackingOptionsAlreadyExistsException(let message):
             return "TrackingOptionsAlreadyExistsException: \(message ?? "")"
         case .trackingOptionsDoesNotExistException(let message):

--- a/Sources/AWSSDKSwift/Services/SNS/SNS_Error.swift
+++ b/Sources/AWSSDKSwift/Services/SNS/SNS_Error.swift
@@ -36,51 +36,51 @@ extension SNSErrorType {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
         switch errorCode {
-        case "AuthorizationErrorException":
+        case "AuthorizationError":
             self = .authorizationErrorException(message: message)
-        case "ConcurrentAccessException":
+        case "ConcurrentAccess":
             self = .concurrentAccessException(message: message)
-        case "EndpointDisabledException":
+        case "EndpointDisabled":
             self = .endpointDisabledException(message: message)
-        case "FilterPolicyLimitExceededException":
+        case "FilterPolicyLimitExceeded":
             self = .filterPolicyLimitExceededException(message: message)
-        case "InternalErrorException":
+        case "InternalError":
             self = .internalErrorException(message: message)
-        case "InvalidParameterException":
+        case "InvalidParameter":
             self = .invalidParameterException(message: message)
-        case "InvalidParameterValueException":
+        case "ParameterValueInvalid":
             self = .invalidParameterValueException(message: message)
-        case "InvalidSecurityException":
+        case "InvalidSecurity":
             self = .invalidSecurityException(message: message)
-        case "KMSAccessDeniedException":
+        case "KMSAccessDenied":
             self = .kMSAccessDeniedException(message: message)
-        case "KMSDisabledException":
+        case "KMSDisabled":
             self = .kMSDisabledException(message: message)
-        case "KMSInvalidStateException":
+        case "KMSInvalidState":
             self = .kMSInvalidStateException(message: message)
-        case "KMSNotFoundException":
+        case "KMSNotFound":
             self = .kMSNotFoundException(message: message)
         case "KMSOptInRequired":
             self = .kMSOptInRequired(message: message)
-        case "KMSThrottlingException":
+        case "KMSThrottling":
             self = .kMSThrottlingException(message: message)
-        case "NotFoundException":
+        case "NotFound":
             self = .notFoundException(message: message)
-        case "PlatformApplicationDisabledException":
+        case "PlatformApplicationDisabled":
             self = .platformApplicationDisabledException(message: message)
-        case "ResourceNotFoundException":
+        case "ResourceNotFound":
             self = .resourceNotFoundException(message: message)
-        case "StaleTagException":
+        case "StaleTag":
             self = .staleTagException(message: message)
-        case "SubscriptionLimitExceededException":
+        case "SubscriptionLimitExceeded":
             self = .subscriptionLimitExceededException(message: message)
-        case "TagLimitExceededException":
+        case "TagLimitExceeded":
             self = .tagLimitExceededException(message: message)
-        case "TagPolicyException":
+        case "TagPolicy":
             self = .tagPolicyException(message: message)
-        case "ThrottledException":
+        case "Throttled":
             self = .throttledException(message: message)
-        case "TopicLimitExceededException":
+        case "TopicLimitExceeded":
             self = .topicLimitExceededException(message: message)
         default:
             return nil
@@ -92,51 +92,51 @@ extension SNSErrorType : CustomStringConvertible {
     public var description : String {
         switch self {
         case .authorizationErrorException(let message):
-            return "AuthorizationErrorException: \(message ?? "")"
+            return "AuthorizationError: \(message ?? "")"
         case .concurrentAccessException(let message):
-            return "ConcurrentAccessException: \(message ?? "")"
+            return "ConcurrentAccess: \(message ?? "")"
         case .endpointDisabledException(let message):
-            return "EndpointDisabledException: \(message ?? "")"
+            return "EndpointDisabled: \(message ?? "")"
         case .filterPolicyLimitExceededException(let message):
-            return "FilterPolicyLimitExceededException: \(message ?? "")"
+            return "FilterPolicyLimitExceeded: \(message ?? "")"
         case .internalErrorException(let message):
-            return "InternalErrorException: \(message ?? "")"
+            return "InternalError: \(message ?? "")"
         case .invalidParameterException(let message):
-            return "InvalidParameterException: \(message ?? "")"
+            return "InvalidParameter: \(message ?? "")"
         case .invalidParameterValueException(let message):
-            return "InvalidParameterValueException: \(message ?? "")"
+            return "ParameterValueInvalid: \(message ?? "")"
         case .invalidSecurityException(let message):
-            return "InvalidSecurityException: \(message ?? "")"
+            return "InvalidSecurity: \(message ?? "")"
         case .kMSAccessDeniedException(let message):
-            return "KMSAccessDeniedException: \(message ?? "")"
+            return "KMSAccessDenied: \(message ?? "")"
         case .kMSDisabledException(let message):
-            return "KMSDisabledException: \(message ?? "")"
+            return "KMSDisabled: \(message ?? "")"
         case .kMSInvalidStateException(let message):
-            return "KMSInvalidStateException: \(message ?? "")"
+            return "KMSInvalidState: \(message ?? "")"
         case .kMSNotFoundException(let message):
-            return "KMSNotFoundException: \(message ?? "")"
+            return "KMSNotFound: \(message ?? "")"
         case .kMSOptInRequired(let message):
             return "KMSOptInRequired: \(message ?? "")"
         case .kMSThrottlingException(let message):
-            return "KMSThrottlingException: \(message ?? "")"
+            return "KMSThrottling: \(message ?? "")"
         case .notFoundException(let message):
-            return "NotFoundException: \(message ?? "")"
+            return "NotFound: \(message ?? "")"
         case .platformApplicationDisabledException(let message):
-            return "PlatformApplicationDisabledException: \(message ?? "")"
+            return "PlatformApplicationDisabled: \(message ?? "")"
         case .resourceNotFoundException(let message):
-            return "ResourceNotFoundException: \(message ?? "")"
+            return "ResourceNotFound: \(message ?? "")"
         case .staleTagException(let message):
-            return "StaleTagException: \(message ?? "")"
+            return "StaleTag: \(message ?? "")"
         case .subscriptionLimitExceededException(let message):
-            return "SubscriptionLimitExceededException: \(message ?? "")"
+            return "SubscriptionLimitExceeded: \(message ?? "")"
         case .tagLimitExceededException(let message):
-            return "TagLimitExceededException: \(message ?? "")"
+            return "TagLimitExceeded: \(message ?? "")"
         case .tagPolicyException(let message):
-            return "TagPolicyException: \(message ?? "")"
+            return "TagPolicy: \(message ?? "")"
         case .throttledException(let message):
-            return "ThrottledException: \(message ?? "")"
+            return "Throttled: \(message ?? "")"
         case .topicLimitExceededException(let message):
-            return "TopicLimitExceededException: \(message ?? "")"
+            return "TopicLimitExceeded: \(message ?? "")"
         }
     }
 }

--- a/Sources/AWSSDKSwift/Services/SQS/SQS_Error.swift
+++ b/Sources/AWSSDKSwift/Services/SQS/SQS_Error.swift
@@ -29,37 +29,37 @@ extension SQSErrorType {
             errorCode = String(errorCode[errorCode.index(index, offsetBy: 1)...])
         }
         switch errorCode {
-        case "BatchEntryIdsNotDistinct":
+        case "AWS.SimpleQueueService.BatchEntryIdsNotDistinct":
             self = .batchEntryIdsNotDistinct(message: message)
-        case "BatchRequestTooLong":
+        case "AWS.SimpleQueueService.BatchRequestTooLong":
             self = .batchRequestTooLong(message: message)
-        case "EmptyBatchRequest":
+        case "AWS.SimpleQueueService.EmptyBatchRequest":
             self = .emptyBatchRequest(message: message)
         case "InvalidAttributeName":
             self = .invalidAttributeName(message: message)
-        case "InvalidBatchEntryId":
+        case "AWS.SimpleQueueService.InvalidBatchEntryId":
             self = .invalidBatchEntryId(message: message)
         case "InvalidIdFormat":
             self = .invalidIdFormat(message: message)
         case "InvalidMessageContents":
             self = .invalidMessageContents(message: message)
-        case "MessageNotInflight":
+        case "AWS.SimpleQueueService.MessageNotInflight":
             self = .messageNotInflight(message: message)
         case "OverLimit":
             self = .overLimit(message: message)
-        case "PurgeQueueInProgress":
+        case "AWS.SimpleQueueService.PurgeQueueInProgress":
             self = .purgeQueueInProgress(message: message)
-        case "QueueDeletedRecently":
+        case "AWS.SimpleQueueService.QueueDeletedRecently":
             self = .queueDeletedRecently(message: message)
-        case "QueueDoesNotExist":
+        case "AWS.SimpleQueueService.NonExistentQueue":
             self = .queueDoesNotExist(message: message)
-        case "QueueNameExists":
+        case "QueueAlreadyExists":
             self = .queueNameExists(message: message)
         case "ReceiptHandleIsInvalid":
             self = .receiptHandleIsInvalid(message: message)
-        case "TooManyEntriesInBatchRequest":
+        case "AWS.SimpleQueueService.TooManyEntriesInBatchRequest":
             self = .tooManyEntriesInBatchRequest(message: message)
-        case "UnsupportedOperation":
+        case "AWS.SimpleQueueService.UnsupportedOperation":
             self = .unsupportedOperation(message: message)
         default:
             return nil
@@ -71,37 +71,37 @@ extension SQSErrorType : CustomStringConvertible {
     public var description : String {
         switch self {
         case .batchEntryIdsNotDistinct(let message):
-            return "BatchEntryIdsNotDistinct: \(message ?? "")"
+            return "AWS.SimpleQueueService.BatchEntryIdsNotDistinct: \(message ?? "")"
         case .batchRequestTooLong(let message):
-            return "BatchRequestTooLong: \(message ?? "")"
+            return "AWS.SimpleQueueService.BatchRequestTooLong: \(message ?? "")"
         case .emptyBatchRequest(let message):
-            return "EmptyBatchRequest: \(message ?? "")"
+            return "AWS.SimpleQueueService.EmptyBatchRequest: \(message ?? "")"
         case .invalidAttributeName(let message):
             return "InvalidAttributeName: \(message ?? "")"
         case .invalidBatchEntryId(let message):
-            return "InvalidBatchEntryId: \(message ?? "")"
+            return "AWS.SimpleQueueService.InvalidBatchEntryId: \(message ?? "")"
         case .invalidIdFormat(let message):
             return "InvalidIdFormat: \(message ?? "")"
         case .invalidMessageContents(let message):
             return "InvalidMessageContents: \(message ?? "")"
         case .messageNotInflight(let message):
-            return "MessageNotInflight: \(message ?? "")"
+            return "AWS.SimpleQueueService.MessageNotInflight: \(message ?? "")"
         case .overLimit(let message):
             return "OverLimit: \(message ?? "")"
         case .purgeQueueInProgress(let message):
-            return "PurgeQueueInProgress: \(message ?? "")"
+            return "AWS.SimpleQueueService.PurgeQueueInProgress: \(message ?? "")"
         case .queueDeletedRecently(let message):
-            return "QueueDeletedRecently: \(message ?? "")"
+            return "AWS.SimpleQueueService.QueueDeletedRecently: \(message ?? "")"
         case .queueDoesNotExist(let message):
-            return "QueueDoesNotExist: \(message ?? "")"
+            return "AWS.SimpleQueueService.NonExistentQueue: \(message ?? "")"
         case .queueNameExists(let message):
-            return "QueueNameExists: \(message ?? "")"
+            return "QueueAlreadyExists: \(message ?? "")"
         case .receiptHandleIsInvalid(let message):
             return "ReceiptHandleIsInvalid: \(message ?? "")"
         case .tooManyEntriesInBatchRequest(let message):
-            return "TooManyEntriesInBatchRequest: \(message ?? "")"
+            return "AWS.SimpleQueueService.TooManyEntriesInBatchRequest: \(message ?? "")"
         case .unsupportedOperation(let message):
-            return "UnsupportedOperation: \(message ?? "")"
+            return "AWS.SimpleQueueService.UnsupportedOperation: \(message ?? "")"
         }
     }
 }

--- a/Sources/AWSSDKSwift/Services/STS/STS_Error.swift
+++ b/Sources/AWSSDKSwift/Services/STS/STS_Error.swift
@@ -23,17 +23,17 @@ extension STSErrorType {
         switch errorCode {
         case "ExpiredTokenException":
             self = .expiredTokenException(message: message)
-        case "IDPCommunicationErrorException":
+        case "IDPCommunicationError":
             self = .iDPCommunicationErrorException(message: message)
-        case "IDPRejectedClaimException":
+        case "IDPRejectedClaim":
             self = .iDPRejectedClaimException(message: message)
         case "InvalidAuthorizationMessageException":
             self = .invalidAuthorizationMessageException(message: message)
-        case "InvalidIdentityTokenException":
+        case "InvalidIdentityToken":
             self = .invalidIdentityTokenException(message: message)
-        case "MalformedPolicyDocumentException":
+        case "MalformedPolicyDocument":
             self = .malformedPolicyDocumentException(message: message)
-        case "PackedPolicyTooLargeException":
+        case "PackedPolicyTooLarge":
             self = .packedPolicyTooLargeException(message: message)
         case "RegionDisabledException":
             self = .regionDisabledException(message: message)
@@ -49,17 +49,17 @@ extension STSErrorType : CustomStringConvertible {
         case .expiredTokenException(let message):
             return "ExpiredTokenException: \(message ?? "")"
         case .iDPCommunicationErrorException(let message):
-            return "IDPCommunicationErrorException: \(message ?? "")"
+            return "IDPCommunicationError: \(message ?? "")"
         case .iDPRejectedClaimException(let message):
-            return "IDPRejectedClaimException: \(message ?? "")"
+            return "IDPRejectedClaim: \(message ?? "")"
         case .invalidAuthorizationMessageException(let message):
             return "InvalidAuthorizationMessageException: \(message ?? "")"
         case .invalidIdentityTokenException(let message):
-            return "InvalidIdentityTokenException: \(message ?? "")"
+            return "InvalidIdentityToken: \(message ?? "")"
         case .malformedPolicyDocumentException(let message):
-            return "MalformedPolicyDocumentException: \(message ?? "")"
+            return "MalformedPolicyDocument: \(message ?? "")"
         case .packedPolicyTooLargeException(let message):
-            return "PackedPolicyTooLargeException: \(message ?? "")"
+            return "PackedPolicyTooLarge: \(message ?? "")"
         case .regionDisabledException(let message):
             return "RegionDisabledException: \(message ?? "")"
         }


### PR DESCRIPTION
Some services error shapes have an "error" section that contains a "code" string. This is the string returned by AWS when that error occurs, not the error shape name which was previously used.

This resolves issue #187 