### PR TITLE
Event loop group provider changes

### DIFF
--- a/CodeGenerator/Templates/api.stencil
+++ b/CodeGenerator/Templates/api.stencil
@@ -17,7 +17,7 @@ public struct {{ name }} {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
 {% if middlewareClass %}
         let middlewares = [{{middlewareClass}}] + middlewares
 {% endif %}
@@ -42,9 +42,11 @@ public struct {{ name }} {
 {% if partitionEndpoint %}
             partitionEndpoint: "{{partitionEndpoint}}",
 {% endif %}
-            middlewares: middlewares{% if errorTypes %},
-            possibleErrorTypes: [{{errorTypes}}.self]
+            middlewares: middlewares,
+{% if errorTypes %}
+            possibleErrorTypes: [{{errorTypes}}.self],
 {% endif %}
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 {%for op in operations %}

--- a/Sources/AWSSDKSwift/Services/ACM/ACM_API.swift
+++ b/Sources/AWSSDKSwift/Services/ACM/ACM_API.swift
@@ -11,7 +11,7 @@ public struct ACM {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct ACM {
             apiVersion: "2015-12-08",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [ACMErrorType.self]
+            possibleErrorTypes: [ACMErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/ACMPCA/ACMPCA_API.swift
+++ b/Sources/AWSSDKSwift/Services/ACMPCA/ACMPCA_API.swift
@@ -11,7 +11,7 @@ public struct ACMPCA {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct ACMPCA {
             apiVersion: "2017-08-22",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [ACMPCAErrorType.self]
+            possibleErrorTypes: [ACMPCAErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/APIGateway/APIGateway_API.swift
+++ b/Sources/AWSSDKSwift/Services/APIGateway/APIGateway_API.swift
@@ -11,7 +11,7 @@ public struct APIGateway {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct APIGateway {
             apiVersion: "2015-07-09",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [APIGatewayErrorType.self]
+            possibleErrorTypes: [APIGatewayErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/AWSBackup/AWSBackup_API.swift
+++ b/Sources/AWSSDKSwift/Services/AWSBackup/AWSBackup_API.swift
@@ -11,7 +11,7 @@ public struct AWSBackup {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct AWSBackup {
             apiVersion: "2018-11-15",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [AWSBackupErrorType.self]
+            possibleErrorTypes: [AWSBackupErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/AWSDirectoryService/AWSDirectoryService_API.swift
+++ b/Sources/AWSSDKSwift/Services/AWSDirectoryService/AWSDirectoryService_API.swift
@@ -11,7 +11,7 @@ public struct AWSDirectoryService {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct AWSDirectoryService {
             apiVersion: "2015-04-16",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [AWSDirectoryServiceErrorType.self]
+            possibleErrorTypes: [AWSDirectoryServiceErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/AlexaForBusiness/AlexaForBusiness_API.swift
+++ b/Sources/AWSSDKSwift/Services/AlexaForBusiness/AlexaForBusiness_API.swift
@@ -11,7 +11,7 @@ public struct AlexaForBusiness {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct AlexaForBusiness {
             apiVersion: "2017-11-09",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [AlexaForBusinessErrorType.self]
+            possibleErrorTypes: [AlexaForBusinessErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Amplify/Amplify_API.swift
+++ b/Sources/AWSSDKSwift/Services/Amplify/Amplify_API.swift
@@ -11,7 +11,7 @@ public struct Amplify {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct Amplify {
             apiVersion: "2017-07-25",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [AmplifyErrorType.self]
+            possibleErrorTypes: [AmplifyErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/ApiGatewayManagementApi/ApiGatewayManagementApi_API.swift
+++ b/Sources/AWSSDKSwift/Services/ApiGatewayManagementApi/ApiGatewayManagementApi_API.swift
@@ -11,7 +11,7 @@ public struct ApiGatewayManagementApi {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct ApiGatewayManagementApi {
             apiVersion: "2018-11-29",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [ApiGatewayManagementApiErrorType.self]
+            possibleErrorTypes: [ApiGatewayManagementApiErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/ApiGatewayV2/ApiGatewayV2_API.swift
+++ b/Sources/AWSSDKSwift/Services/ApiGatewayV2/ApiGatewayV2_API.swift
@@ -11,7 +11,7 @@ public struct ApiGatewayV2 {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct ApiGatewayV2 {
             apiVersion: "2018-11-29",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [ApiGatewayV2ErrorType.self]
+            possibleErrorTypes: [ApiGatewayV2ErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/AppMesh/AppMesh_API.swift
+++ b/Sources/AWSSDKSwift/Services/AppMesh/AppMesh_API.swift
@@ -23,7 +23,7 @@ public struct AppMesh {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -34,7 +34,8 @@ public struct AppMesh {
             apiVersion: "2019-01-25",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [AppMeshErrorType.self]
+            possibleErrorTypes: [AppMeshErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/AppStream/AppStream_API.swift
+++ b/Sources/AWSSDKSwift/Services/AppStream/AppStream_API.swift
@@ -11,7 +11,7 @@ public struct AppStream {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -25,7 +25,8 @@ public struct AppStream {
             endpoint: endpoint,
             serviceEndpoints: ["fips": "appstream2-fips.us-west-2.amazonaws.com"],
             middlewares: middlewares,
-            possibleErrorTypes: [AppStreamErrorType.self]
+            possibleErrorTypes: [AppStreamErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/AppSync/AppSync_API.swift
+++ b/Sources/AWSSDKSwift/Services/AppSync/AppSync_API.swift
@@ -11,7 +11,7 @@ public struct AppSync {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct AppSync {
             apiVersion: "2017-07-25",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [AppSyncErrorType.self]
+            possibleErrorTypes: [AppSyncErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/ApplicationAutoScaling/ApplicationAutoScaling_API.swift
+++ b/Sources/AWSSDKSwift/Services/ApplicationAutoScaling/ApplicationAutoScaling_API.swift
@@ -11,7 +11,7 @@ public struct ApplicationAutoScaling {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -24,7 +24,8 @@ public struct ApplicationAutoScaling {
             apiVersion: "2016-02-06",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [ApplicationAutoScalingErrorType.self]
+            possibleErrorTypes: [ApplicationAutoScalingErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/ApplicationDiscoveryService/ApplicationDiscoveryService_API.swift
+++ b/Sources/AWSSDKSwift/Services/ApplicationDiscoveryService/ApplicationDiscoveryService_API.swift
@@ -11,7 +11,7 @@ public struct ApplicationDiscoveryService {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct ApplicationDiscoveryService {
             apiVersion: "2015-11-01",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [ApplicationDiscoveryServiceErrorType.self]
+            possibleErrorTypes: [ApplicationDiscoveryServiceErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/ApplicationInsights/ApplicationInsights_API.swift
+++ b/Sources/AWSSDKSwift/Services/ApplicationInsights/ApplicationInsights_API.swift
@@ -11,7 +11,7 @@ public struct ApplicationInsights {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct ApplicationInsights {
             apiVersion: "2018-11-25",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [ApplicationInsightsErrorType.self]
+            possibleErrorTypes: [ApplicationInsightsErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Athena/Athena_API.swift
+++ b/Sources/AWSSDKSwift/Services/Athena/Athena_API.swift
@@ -11,7 +11,7 @@ public struct Athena {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct Athena {
             apiVersion: "2017-05-18",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [AthenaErrorType.self]
+            possibleErrorTypes: [AthenaErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/AutoScaling/AutoScaling_API.swift
+++ b/Sources/AWSSDKSwift/Services/AutoScaling/AutoScaling_API.swift
@@ -11,7 +11,7 @@ public struct AutoScaling {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct AutoScaling {
             apiVersion: "2011-01-01",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [AutoScalingErrorType.self]
+            possibleErrorTypes: [AutoScalingErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/AutoScalingPlans/AutoScalingPlans_API.swift
+++ b/Sources/AWSSDKSwift/Services/AutoScalingPlans/AutoScalingPlans_API.swift
@@ -11,7 +11,7 @@ public struct AutoScalingPlans {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -24,7 +24,8 @@ public struct AutoScalingPlans {
             apiVersion: "2018-01-06",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [AutoScalingPlansErrorType.self]
+            possibleErrorTypes: [AutoScalingPlansErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Batch/Batch_API.swift
+++ b/Sources/AWSSDKSwift/Services/Batch/Batch_API.swift
@@ -11,7 +11,7 @@ public struct Batch {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct Batch {
             apiVersion: "2016-08-10",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [BatchErrorType.self]
+            possibleErrorTypes: [BatchErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Budgets/Budgets_API.swift
+++ b/Sources/AWSSDKSwift/Services/Budgets/Budgets_API.swift
@@ -11,7 +11,7 @@ public struct Budgets {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -25,7 +25,8 @@ public struct Budgets {
             serviceEndpoints: ["aws-global": "budgets.amazonaws.com"],
             partitionEndpoint: "aws-global",
             middlewares: middlewares,
-            possibleErrorTypes: [BudgetsErrorType.self]
+            possibleErrorTypes: [BudgetsErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Chime/Chime_API.swift
+++ b/Sources/AWSSDKSwift/Services/Chime/Chime_API.swift
@@ -11,7 +11,7 @@ public struct Chime {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -24,7 +24,8 @@ public struct Chime {
             serviceEndpoints: ["aws-global": "service.chime.aws.amazon.com"],
             partitionEndpoint: "aws-global",
             middlewares: middlewares,
-            possibleErrorTypes: [ChimeErrorType.self]
+            possibleErrorTypes: [ChimeErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Cloud9/Cloud9_API.swift
+++ b/Sources/AWSSDKSwift/Services/Cloud9/Cloud9_API.swift
@@ -11,7 +11,7 @@ public struct Cloud9 {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct Cloud9 {
             apiVersion: "2017-09-23",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [Cloud9ErrorType.self]
+            possibleErrorTypes: [Cloud9ErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/CloudDirectory/CloudDirectory_API.swift
+++ b/Sources/AWSSDKSwift/Services/CloudDirectory/CloudDirectory_API.swift
@@ -11,7 +11,7 @@ public struct CloudDirectory {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct CloudDirectory {
             apiVersion: "2017-01-11",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [CloudDirectoryErrorType.self]
+            possibleErrorTypes: [CloudDirectoryErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/CloudFormation/CloudFormation_API.swift
+++ b/Sources/AWSSDKSwift/Services/CloudFormation/CloudFormation_API.swift
@@ -11,7 +11,7 @@ public struct CloudFormation {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct CloudFormation {
             apiVersion: "2010-05-15",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [CloudFormationErrorType.self]
+            possibleErrorTypes: [CloudFormationErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/CloudFront/CloudFront_API.swift
+++ b/Sources/AWSSDKSwift/Services/CloudFront/CloudFront_API.swift
@@ -11,7 +11,7 @@ public struct CloudFront {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -24,7 +24,8 @@ public struct CloudFront {
             serviceEndpoints: ["aws-global": "cloudfront.amazonaws.com"],
             partitionEndpoint: "aws-global",
             middlewares: middlewares,
-            possibleErrorTypes: [CloudFrontErrorType.self]
+            possibleErrorTypes: [CloudFrontErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/CloudHSM/CloudHSM_API.swift
+++ b/Sources/AWSSDKSwift/Services/CloudHSM/CloudHSM_API.swift
@@ -11,7 +11,7 @@ public struct CloudHSM {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct CloudHSM {
             apiVersion: "2014-05-30",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [CloudHSMErrorType.self]
+            possibleErrorTypes: [CloudHSMErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/CloudHSMV2/CloudHSMV2_API.swift
+++ b/Sources/AWSSDKSwift/Services/CloudHSMV2/CloudHSMV2_API.swift
@@ -11,7 +11,7 @@ public struct CloudHSMV2 {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -24,7 +24,8 @@ public struct CloudHSMV2 {
             apiVersion: "2017-04-28",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [CloudHSMV2ErrorType.self]
+            possibleErrorTypes: [CloudHSMV2ErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/CloudSearch/CloudSearch_API.swift
+++ b/Sources/AWSSDKSwift/Services/CloudSearch/CloudSearch_API.swift
@@ -11,7 +11,7 @@ public struct CloudSearch {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct CloudSearch {
             apiVersion: "2013-01-01",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [CloudSearchErrorType.self]
+            possibleErrorTypes: [CloudSearchErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/CloudSearchDomain/CloudSearchDomain_API.swift
+++ b/Sources/AWSSDKSwift/Services/CloudSearchDomain/CloudSearchDomain_API.swift
@@ -11,7 +11,7 @@ public struct CloudSearchDomain {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct CloudSearchDomain {
             apiVersion: "2013-01-01",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [CloudSearchDomainErrorType.self]
+            possibleErrorTypes: [CloudSearchDomainErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/CloudTrail/CloudTrail_API.swift
+++ b/Sources/AWSSDKSwift/Services/CloudTrail/CloudTrail_API.swift
@@ -11,7 +11,7 @@ public struct CloudTrail {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct CloudTrail {
             apiVersion: "2013-11-01",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [CloudTrailErrorType.self]
+            possibleErrorTypes: [CloudTrailErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/CloudWatch/CloudWatch_API.swift
+++ b/Sources/AWSSDKSwift/Services/CloudWatch/CloudWatch_API.swift
@@ -11,7 +11,7 @@ public struct CloudWatch {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct CloudWatch {
             apiVersion: "2010-08-01",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [CloudWatchErrorType.self]
+            possibleErrorTypes: [CloudWatchErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/CloudWatchEvents/CloudWatchEvents_API.swift
+++ b/Sources/AWSSDKSwift/Services/CloudWatchEvents/CloudWatchEvents_API.swift
@@ -11,7 +11,7 @@ public struct CloudWatchEvents {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct CloudWatchEvents {
             apiVersion: "2015-10-07",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [CloudWatchEventsErrorType.self]
+            possibleErrorTypes: [CloudWatchEventsErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/CloudWatchLogs/CloudWatchLogs_API.swift
+++ b/Sources/AWSSDKSwift/Services/CloudWatchLogs/CloudWatchLogs_API.swift
@@ -11,7 +11,7 @@ public struct CloudWatchLogs {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct CloudWatchLogs {
             apiVersion: "2014-03-28",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [CloudWatchLogsErrorType.self]
+            possibleErrorTypes: [CloudWatchLogsErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/CodeBuild/CodeBuild_API.swift
+++ b/Sources/AWSSDKSwift/Services/CodeBuild/CodeBuild_API.swift
@@ -11,7 +11,7 @@ public struct CodeBuild {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -24,7 +24,8 @@ public struct CodeBuild {
             endpoint: endpoint,
             serviceEndpoints: ["us-east-1-fips": "codebuild-fips.us-east-1.amazonaws.com", "us-east-2-fips": "codebuild-fips.us-east-2.amazonaws.com", "us-west-1-fips": "codebuild-fips.us-west-1.amazonaws.com", "us-west-2-fips": "codebuild-fips.us-west-2.amazonaws.com"],
             middlewares: middlewares,
-            possibleErrorTypes: [CodeBuildErrorType.self]
+            possibleErrorTypes: [CodeBuildErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/CodeCommit/CodeCommit_API.swift
+++ b/Sources/AWSSDKSwift/Services/CodeCommit/CodeCommit_API.swift
@@ -11,7 +11,7 @@ public struct CodeCommit {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -24,7 +24,8 @@ public struct CodeCommit {
             endpoint: endpoint,
             serviceEndpoints: ["fips": "codecommit-fips.ca-central-1.amazonaws.com"],
             middlewares: middlewares,
-            possibleErrorTypes: [CodeCommitErrorType.self]
+            possibleErrorTypes: [CodeCommitErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/CodeDeploy/CodeDeploy_API.swift
+++ b/Sources/AWSSDKSwift/Services/CodeDeploy/CodeDeploy_API.swift
@@ -11,7 +11,7 @@ public struct CodeDeploy {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -24,7 +24,8 @@ public struct CodeDeploy {
             endpoint: endpoint,
             serviceEndpoints: ["us-east-1-fips": "codedeploy-fips.us-east-1.amazonaws.com", "us-east-2-fips": "codedeploy-fips.us-east-2.amazonaws.com", "us-west-1-fips": "codedeploy-fips.us-west-1.amazonaws.com", "us-west-2-fips": "codedeploy-fips.us-west-2.amazonaws.com"],
             middlewares: middlewares,
-            possibleErrorTypes: [CodeDeployErrorType.self]
+            possibleErrorTypes: [CodeDeployErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/CodePipeline/CodePipeline_API.swift
+++ b/Sources/AWSSDKSwift/Services/CodePipeline/CodePipeline_API.swift
@@ -11,7 +11,7 @@ public struct CodePipeline {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct CodePipeline {
             apiVersion: "2015-07-09",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [CodePipelineErrorType.self]
+            possibleErrorTypes: [CodePipelineErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/CodeStar/CodeStar_API.swift
+++ b/Sources/AWSSDKSwift/Services/CodeStar/CodeStar_API.swift
@@ -11,7 +11,7 @@ public struct CodeStar {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct CodeStar {
             apiVersion: "2017-04-19",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [CodeStarErrorType.self]
+            possibleErrorTypes: [CodeStarErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/CognitoIdentity/CognitoIdentity_API.swift
+++ b/Sources/AWSSDKSwift/Services/CognitoIdentity/CognitoIdentity_API.swift
@@ -11,7 +11,7 @@ public struct CognitoIdentity {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct CognitoIdentity {
             apiVersion: "2014-06-30",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [CognitoIdentityErrorType.self]
+            possibleErrorTypes: [CognitoIdentityErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/CognitoIdentityProvider/CognitoIdentityProvider_API.swift
+++ b/Sources/AWSSDKSwift/Services/CognitoIdentityProvider/CognitoIdentityProvider_API.swift
@@ -11,7 +11,7 @@ public struct CognitoIdentityProvider {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct CognitoIdentityProvider {
             apiVersion: "2016-04-18",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [CognitoIdentityProviderErrorType.self]
+            possibleErrorTypes: [CognitoIdentityProviderErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/CognitoSync/CognitoSync_API.swift
+++ b/Sources/AWSSDKSwift/Services/CognitoSync/CognitoSync_API.swift
@@ -11,7 +11,7 @@ public struct CognitoSync {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct CognitoSync {
             apiVersion: "2014-06-30",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [CognitoSyncErrorType.self]
+            possibleErrorTypes: [CognitoSyncErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Comprehend/Comprehend_API.swift
+++ b/Sources/AWSSDKSwift/Services/Comprehend/Comprehend_API.swift
@@ -11,7 +11,7 @@ public struct Comprehend {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct Comprehend {
             apiVersion: "2017-11-27",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [ComprehendErrorType.self]
+            possibleErrorTypes: [ComprehendErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/ComprehendMedical/ComprehendMedical_API.swift
+++ b/Sources/AWSSDKSwift/Services/ComprehendMedical/ComprehendMedical_API.swift
@@ -11,7 +11,7 @@ public struct ComprehendMedical {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct ComprehendMedical {
             apiVersion: "2018-10-30",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [ComprehendMedicalErrorType.self]
+            possibleErrorTypes: [ComprehendMedicalErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/ConfigService/ConfigService_API.swift
+++ b/Sources/AWSSDKSwift/Services/ConfigService/ConfigService_API.swift
@@ -11,7 +11,7 @@ public struct ConfigService {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct ConfigService {
             apiVersion: "2014-11-12",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [ConfigServiceErrorType.self]
+            possibleErrorTypes: [ConfigServiceErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Connect/Connect_API.swift
+++ b/Sources/AWSSDKSwift/Services/Connect/Connect_API.swift
@@ -11,7 +11,7 @@ public struct Connect {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct Connect {
             apiVersion: "2017-08-08",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [ConnectErrorType.self]
+            possibleErrorTypes: [ConnectErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/CostExplorer/CostExplorer_API.swift
+++ b/Sources/AWSSDKSwift/Services/CostExplorer/CostExplorer_API.swift
@@ -11,7 +11,7 @@ public struct CostExplorer {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -25,7 +25,8 @@ public struct CostExplorer {
             serviceEndpoints: ["aws-global": "ce.us-east-1.amazonaws.com"],
             partitionEndpoint: "aws-global",
             middlewares: middlewares,
-            possibleErrorTypes: [CostExplorerErrorType.self]
+            possibleErrorTypes: [CostExplorerErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/CostandUsageReportService/CostandUsageReportService_API.swift
+++ b/Sources/AWSSDKSwift/Services/CostandUsageReportService/CostandUsageReportService_API.swift
@@ -11,7 +11,7 @@ public struct CostandUsageReportService {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct CostandUsageReportService {
             apiVersion: "2017-01-06",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [CostandUsageReportServiceErrorType.self]
+            possibleErrorTypes: [CostandUsageReportServiceErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/DAX/DAX_API.swift
+++ b/Sources/AWSSDKSwift/Services/DAX/DAX_API.swift
@@ -11,7 +11,7 @@ public struct DAX {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct DAX {
             apiVersion: "2017-04-19",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [DAXErrorType.self]
+            possibleErrorTypes: [DAXErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/DLM/DLM_API.swift
+++ b/Sources/AWSSDKSwift/Services/DLM/DLM_API.swift
@@ -11,7 +11,7 @@ public struct DLM {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct DLM {
             apiVersion: "2018-01-12",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [DLMErrorType.self]
+            possibleErrorTypes: [DLMErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/DataPipeline/DataPipeline_API.swift
+++ b/Sources/AWSSDKSwift/Services/DataPipeline/DataPipeline_API.swift
@@ -11,7 +11,7 @@ public struct DataPipeline {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct DataPipeline {
             apiVersion: "2012-10-29",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [DataPipelineErrorType.self]
+            possibleErrorTypes: [DataPipelineErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/DataSync/DataSync_API.swift
+++ b/Sources/AWSSDKSwift/Services/DataSync/DataSync_API.swift
@@ -11,7 +11,7 @@ public struct DataSync {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -24,7 +24,8 @@ public struct DataSync {
             endpoint: endpoint,
             serviceEndpoints: ["fips-us-east-1": "datasync-fips.us-east-1.amazonaws.com", "fips-us-east-2": "datasync-fips.us-east-2.amazonaws.com", "fips-us-west-1": "datasync-fips.us-west-1.amazonaws.com", "fips-us-west-2": "datasync-fips.us-west-2.amazonaws.com"],
             middlewares: middlewares,
-            possibleErrorTypes: [DataSyncErrorType.self]
+            possibleErrorTypes: [DataSyncErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/DatabaseMigrationService/DatabaseMigrationService_API.swift
+++ b/Sources/AWSSDKSwift/Services/DatabaseMigrationService/DatabaseMigrationService_API.swift
@@ -11,7 +11,7 @@ public struct DatabaseMigrationService {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct DatabaseMigrationService {
             apiVersion: "2016-01-01",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [DatabaseMigrationServiceErrorType.self]
+            possibleErrorTypes: [DatabaseMigrationServiceErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/DeviceFarm/DeviceFarm_API.swift
+++ b/Sources/AWSSDKSwift/Services/DeviceFarm/DeviceFarm_API.swift
@@ -11,7 +11,7 @@ public struct DeviceFarm {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct DeviceFarm {
             apiVersion: "2015-06-23",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [DeviceFarmErrorType.self]
+            possibleErrorTypes: [DeviceFarmErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/DirectConnect/DirectConnect_API.swift
+++ b/Sources/AWSSDKSwift/Services/DirectConnect/DirectConnect_API.swift
@@ -11,7 +11,7 @@ public struct DirectConnect {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct DirectConnect {
             apiVersion: "2012-10-25",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [DirectConnectErrorType.self]
+            possibleErrorTypes: [DirectConnectErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/DocDB/DocDB_API.swift
+++ b/Sources/AWSSDKSwift/Services/DocDB/DocDB_API.swift
@@ -11,7 +11,7 @@ public struct DocDB {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct DocDB {
             apiVersion: "2014-10-31",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [DocDBErrorType.self]
+            possibleErrorTypes: [DocDBErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/DynamoDB/DynamoDB_API.swift
+++ b/Sources/AWSSDKSwift/Services/DynamoDB/DynamoDB_API.swift
@@ -11,7 +11,7 @@ public struct DynamoDB {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -24,7 +24,8 @@ public struct DynamoDB {
             endpoint: endpoint,
             serviceEndpoints: ["ca-central-1-fips": "dynamodb-fips.ca-central-1.amazonaws.com", "local": "localhost:8000", "us-east-1-fips": "dynamodb-fips.us-east-1.amazonaws.com", "us-east-2-fips": "dynamodb-fips.us-east-2.amazonaws.com", "us-west-1-fips": "dynamodb-fips.us-west-1.amazonaws.com", "us-west-2-fips": "dynamodb-fips.us-west-2.amazonaws.com"],
             middlewares: middlewares,
-            possibleErrorTypes: [DynamoDBErrorType.self]
+            possibleErrorTypes: [DynamoDBErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/DynamoDBStreams/DynamoDBStreams_API.swift
+++ b/Sources/AWSSDKSwift/Services/DynamoDBStreams/DynamoDBStreams_API.swift
@@ -11,7 +11,7 @@ public struct DynamoDBStreams {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -25,7 +25,8 @@ public struct DynamoDBStreams {
             endpoint: endpoint,
             serviceEndpoints: ["ca-central-1-fips": "dynamodb-fips.ca-central-1.amazonaws.com", "local": "localhost:8000", "us-east-1-fips": "dynamodb-fips.us-east-1.amazonaws.com", "us-east-2-fips": "dynamodb-fips.us-east-2.amazonaws.com", "us-west-1-fips": "dynamodb-fips.us-west-1.amazonaws.com", "us-west-2-fips": "dynamodb-fips.us-west-2.amazonaws.com"],
             middlewares: middlewares,
-            possibleErrorTypes: [DynamoDBStreamsErrorType.self]
+            possibleErrorTypes: [DynamoDBStreamsErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/EC2/EC2_API.swift
+++ b/Sources/AWSSDKSwift/Services/EC2/EC2_API.swift
@@ -11,7 +11,7 @@ public struct EC2 {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -21,7 +21,9 @@ public struct EC2 {
             serviceProtocol: ServiceProtocol(type: .other("ec2")),
             apiVersion: "2016-11-15",
             endpoint: endpoint,
-            middlewares: middlewares        )
+            middlewares: middlewares,
+            eventLoopGroupProvider: eventLoopGroupProvider
+        )
     }
 
     ///  Accepts the Convertible Reserved Instance exchange quote described in the GetReservedInstancesExchangeQuote call.

--- a/Sources/AWSSDKSwift/Services/EC2InstanceConnect/EC2InstanceConnect_API.swift
+++ b/Sources/AWSSDKSwift/Services/EC2InstanceConnect/EC2InstanceConnect_API.swift
@@ -11,7 +11,7 @@ public struct EC2InstanceConnect {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct EC2InstanceConnect {
             apiVersion: "2018-04-02",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [EC2InstanceConnectErrorType.self]
+            possibleErrorTypes: [EC2InstanceConnectErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/ECR/ECR_API.swift
+++ b/Sources/AWSSDKSwift/Services/ECR/ECR_API.swift
@@ -11,7 +11,7 @@ public struct ECR {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -25,7 +25,8 @@ public struct ECR {
             endpoint: endpoint,
             serviceEndpoints: ["ap-east-1": "api.ecr.ap-east-1.amazonaws.com", "ap-northeast-1": "api.ecr.ap-northeast-1.amazonaws.com", "ap-northeast-2": "api.ecr.ap-northeast-2.amazonaws.com", "ap-south-1": "api.ecr.ap-south-1.amazonaws.com", "ap-southeast-1": "api.ecr.ap-southeast-1.amazonaws.com", "ap-southeast-2": "api.ecr.ap-southeast-2.amazonaws.com", "ca-central-1": "api.ecr.ca-central-1.amazonaws.com", "eu-central-1": "api.ecr.eu-central-1.amazonaws.com", "eu-north-1": "api.ecr.eu-north-1.amazonaws.com", "eu-west-1": "api.ecr.eu-west-1.amazonaws.com", "eu-west-2": "api.ecr.eu-west-2.amazonaws.com", "eu-west-3": "api.ecr.eu-west-3.amazonaws.com", "me-south-1": "api.ecr.me-south-1.amazonaws.com", "sa-east-1": "api.ecr.sa-east-1.amazonaws.com", "us-east-1": "api.ecr.us-east-1.amazonaws.com", "us-east-2": "api.ecr.us-east-2.amazonaws.com", "us-west-1": "api.ecr.us-west-1.amazonaws.com", "us-west-2": "api.ecr.us-west-2.amazonaws.com"],
             middlewares: middlewares,
-            possibleErrorTypes: [ECRErrorType.self]
+            possibleErrorTypes: [ECRErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/ECS/ECS_API.swift
+++ b/Sources/AWSSDKSwift/Services/ECS/ECS_API.swift
@@ -11,7 +11,7 @@ public struct ECS {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct ECS {
             apiVersion: "2014-11-13",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [ECSErrorType.self]
+            possibleErrorTypes: [ECSErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/EFS/EFS_API.swift
+++ b/Sources/AWSSDKSwift/Services/EFS/EFS_API.swift
@@ -11,7 +11,7 @@ public struct EFS {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct EFS {
             apiVersion: "2015-02-01",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [EFSErrorType.self]
+            possibleErrorTypes: [EFSErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/EKS/EKS_API.swift
+++ b/Sources/AWSSDKSwift/Services/EKS/EKS_API.swift
@@ -11,7 +11,7 @@ public struct EKS {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct EKS {
             apiVersion: "2017-11-01",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [EKSErrorType.self]
+            possibleErrorTypes: [EKSErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/ELB/ELB_API.swift
+++ b/Sources/AWSSDKSwift/Services/ELB/ELB_API.swift
@@ -11,7 +11,7 @@ public struct ELB {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct ELB {
             apiVersion: "2012-06-01",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [ELBErrorType.self]
+            possibleErrorTypes: [ELBErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/ELBV2/ELBV2_API.swift
+++ b/Sources/AWSSDKSwift/Services/ELBV2/ELBV2_API.swift
@@ -11,7 +11,7 @@ public struct ELBV2 {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct ELBV2 {
             apiVersion: "2015-12-01",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [ELBV2ErrorType.self]
+            possibleErrorTypes: [ELBV2ErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/EMR/EMR_API.swift
+++ b/Sources/AWSSDKSwift/Services/EMR/EMR_API.swift
@@ -11,7 +11,7 @@ public struct EMR {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct EMR {
             apiVersion: "2009-03-31",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [EMRErrorType.self]
+            possibleErrorTypes: [EMRErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/ElastiCache/ElastiCache_API.swift
+++ b/Sources/AWSSDKSwift/Services/ElastiCache/ElastiCache_API.swift
@@ -11,7 +11,7 @@ public struct ElastiCache {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct ElastiCache {
             endpoint: endpoint,
             serviceEndpoints: ["fips": "elasticache-fips.us-west-1.amazonaws.com"],
             middlewares: middlewares,
-            possibleErrorTypes: [ElastiCacheErrorType.self]
+            possibleErrorTypes: [ElastiCacheErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/ElasticBeanstalk/ElasticBeanstalk_API.swift
+++ b/Sources/AWSSDKSwift/Services/ElasticBeanstalk/ElasticBeanstalk_API.swift
@@ -11,7 +11,7 @@ public struct ElasticBeanstalk {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct ElasticBeanstalk {
             apiVersion: "2010-12-01",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [ElasticBeanstalkErrorType.self]
+            possibleErrorTypes: [ElasticBeanstalkErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/ElasticTranscoder/ElasticTranscoder_API.swift
+++ b/Sources/AWSSDKSwift/Services/ElasticTranscoder/ElasticTranscoder_API.swift
@@ -11,7 +11,7 @@ public struct ElasticTranscoder {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct ElasticTranscoder {
             apiVersion: "2012-09-25",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [ElasticTranscoderErrorType.self]
+            possibleErrorTypes: [ElasticTranscoderErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/ElasticsearchService/ElasticsearchService_API.swift
+++ b/Sources/AWSSDKSwift/Services/ElasticsearchService/ElasticsearchService_API.swift
@@ -11,7 +11,7 @@ public struct ElasticsearchService {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct ElasticsearchService {
             endpoint: endpoint,
             serviceEndpoints: ["fips": "es-fips.us-west-1.amazonaws.com"],
             middlewares: middlewares,
-            possibleErrorTypes: [ElasticsearchServiceErrorType.self]
+            possibleErrorTypes: [ElasticsearchServiceErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/EventBridge/EventBridge_API.swift
+++ b/Sources/AWSSDKSwift/Services/EventBridge/EventBridge_API.swift
@@ -11,7 +11,7 @@ public struct EventBridge {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct EventBridge {
             apiVersion: "2015-10-07",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [EventBridgeErrorType.self]
+            possibleErrorTypes: [EventBridgeErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/FMS/FMS_API.swift
+++ b/Sources/AWSSDKSwift/Services/FMS/FMS_API.swift
@@ -11,7 +11,7 @@ public struct FMS {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct FMS {
             apiVersion: "2018-01-01",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [FMSErrorType.self]
+            possibleErrorTypes: [FMSErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/FSx/FSx_API.swift
+++ b/Sources/AWSSDKSwift/Services/FSx/FSx_API.swift
@@ -11,7 +11,7 @@ public struct FSx {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct FSx {
             apiVersion: "2018-03-01",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [FSxErrorType.self]
+            possibleErrorTypes: [FSxErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Firehose/Firehose_API.swift
+++ b/Sources/AWSSDKSwift/Services/Firehose/Firehose_API.swift
@@ -11,7 +11,7 @@ public struct Firehose {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct Firehose {
             apiVersion: "2015-08-04",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [FirehoseErrorType.self]
+            possibleErrorTypes: [FirehoseErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/ForecastQueryService/ForecastQueryService_API.swift
+++ b/Sources/AWSSDKSwift/Services/ForecastQueryService/ForecastQueryService_API.swift
@@ -11,7 +11,7 @@ public struct ForecastQueryService {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -24,7 +24,8 @@ public struct ForecastQueryService {
             apiVersion: "2018-06-26",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [ForecastQueryServiceErrorType.self]
+            possibleErrorTypes: [ForecastQueryServiceErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/ForecastService/ForecastService_API.swift
+++ b/Sources/AWSSDKSwift/Services/ForecastService/ForecastService_API.swift
@@ -11,7 +11,7 @@ public struct ForecastService {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct ForecastService {
             apiVersion: "2018-06-26",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [ForecastServiceErrorType.self]
+            possibleErrorTypes: [ForecastServiceErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/GameLift/GameLift_API.swift
+++ b/Sources/AWSSDKSwift/Services/GameLift/GameLift_API.swift
@@ -11,7 +11,7 @@ public struct GameLift {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct GameLift {
             apiVersion: "2015-10-01",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [GameLiftErrorType.self]
+            possibleErrorTypes: [GameLiftErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Glacier/Glacier_API.swift
+++ b/Sources/AWSSDKSwift/Services/Glacier/Glacier_API.swift
@@ -13,7 +13,7 @@ public struct Glacier {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         let middlewares = [GlacierRequestMiddleware(apiVersion: "2012-06-01")] + middlewares
         self.client = AWSClient(
             accessKeyId: accessKeyId,
@@ -25,7 +25,8 @@ public struct Glacier {
             apiVersion: "2012-06-01",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [GlacierErrorType.self]
+            possibleErrorTypes: [GlacierErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/GlobalAccelerator/GlobalAccelerator_API.swift
+++ b/Sources/AWSSDKSwift/Services/GlobalAccelerator/GlobalAccelerator_API.swift
@@ -11,7 +11,7 @@ public struct GlobalAccelerator {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct GlobalAccelerator {
             apiVersion: "2018-08-08",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [GlobalAcceleratorErrorType.self]
+            possibleErrorTypes: [GlobalAcceleratorErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Glue/Glue_API.swift
+++ b/Sources/AWSSDKSwift/Services/Glue/Glue_API.swift
@@ -11,7 +11,7 @@ public struct Glue {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct Glue {
             apiVersion: "2017-03-31",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [GlueErrorType.self]
+            possibleErrorTypes: [GlueErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Greengrass/Greengrass_API.swift
+++ b/Sources/AWSSDKSwift/Services/Greengrass/Greengrass_API.swift
@@ -11,7 +11,7 @@ public struct Greengrass {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct Greengrass {
             apiVersion: "2017-06-07",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [GreengrassErrorType.self]
+            possibleErrorTypes: [GreengrassErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/GroundStation/GroundStation_API.swift
+++ b/Sources/AWSSDKSwift/Services/GroundStation/GroundStation_API.swift
@@ -14,7 +14,7 @@ public struct GroundStation {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -25,7 +25,8 @@ public struct GroundStation {
             apiVersion: "2019-05-23",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [GroundStationErrorType.self]
+            possibleErrorTypes: [GroundStationErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/GuardDuty/GuardDuty_API.swift
+++ b/Sources/AWSSDKSwift/Services/GuardDuty/GuardDuty_API.swift
@@ -11,7 +11,7 @@ public struct GuardDuty {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct GuardDuty {
             endpoint: endpoint,
             serviceEndpoints: ["us-east-1-fips": "guardduty-fips.us-east-1.amazonaws.com", "us-east-2-fips": "guardduty-fips.us-east-2.amazonaws.com", "us-west-1-fips": "guardduty-fips.us-west-1.amazonaws.com", "us-west-2-fips": "guardduty-fips.us-west-2.amazonaws.com"],
             middlewares: middlewares,
-            possibleErrorTypes: [GuardDutyErrorType.self]
+            possibleErrorTypes: [GuardDutyErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Health/Health_API.swift
+++ b/Sources/AWSSDKSwift/Services/Health/Health_API.swift
@@ -11,7 +11,7 @@ public struct Health {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct Health {
             apiVersion: "2016-08-04",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [HealthErrorType.self]
+            possibleErrorTypes: [HealthErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/IAM/IAM_API.swift
+++ b/Sources/AWSSDKSwift/Services/IAM/IAM_API.swift
@@ -11,7 +11,7 @@ public struct IAM {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -24,7 +24,8 @@ public struct IAM {
             serviceEndpoints: ["aws-global": "iam.amazonaws.com"],
             partitionEndpoint: "aws-global",
             middlewares: middlewares,
-            possibleErrorTypes: [IAMErrorType.self]
+            possibleErrorTypes: [IAMErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/ImportExport/ImportExport_API.swift
+++ b/Sources/AWSSDKSwift/Services/ImportExport/ImportExport_API.swift
@@ -11,7 +11,7 @@ public struct ImportExport {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -24,7 +24,8 @@ public struct ImportExport {
             serviceEndpoints: ["aws-global": "importexport.amazonaws.com"],
             partitionEndpoint: "aws-global",
             middlewares: middlewares,
-            possibleErrorTypes: [ImportExportErrorType.self]
+            possibleErrorTypes: [ImportExportErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Inspector/Inspector_API.swift
+++ b/Sources/AWSSDKSwift/Services/Inspector/Inspector_API.swift
@@ -11,7 +11,7 @@ public struct Inspector {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct Inspector {
             apiVersion: "2016-02-16",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [InspectorErrorType.self]
+            possibleErrorTypes: [InspectorErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/IoT/IoT_API.swift
+++ b/Sources/AWSSDKSwift/Services/IoT/IoT_API.swift
@@ -11,7 +11,7 @@ public struct IoT {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct IoT {
             apiVersion: "2015-05-28",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [IoTErrorType.self]
+            possibleErrorTypes: [IoTErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/IoT1ClickDevicesService/IoT1ClickDevicesService_API.swift
+++ b/Sources/AWSSDKSwift/Services/IoT1ClickDevicesService/IoT1ClickDevicesService_API.swift
@@ -13,7 +13,7 @@ public struct IoT1ClickDevicesService {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -25,7 +25,8 @@ public struct IoT1ClickDevicesService {
             apiVersion: "2018-05-14",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [IoT1ClickDevicesServiceErrorType.self]
+            possibleErrorTypes: [IoT1ClickDevicesServiceErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/IoT1ClickProjects/IoT1ClickProjects_API.swift
+++ b/Sources/AWSSDKSwift/Services/IoT1ClickProjects/IoT1ClickProjects_API.swift
@@ -11,7 +11,7 @@ public struct IoT1ClickProjects {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct IoT1ClickProjects {
             apiVersion: "2018-05-14",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [IoT1ClickProjectsErrorType.self]
+            possibleErrorTypes: [IoT1ClickProjectsErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/IoTAnalytics/IoTAnalytics_API.swift
+++ b/Sources/AWSSDKSwift/Services/IoTAnalytics/IoTAnalytics_API.swift
@@ -11,7 +11,7 @@ public struct IoTAnalytics {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct IoTAnalytics {
             apiVersion: "2017-11-27",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [IoTAnalyticsErrorType.self]
+            possibleErrorTypes: [IoTAnalyticsErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/IoTDataPlane/IoTDataPlane_API.swift
+++ b/Sources/AWSSDKSwift/Services/IoTDataPlane/IoTDataPlane_API.swift
@@ -11,7 +11,7 @@ public struct IoTDataPlane {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct IoTDataPlane {
             apiVersion: "2015-05-28",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [IoTDataPlaneErrorType.self]
+            possibleErrorTypes: [IoTDataPlaneErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/IoTEvents/IoTEvents_API.swift
+++ b/Sources/AWSSDKSwift/Services/IoTEvents/IoTEvents_API.swift
@@ -11,7 +11,7 @@ public struct IoTEvents {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct IoTEvents {
             apiVersion: "2018-07-27",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [IoTEventsErrorType.self]
+            possibleErrorTypes: [IoTEventsErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/IoTEventsData/IoTEventsData_API.swift
+++ b/Sources/AWSSDKSwift/Services/IoTEventsData/IoTEventsData_API.swift
@@ -11,7 +11,7 @@ public struct IoTEventsData {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct IoTEventsData {
             apiVersion: "2018-10-23",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [IoTEventsDataErrorType.self]
+            possibleErrorTypes: [IoTEventsDataErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/IoTJobsDataPlane/IoTJobsDataPlane_API.swift
+++ b/Sources/AWSSDKSwift/Services/IoTJobsDataPlane/IoTJobsDataPlane_API.swift
@@ -11,7 +11,7 @@ public struct IoTJobsDataPlane {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct IoTJobsDataPlane {
             apiVersion: "2017-09-29",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [IoTJobsDataPlaneErrorType.self]
+            possibleErrorTypes: [IoTJobsDataPlaneErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/IoTThingsGraph/IoTThingsGraph_API.swift
+++ b/Sources/AWSSDKSwift/Services/IoTThingsGraph/IoTThingsGraph_API.swift
@@ -11,7 +11,7 @@ public struct IoTThingsGraph {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct IoTThingsGraph {
             apiVersion: "2018-09-06",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [IoTThingsGraphErrorType.self]
+            possibleErrorTypes: [IoTThingsGraphErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/KMS/KMS_API.swift
+++ b/Sources/AWSSDKSwift/Services/KMS/KMS_API.swift
@@ -11,7 +11,7 @@ public struct KMS {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct KMS {
             apiVersion: "2014-11-01",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [KMSErrorType.self]
+            possibleErrorTypes: [KMSErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Kafka/Kafka_API.swift
+++ b/Sources/AWSSDKSwift/Services/Kafka/Kafka_API.swift
@@ -13,7 +13,7 @@ public struct Kafka {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -24,7 +24,8 @@ public struct Kafka {
             apiVersion: "2018-11-14",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [KafkaErrorType.self]
+            possibleErrorTypes: [KafkaErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Kinesis/Kinesis_API.swift
+++ b/Sources/AWSSDKSwift/Services/Kinesis/Kinesis_API.swift
@@ -11,7 +11,7 @@ public struct Kinesis {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct Kinesis {
             apiVersion: "2013-12-02",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [KinesisErrorType.self]
+            possibleErrorTypes: [KinesisErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/KinesisAnalytics/KinesisAnalytics_API.swift
+++ b/Sources/AWSSDKSwift/Services/KinesisAnalytics/KinesisAnalytics_API.swift
@@ -11,7 +11,7 @@ public struct KinesisAnalytics {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct KinesisAnalytics {
             apiVersion: "2015-08-14",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [KinesisAnalyticsErrorType.self]
+            possibleErrorTypes: [KinesisAnalyticsErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/KinesisAnalyticsV2/KinesisAnalyticsV2_API.swift
+++ b/Sources/AWSSDKSwift/Services/KinesisAnalyticsV2/KinesisAnalyticsV2_API.swift
@@ -11,7 +11,7 @@ public struct KinesisAnalyticsV2 {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct KinesisAnalyticsV2 {
             apiVersion: "2018-05-23",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [KinesisAnalyticsV2ErrorType.self]
+            possibleErrorTypes: [KinesisAnalyticsV2ErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/KinesisVideo/KinesisVideo_API.swift
+++ b/Sources/AWSSDKSwift/Services/KinesisVideo/KinesisVideo_API.swift
@@ -8,7 +8,7 @@ public struct KinesisVideo {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -19,7 +19,8 @@ public struct KinesisVideo {
             apiVersion: "2017-09-30",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [KinesisVideoErrorType.self]
+            possibleErrorTypes: [KinesisVideoErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/KinesisVideoArchivedMedia/KinesisVideoArchivedMedia_API.swift
+++ b/Sources/AWSSDKSwift/Services/KinesisVideoArchivedMedia/KinesisVideoArchivedMedia_API.swift
@@ -8,7 +8,7 @@ public struct KinesisVideoArchivedMedia {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -19,7 +19,8 @@ public struct KinesisVideoArchivedMedia {
             apiVersion: "2017-09-30",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [KinesisVideoArchivedMediaErrorType.self]
+            possibleErrorTypes: [KinesisVideoArchivedMediaErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/KinesisVideoMedia/KinesisVideoMedia_API.swift
+++ b/Sources/AWSSDKSwift/Services/KinesisVideoMedia/KinesisVideoMedia_API.swift
@@ -8,7 +8,7 @@ public struct KinesisVideoMedia {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -19,7 +19,8 @@ public struct KinesisVideoMedia {
             apiVersion: "2017-09-30",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [KinesisVideoMediaErrorType.self]
+            possibleErrorTypes: [KinesisVideoMediaErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/LakeFormation/LakeFormation_API.swift
+++ b/Sources/AWSSDKSwift/Services/LakeFormation/LakeFormation_API.swift
@@ -11,7 +11,7 @@ public struct LakeFormation {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct LakeFormation {
             apiVersion: "2017-03-31",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [LakeFormationErrorType.self]
+            possibleErrorTypes: [LakeFormationErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Lambda/Lambda_API.swift
+++ b/Sources/AWSSDKSwift/Services/Lambda/Lambda_API.swift
@@ -11,7 +11,7 @@ public struct Lambda {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct Lambda {
             apiVersion: "2015-03-31",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [LambdaErrorType.self]
+            possibleErrorTypes: [LambdaErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/LexModelBuildingService/LexModelBuildingService_API.swift
+++ b/Sources/AWSSDKSwift/Services/LexModelBuildingService/LexModelBuildingService_API.swift
@@ -11,7 +11,7 @@ public struct LexModelBuildingService {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct LexModelBuildingService {
             apiVersion: "2017-04-19",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [LexModelBuildingServiceErrorType.self]
+            possibleErrorTypes: [LexModelBuildingServiceErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/LexRuntimeService/LexRuntimeService_API.swift
+++ b/Sources/AWSSDKSwift/Services/LexRuntimeService/LexRuntimeService_API.swift
@@ -11,7 +11,7 @@ public struct LexRuntimeService {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct LexRuntimeService {
             apiVersion: "2016-11-28",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [LexRuntimeServiceErrorType.self]
+            possibleErrorTypes: [LexRuntimeServiceErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/LicenseManager/LicenseManager_API.swift
+++ b/Sources/AWSSDKSwift/Services/LicenseManager/LicenseManager_API.swift
@@ -11,7 +11,7 @@ public struct LicenseManager {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct LicenseManager {
             apiVersion: "2018-08-01",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [LicenseManagerErrorType.self]
+            possibleErrorTypes: [LicenseManagerErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Lightsail/Lightsail_API.swift
+++ b/Sources/AWSSDKSwift/Services/Lightsail/Lightsail_API.swift
@@ -11,7 +11,7 @@ public struct Lightsail {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct Lightsail {
             apiVersion: "2016-11-28",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [LightsailErrorType.self]
+            possibleErrorTypes: [LightsailErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/MQ/MQ_API.swift
+++ b/Sources/AWSSDKSwift/Services/MQ/MQ_API.swift
@@ -11,7 +11,7 @@ public struct MQ {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct MQ {
             endpoint: endpoint,
             serviceEndpoints: ["fips-us-east-1": "mq-fips.us-east-1.amazonaws.com", "fips-us-east-2": "mq-fips.us-east-2.amazonaws.com", "fips-us-west-1": "mq-fips.us-west-1.amazonaws.com", "fips-us-west-2": "mq-fips.us-west-2.amazonaws.com"],
             middlewares: middlewares,
-            possibleErrorTypes: [MQErrorType.self]
+            possibleErrorTypes: [MQErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/MTurk/MTurk_API.swift
+++ b/Sources/AWSSDKSwift/Services/MTurk/MTurk_API.swift
@@ -11,7 +11,7 @@ public struct MTurk {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -24,7 +24,8 @@ public struct MTurk {
             endpoint: endpoint,
             serviceEndpoints: ["sandbox": "mturk-requester-sandbox.us-east-1.amazonaws.com"],
             middlewares: middlewares,
-            possibleErrorTypes: [MTurkErrorType.self]
+            possibleErrorTypes: [MTurkErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/MachineLearning/MachineLearning_API.swift
+++ b/Sources/AWSSDKSwift/Services/MachineLearning/MachineLearning_API.swift
@@ -11,7 +11,7 @@ public struct MachineLearning {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct MachineLearning {
             apiVersion: "2014-12-12",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [MachineLearningErrorType.self]
+            possibleErrorTypes: [MachineLearningErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Macie/Macie_API.swift
+++ b/Sources/AWSSDKSwift/Services/Macie/Macie_API.swift
@@ -11,7 +11,7 @@ public struct Macie {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct Macie {
             apiVersion: "2017-12-19",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [MacieErrorType.self]
+            possibleErrorTypes: [MacieErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/ManagedBlockchain/ManagedBlockchain_API.swift
+++ b/Sources/AWSSDKSwift/Services/ManagedBlockchain/ManagedBlockchain_API.swift
@@ -11,7 +11,7 @@ public struct ManagedBlockchain {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct ManagedBlockchain {
             apiVersion: "2018-09-24",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [ManagedBlockchainErrorType.self]
+            possibleErrorTypes: [ManagedBlockchainErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/MarketplaceCommerceAnalytics/MarketplaceCommerceAnalytics_API.swift
+++ b/Sources/AWSSDKSwift/Services/MarketplaceCommerceAnalytics/MarketplaceCommerceAnalytics_API.swift
@@ -11,7 +11,7 @@ public struct MarketplaceCommerceAnalytics {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct MarketplaceCommerceAnalytics {
             apiVersion: "2015-07-01",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [MarketplaceCommerceAnalyticsErrorType.self]
+            possibleErrorTypes: [MarketplaceCommerceAnalyticsErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/MarketplaceEntitlementService/MarketplaceEntitlementService_API.swift
+++ b/Sources/AWSSDKSwift/Services/MarketplaceEntitlementService/MarketplaceEntitlementService_API.swift
@@ -11,7 +11,7 @@ public struct MarketplaceEntitlementService {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -24,7 +24,8 @@ public struct MarketplaceEntitlementService {
             apiVersion: "2017-01-11",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [MarketplaceEntitlementServiceErrorType.self]
+            possibleErrorTypes: [MarketplaceEntitlementServiceErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/MarketplaceMetering/MarketplaceMetering_API.swift
+++ b/Sources/AWSSDKSwift/Services/MarketplaceMetering/MarketplaceMetering_API.swift
@@ -11,7 +11,7 @@ public struct MarketplaceMetering {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -24,7 +24,8 @@ public struct MarketplaceMetering {
             apiVersion: "2016-01-14",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [MarketplaceMeteringErrorType.self]
+            possibleErrorTypes: [MarketplaceMeteringErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/MediaConnect/MediaConnect_API.swift
+++ b/Sources/AWSSDKSwift/Services/MediaConnect/MediaConnect_API.swift
@@ -11,7 +11,7 @@ public struct MediaConnect {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct MediaConnect {
             apiVersion: "2018-11-14",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [MediaConnectErrorType.self]
+            possibleErrorTypes: [MediaConnectErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/MediaConvert/MediaConvert_API.swift
+++ b/Sources/AWSSDKSwift/Services/MediaConvert/MediaConvert_API.swift
@@ -11,7 +11,7 @@ public struct MediaConvert {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct MediaConvert {
             apiVersion: "2017-08-29",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [MediaConvertErrorType.self]
+            possibleErrorTypes: [MediaConvertErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/MediaLive/MediaLive_API.swift
+++ b/Sources/AWSSDKSwift/Services/MediaLive/MediaLive_API.swift
@@ -11,7 +11,7 @@ public struct MediaLive {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct MediaLive {
             apiVersion: "2017-10-14",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [MediaLiveErrorType.self]
+            possibleErrorTypes: [MediaLiveErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/MediaPackage/MediaPackage_API.swift
+++ b/Sources/AWSSDKSwift/Services/MediaPackage/MediaPackage_API.swift
@@ -11,7 +11,7 @@ public struct MediaPackage {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct MediaPackage {
             apiVersion: "2017-10-12",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [MediaPackageErrorType.self]
+            possibleErrorTypes: [MediaPackageErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/MediaPackageVod/MediaPackageVod_API.swift
+++ b/Sources/AWSSDKSwift/Services/MediaPackageVod/MediaPackageVod_API.swift
@@ -11,7 +11,7 @@ public struct MediaPackageVod {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct MediaPackageVod {
             apiVersion: "2018-11-07",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [MediaPackageVodErrorType.self]
+            possibleErrorTypes: [MediaPackageVodErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/MediaStore/MediaStore_API.swift
+++ b/Sources/AWSSDKSwift/Services/MediaStore/MediaStore_API.swift
@@ -11,7 +11,7 @@ public struct MediaStore {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct MediaStore {
             apiVersion: "2017-09-01",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [MediaStoreErrorType.self]
+            possibleErrorTypes: [MediaStoreErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/MediaStoreData/MediaStoreData_API.swift
+++ b/Sources/AWSSDKSwift/Services/MediaStoreData/MediaStoreData_API.swift
@@ -11,7 +11,7 @@ public struct MediaStoreData {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct MediaStoreData {
             apiVersion: "2017-09-01",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [MediaStoreDataErrorType.self]
+            possibleErrorTypes: [MediaStoreDataErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/MediaTailor/MediaTailor_API.swift
+++ b/Sources/AWSSDKSwift/Services/MediaTailor/MediaTailor_API.swift
@@ -11,7 +11,7 @@ public struct MediaTailor {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct MediaTailor {
             apiVersion: "2018-04-23",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [MediaTailorErrorType.self]
+            possibleErrorTypes: [MediaTailorErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/MigrationHub/MigrationHub_API.swift
+++ b/Sources/AWSSDKSwift/Services/MigrationHub/MigrationHub_API.swift
@@ -11,7 +11,7 @@ public struct MigrationHub {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct MigrationHub {
             apiVersion: "2017-05-31",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [MigrationHubErrorType.self]
+            possibleErrorTypes: [MigrationHubErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Mobile/Mobile_API.swift
+++ b/Sources/AWSSDKSwift/Services/Mobile/Mobile_API.swift
@@ -11,7 +11,7 @@ public struct Mobile {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct Mobile {
             apiVersion: "2017-07-01",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [MobileErrorType.self]
+            possibleErrorTypes: [MobileErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/MobileAnalytics/MobileAnalytics_API.swift
+++ b/Sources/AWSSDKSwift/Services/MobileAnalytics/MobileAnalytics_API.swift
@@ -11,7 +11,7 @@ public struct MobileAnalytics {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct MobileAnalytics {
             apiVersion: "2014-06-05",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [MobileAnalyticsErrorType.self]
+            possibleErrorTypes: [MobileAnalyticsErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Neptune/Neptune_API.swift
+++ b/Sources/AWSSDKSwift/Services/Neptune/Neptune_API.swift
@@ -11,7 +11,7 @@ public struct Neptune {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct Neptune {
             apiVersion: "2014-10-31",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [NeptuneErrorType.self]
+            possibleErrorTypes: [NeptuneErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/OpsWorks/OpsWorks_API.swift
+++ b/Sources/AWSSDKSwift/Services/OpsWorks/OpsWorks_API.swift
@@ -11,7 +11,7 @@ public struct OpsWorks {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct OpsWorks {
             apiVersion: "2013-02-18",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [OpsWorksErrorType.self]
+            possibleErrorTypes: [OpsWorksErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/OpsWorksCM/OpsWorksCM_API.swift
+++ b/Sources/AWSSDKSwift/Services/OpsWorksCM/OpsWorksCM_API.swift
@@ -11,7 +11,7 @@ public struct OpsWorksCM {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct OpsWorksCM {
             apiVersion: "2016-11-01",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [OpsWorksCMErrorType.self]
+            possibleErrorTypes: [OpsWorksCMErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Organizations/Organizations_API.swift
+++ b/Sources/AWSSDKSwift/Services/Organizations/Organizations_API.swift
@@ -11,7 +11,7 @@ public struct Organizations {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -25,7 +25,8 @@ public struct Organizations {
             serviceEndpoints: ["aws-global": "organizations.us-east-1.amazonaws.com"],
             partitionEndpoint: "aws-global",
             middlewares: middlewares,
-            possibleErrorTypes: [OrganizationsErrorType.self]
+            possibleErrorTypes: [OrganizationsErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/PI/PI_API.swift
+++ b/Sources/AWSSDKSwift/Services/PI/PI_API.swift
@@ -11,7 +11,7 @@ public struct PI {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct PI {
             apiVersion: "2018-02-27",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [PIErrorType.self]
+            possibleErrorTypes: [PIErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Personalize/Personalize_API.swift
+++ b/Sources/AWSSDKSwift/Services/Personalize/Personalize_API.swift
@@ -11,7 +11,7 @@ public struct Personalize {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct Personalize {
             apiVersion: "2018-05-22",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [PersonalizeErrorType.self]
+            possibleErrorTypes: [PersonalizeErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/PersonalizeEvents/PersonalizeEvents_API.swift
+++ b/Sources/AWSSDKSwift/Services/PersonalizeEvents/PersonalizeEvents_API.swift
@@ -8,7 +8,7 @@ public struct PersonalizeEvents {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -20,7 +20,8 @@ public struct PersonalizeEvents {
             apiVersion: "2018-03-22",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [PersonalizeEventsErrorType.self]
+            possibleErrorTypes: [PersonalizeEventsErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/PersonalizeRuntime/PersonalizeRuntime_API.swift
+++ b/Sources/AWSSDKSwift/Services/PersonalizeRuntime/PersonalizeRuntime_API.swift
@@ -8,7 +8,7 @@ public struct PersonalizeRuntime {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -20,7 +20,8 @@ public struct PersonalizeRuntime {
             apiVersion: "2018-05-22",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [PersonalizeRuntimeErrorType.self]
+            possibleErrorTypes: [PersonalizeRuntimeErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Pinpoint/Pinpoint_API.swift
+++ b/Sources/AWSSDKSwift/Services/Pinpoint/Pinpoint_API.swift
@@ -11,7 +11,7 @@ public struct Pinpoint {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct Pinpoint {
             apiVersion: "2016-12-01",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [PinpointErrorType.self]
+            possibleErrorTypes: [PinpointErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/PinpointEmail/PinpointEmail_API.swift
+++ b/Sources/AWSSDKSwift/Services/PinpointEmail/PinpointEmail_API.swift
@@ -11,7 +11,7 @@ public struct PinpointEmail {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct PinpointEmail {
             apiVersion: "2018-07-26",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [PinpointEmailErrorType.self]
+            possibleErrorTypes: [PinpointEmailErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/PinpointSMSVoice/PinpointSMSVoice_API.swift
+++ b/Sources/AWSSDKSwift/Services/PinpointSMSVoice/PinpointSMSVoice_API.swift
@@ -11,7 +11,7 @@ public struct PinpointSMSVoice {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct PinpointSMSVoice {
             apiVersion: "2018-09-05",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [PinpointSMSVoiceErrorType.self]
+            possibleErrorTypes: [PinpointSMSVoiceErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Polly/Polly_API.swift
+++ b/Sources/AWSSDKSwift/Services/Polly/Polly_API.swift
@@ -11,7 +11,7 @@ public struct Polly {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct Polly {
             apiVersion: "2016-06-10",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [PollyErrorType.self]
+            possibleErrorTypes: [PollyErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Pricing/Pricing_API.swift
+++ b/Sources/AWSSDKSwift/Services/Pricing/Pricing_API.swift
@@ -11,7 +11,7 @@ public struct Pricing {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -24,7 +24,8 @@ public struct Pricing {
             apiVersion: "2017-10-15",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [PricingErrorType.self]
+            possibleErrorTypes: [PricingErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/QLDB/QLDB_API.swift
+++ b/Sources/AWSSDKSwift/Services/QLDB/QLDB_API.swift
@@ -11,7 +11,7 @@ public struct QLDB {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct QLDB {
             apiVersion: "2019-01-02",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [QLDBErrorType.self]
+            possibleErrorTypes: [QLDBErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/QLDBSession/QLDBSession_API.swift
+++ b/Sources/AWSSDKSwift/Services/QLDBSession/QLDBSession_API.swift
@@ -11,7 +11,7 @@ public struct QLDBSession {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -24,7 +24,8 @@ public struct QLDBSession {
             apiVersion: "2019-07-11",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [QLDBSessionErrorType.self]
+            possibleErrorTypes: [QLDBSessionErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/QuickSight/QuickSight_API.swift
+++ b/Sources/AWSSDKSwift/Services/QuickSight/QuickSight_API.swift
@@ -11,7 +11,7 @@ public struct QuickSight {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct QuickSight {
             apiVersion: "2018-04-01",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [QuickSightErrorType.self]
+            possibleErrorTypes: [QuickSightErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/RAM/RAM_API.swift
+++ b/Sources/AWSSDKSwift/Services/RAM/RAM_API.swift
@@ -11,7 +11,7 @@ public struct RAM {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct RAM {
             apiVersion: "2018-01-04",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [RAMErrorType.self]
+            possibleErrorTypes: [RAMErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/RDS/RDS_API.swift
+++ b/Sources/AWSSDKSwift/Services/RDS/RDS_API.swift
@@ -11,7 +11,7 @@ public struct RDS {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct RDS {
             apiVersion: "2014-10-31",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [RDSErrorType.self]
+            possibleErrorTypes: [RDSErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/RDSDataService/RDSDataService_API.swift
+++ b/Sources/AWSSDKSwift/Services/RDSDataService/RDSDataService_API.swift
@@ -11,7 +11,7 @@ public struct RDSDataService {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct RDSDataService {
             apiVersion: "2018-08-01",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [RDSDataServiceErrorType.self]
+            possibleErrorTypes: [RDSDataServiceErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Redshift/Redshift_API.swift
+++ b/Sources/AWSSDKSwift/Services/Redshift/Redshift_API.swift
@@ -11,7 +11,7 @@ public struct Redshift {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct Redshift {
             apiVersion: "2012-12-01",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [RedshiftErrorType.self]
+            possibleErrorTypes: [RedshiftErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Rekognition/Rekognition_API.swift
+++ b/Sources/AWSSDKSwift/Services/Rekognition/Rekognition_API.swift
@@ -11,7 +11,7 @@ public struct Rekognition {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct Rekognition {
             apiVersion: "2016-06-27",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [RekognitionErrorType.self]
+            possibleErrorTypes: [RekognitionErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/ResourceGroups/ResourceGroups_API.swift
+++ b/Sources/AWSSDKSwift/Services/ResourceGroups/ResourceGroups_API.swift
@@ -11,7 +11,7 @@ public struct ResourceGroups {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct ResourceGroups {
             endpoint: endpoint,
             serviceEndpoints: ["fips-us-east-1": "resource-groups-fips.us-east-1.amazonaws.com", "fips-us-east-2": "resource-groups-fips.us-east-2.amazonaws.com", "fips-us-west-1": "resource-groups-fips.us-west-1.amazonaws.com", "fips-us-west-2": "resource-groups-fips.us-west-2.amazonaws.com"],
             middlewares: middlewares,
-            possibleErrorTypes: [ResourceGroupsErrorType.self]
+            possibleErrorTypes: [ResourceGroupsErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/ResourceGroupsTaggingAPI/ResourceGroupsTaggingAPI_API.swift
+++ b/Sources/AWSSDKSwift/Services/ResourceGroupsTaggingAPI/ResourceGroupsTaggingAPI_API.swift
@@ -11,7 +11,7 @@ public struct ResourceGroupsTaggingAPI {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct ResourceGroupsTaggingAPI {
             apiVersion: "2017-01-26",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [ResourceGroupsTaggingAPIErrorType.self]
+            possibleErrorTypes: [ResourceGroupsTaggingAPIErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/RoboMaker/RoboMaker_API.swift
+++ b/Sources/AWSSDKSwift/Services/RoboMaker/RoboMaker_API.swift
@@ -11,7 +11,7 @@ public struct RoboMaker {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct RoboMaker {
             apiVersion: "2018-06-29",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [RoboMakerErrorType.self]
+            possibleErrorTypes: [RoboMakerErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Route53/Route53_API.swift
+++ b/Sources/AWSSDKSwift/Services/Route53/Route53_API.swift
@@ -11,7 +11,7 @@ public struct Route53 {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -24,7 +24,8 @@ public struct Route53 {
             serviceEndpoints: ["aws-global": "route53.amazonaws.com"],
             partitionEndpoint: "aws-global",
             middlewares: middlewares,
-            possibleErrorTypes: [Route53ErrorType.self]
+            possibleErrorTypes: [Route53ErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Route53Domains/Route53Domains_API.swift
+++ b/Sources/AWSSDKSwift/Services/Route53Domains/Route53Domains_API.swift
@@ -11,7 +11,7 @@ public struct Route53Domains {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct Route53Domains {
             apiVersion: "2014-05-15",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [Route53DomainsErrorType.self]
+            possibleErrorTypes: [Route53DomainsErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Route53Resolver/Route53Resolver_API.swift
+++ b/Sources/AWSSDKSwift/Services/Route53Resolver/Route53Resolver_API.swift
@@ -11,7 +11,7 @@ public struct Route53Resolver {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct Route53Resolver {
             apiVersion: "2018-04-01",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [Route53ResolverErrorType.self]
+            possibleErrorTypes: [Route53ResolverErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/S3/S3_API.swift
+++ b/Sources/AWSSDKSwift/Services/S3/S3_API.swift
@@ -10,7 +10,7 @@ public struct S3 {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         let middlewares = [S3RequestMiddleware()] + middlewares
         self.client = AWSClient(
             accessKeyId: accessKeyId,
@@ -24,7 +24,8 @@ public struct S3 {
             serviceEndpoints: ["ap-east-1": "s3.ap-east-1.amazonaws.com", "ap-northeast-1": "s3.ap-northeast-1.amazonaws.com", "ap-northeast-2": "s3.ap-northeast-2.amazonaws.com", "ap-south-1": "s3.ap-south-1.amazonaws.com", "ap-southeast-1": "s3.ap-southeast-1.amazonaws.com", "ap-southeast-2": "s3.ap-southeast-2.amazonaws.com", "ca-central-1": "s3.ca-central-1.amazonaws.com", "eu-central-1": "s3.eu-central-1.amazonaws.com", "eu-north-1": "s3.eu-north-1.amazonaws.com", "eu-west-1": "s3.eu-west-1.amazonaws.com", "eu-west-2": "s3.eu-west-2.amazonaws.com", "eu-west-3": "s3.eu-west-3.amazonaws.com", "me-south-1": "s3.me-south-1.amazonaws.com", "s3-external-1": "s3-external-1.amazonaws.com", "sa-east-1": "s3.sa-east-1.amazonaws.com", "us-east-1": "s3.amazonaws.com", "us-east-2": "s3.us-east-2.amazonaws.com", "us-west-1": "s3.us-west-1.amazonaws.com", "us-west-2": "s3.us-west-2.amazonaws.com"],
             partitionEndpoint: "us-east-1",
             middlewares: middlewares,
-            possibleErrorTypes: [S3ErrorType.self]
+            possibleErrorTypes: [S3ErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/S3Control/S3Control_API.swift
+++ b/Sources/AWSSDKSwift/Services/S3Control/S3Control_API.swift
@@ -11,7 +11,7 @@ public struct S3Control {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -24,7 +24,8 @@ public struct S3Control {
             endpoint: endpoint,
             serviceEndpoints: ["ap-northeast-1": "s3-control.ap-northeast-1.amazonaws.com", "ap-northeast-2": "s3-control.ap-northeast-2.amazonaws.com", "ap-south-1": "s3-control.ap-south-1.amazonaws.com", "ap-southeast-1": "s3-control.ap-southeast-1.amazonaws.com", "ap-southeast-2": "s3-control.ap-southeast-2.amazonaws.com", "ca-central-1": "s3-control.ca-central-1.amazonaws.com", "eu-central-1": "s3-control.eu-central-1.amazonaws.com", "eu-north-1": "s3-control.eu-north-1.amazonaws.com", "eu-west-1": "s3-control.eu-west-1.amazonaws.com", "eu-west-2": "s3-control.eu-west-2.amazonaws.com", "eu-west-3": "s3-control.eu-west-3.amazonaws.com", "sa-east-1": "s3-control.sa-east-1.amazonaws.com", "us-east-1": "s3-control.us-east-1.amazonaws.com", "us-east-1-fips": "s3-control-fips.us-east-1.amazonaws.com", "us-east-2": "s3-control.us-east-2.amazonaws.com", "us-east-2-fips": "s3-control-fips.us-east-2.amazonaws.com", "us-west-1": "s3-control.us-west-1.amazonaws.com", "us-west-1-fips": "s3-control-fips.us-west-1.amazonaws.com", "us-west-2": "s3-control.us-west-2.amazonaws.com", "us-west-2-fips": "s3-control-fips.us-west-2.amazonaws.com"],
             middlewares: middlewares,
-            possibleErrorTypes: [S3ControlErrorType.self]
+            possibleErrorTypes: [S3ControlErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/SES/SES_API.swift
+++ b/Sources/AWSSDKSwift/Services/SES/SES_API.swift
@@ -11,7 +11,7 @@ public struct SES {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct SES {
             apiVersion: "2010-12-01",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [SESErrorType.self]
+            possibleErrorTypes: [SESErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/SFN/SFN_API.swift
+++ b/Sources/AWSSDKSwift/Services/SFN/SFN_API.swift
@@ -11,7 +11,7 @@ public struct SFN {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct SFN {
             apiVersion: "2016-11-23",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [SFNErrorType.self]
+            possibleErrorTypes: [SFNErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/SMS/SMS_API.swift
+++ b/Sources/AWSSDKSwift/Services/SMS/SMS_API.swift
@@ -11,7 +11,7 @@ public struct SMS {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct SMS {
             apiVersion: "2016-10-24",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [SMSErrorType.self]
+            possibleErrorTypes: [SMSErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/SNS/SNS_API.swift
+++ b/Sources/AWSSDKSwift/Services/SNS/SNS_API.swift
@@ -11,7 +11,7 @@ public struct SNS {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct SNS {
             apiVersion: "2010-03-31",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [SNSErrorType.self]
+            possibleErrorTypes: [SNSErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/SQS/SQS_API.swift
+++ b/Sources/AWSSDKSwift/Services/SQS/SQS_API.swift
@@ -11,7 +11,7 @@ public struct SQS {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct SQS {
             endpoint: endpoint,
             serviceEndpoints: ["fips-us-east-1": "sqs-fips.us-east-1.amazonaws.com", "fips-us-east-2": "sqs-fips.us-east-2.amazonaws.com", "fips-us-west-1": "sqs-fips.us-west-1.amazonaws.com", "fips-us-west-2": "sqs-fips.us-west-2.amazonaws.com"],
             middlewares: middlewares,
-            possibleErrorTypes: [SQSErrorType.self]
+            possibleErrorTypes: [SQSErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/SSM/SSM_API.swift
+++ b/Sources/AWSSDKSwift/Services/SSM/SSM_API.swift
@@ -11,7 +11,7 @@ public struct SSM {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct SSM {
             apiVersion: "2014-11-06",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [SSMErrorType.self]
+            possibleErrorTypes: [SSMErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/STS/STS_API.swift
+++ b/Sources/AWSSDKSwift/Services/STS/STS_API.swift
@@ -11,7 +11,7 @@ public struct STS {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -24,7 +24,8 @@ public struct STS {
             serviceEndpoints: ["ap-east-1": "sts.ap-east-1.amazonaws.com", "ap-northeast-1": "sts.ap-northeast-1.amazonaws.com", "ap-northeast-2": "sts.ap-northeast-2.amazonaws.com", "ap-south-1": "sts.ap-south-1.amazonaws.com", "ap-southeast-1": "sts.ap-southeast-1.amazonaws.com", "ap-southeast-2": "sts.ap-southeast-2.amazonaws.com", "aws-global": "sts.aws-global.amazonaws.com", "ca-central-1": "sts.ca-central-1.amazonaws.com", "eu-central-1": "sts.eu-central-1.amazonaws.com", "eu-north-1": "sts.eu-north-1.amazonaws.com", "eu-west-1": "sts.eu-west-1.amazonaws.com", "eu-west-2": "sts.eu-west-2.amazonaws.com", "eu-west-3": "sts.eu-west-3.amazonaws.com", "me-south-1": "sts.me-south-1.amazonaws.com", "sa-east-1": "sts.sa-east-1.amazonaws.com", "us-east-1": "sts.us-east-1.amazonaws.com", "us-east-1-fips": "sts-fips.us-east-1.amazonaws.com", "us-east-2": "sts.us-east-2.amazonaws.com", "us-east-2-fips": "sts-fips.us-east-2.amazonaws.com", "us-west-1": "sts.us-west-1.amazonaws.com", "us-west-1-fips": "sts-fips.us-west-1.amazonaws.com", "us-west-2": "sts.us-west-2.amazonaws.com", "us-west-2-fips": "sts-fips.us-west-2.amazonaws.com"],
             partitionEndpoint: "aws-global",
             middlewares: middlewares,
-            possibleErrorTypes: [STSErrorType.self]
+            possibleErrorTypes: [STSErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/SWF/SWF_API.swift
+++ b/Sources/AWSSDKSwift/Services/SWF/SWF_API.swift
@@ -11,7 +11,7 @@ public struct SWF {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct SWF {
             apiVersion: "2012-01-25",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [SWFErrorType.self]
+            possibleErrorTypes: [SWFErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/SageMaker/SageMaker_API.swift
+++ b/Sources/AWSSDKSwift/Services/SageMaker/SageMaker_API.swift
@@ -11,7 +11,7 @@ public struct SageMaker {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -25,7 +25,8 @@ public struct SageMaker {
             endpoint: endpoint,
             serviceEndpoints: ["us-east-1-fips": "api-fips.sagemaker.us-east-1.amazonaws.com", "us-east-2-fips": "api-fips.sagemaker.us-east-2.amazonaws.com", "us-west-1-fips": "api-fips.sagemaker.us-west-1.amazonaws.com", "us-west-2-fips": "api-fips.sagemaker.us-west-2.amazonaws.com"],
             middlewares: middlewares,
-            possibleErrorTypes: [SageMakerErrorType.self]
+            possibleErrorTypes: [SageMakerErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/SageMakerRuntime/SageMakerRuntime_API.swift
+++ b/Sources/AWSSDKSwift/Services/SageMakerRuntime/SageMakerRuntime_API.swift
@@ -11,7 +11,7 @@ public struct SageMakerRuntime {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -24,7 +24,8 @@ public struct SageMakerRuntime {
             endpoint: endpoint,
             serviceEndpoints: ["us-east-1-fips": "runtime-fips.sagemaker.us-east-1.amazonaws.com", "us-east-2-fips": "runtime-fips.sagemaker.us-east-2.amazonaws.com", "us-west-1-fips": "runtime-fips.sagemaker.us-west-1.amazonaws.com", "us-west-2-fips": "runtime-fips.sagemaker.us-west-2.amazonaws.com"],
             middlewares: middlewares,
-            possibleErrorTypes: [SageMakerRuntimeErrorType.self]
+            possibleErrorTypes: [SageMakerRuntimeErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/SecretsManager/SecretsManager_API.swift
+++ b/Sources/AWSSDKSwift/Services/SecretsManager/SecretsManager_API.swift
@@ -11,7 +11,7 @@ public struct SecretsManager {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -24,7 +24,8 @@ public struct SecretsManager {
             endpoint: endpoint,
             serviceEndpoints: ["us-east-1-fips": "secretsmanager-fips.us-east-1.amazonaws.com", "us-east-2-fips": "secretsmanager-fips.us-east-2.amazonaws.com", "us-west-1-fips": "secretsmanager-fips.us-west-1.amazonaws.com", "us-west-2-fips": "secretsmanager-fips.us-west-2.amazonaws.com"],
             middlewares: middlewares,
-            possibleErrorTypes: [SecretsManagerErrorType.self]
+            possibleErrorTypes: [SecretsManagerErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/SecurityHub/SecurityHub_API.swift
+++ b/Sources/AWSSDKSwift/Services/SecurityHub/SecurityHub_API.swift
@@ -11,7 +11,7 @@ public struct SecurityHub {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct SecurityHub {
             apiVersion: "2018-10-26",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [SecurityHubErrorType.self]
+            possibleErrorTypes: [SecurityHubErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/ServerlessApplicationRepository/ServerlessApplicationRepository_API.swift
+++ b/Sources/AWSSDKSwift/Services/ServerlessApplicationRepository/ServerlessApplicationRepository_API.swift
@@ -30,7 +30,7 @@ public struct ServerlessApplicationRepository {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -41,7 +41,8 @@ public struct ServerlessApplicationRepository {
             apiVersion: "2017-09-08",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [ServerlessApplicationRepositoryErrorType.self]
+            possibleErrorTypes: [ServerlessApplicationRepositoryErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/ServiceCatalog/ServiceCatalog_API.swift
+++ b/Sources/AWSSDKSwift/Services/ServiceCatalog/ServiceCatalog_API.swift
@@ -11,7 +11,7 @@ public struct ServiceCatalog {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -24,7 +24,8 @@ public struct ServiceCatalog {
             endpoint: endpoint,
             serviceEndpoints: ["us-east-1-fips": "servicecatalog-fips.us-east-1.amazonaws.com", "us-east-2-fips": "servicecatalog-fips.us-east-2.amazonaws.com", "us-west-1-fips": "servicecatalog-fips.us-west-1.amazonaws.com", "us-west-2-fips": "servicecatalog-fips.us-west-2.amazonaws.com"],
             middlewares: middlewares,
-            possibleErrorTypes: [ServiceCatalogErrorType.self]
+            possibleErrorTypes: [ServiceCatalogErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/ServiceDiscovery/ServiceDiscovery_API.swift
+++ b/Sources/AWSSDKSwift/Services/ServiceDiscovery/ServiceDiscovery_API.swift
@@ -11,7 +11,7 @@ public struct ServiceDiscovery {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct ServiceDiscovery {
             apiVersion: "2017-03-14",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [ServiceDiscoveryErrorType.self]
+            possibleErrorTypes: [ServiceDiscoveryErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/ServiceQuotas/ServiceQuotas_API.swift
+++ b/Sources/AWSSDKSwift/Services/ServiceQuotas/ServiceQuotas_API.swift
@@ -11,7 +11,7 @@ public struct ServiceQuotas {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct ServiceQuotas {
             apiVersion: "2019-06-24",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [ServiceQuotasErrorType.self]
+            possibleErrorTypes: [ServiceQuotasErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Shield/Shield_API.swift
+++ b/Sources/AWSSDKSwift/Services/Shield/Shield_API.swift
@@ -11,7 +11,7 @@ public struct Shield {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct Shield {
             apiVersion: "2016-06-02",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [ShieldErrorType.self]
+            possibleErrorTypes: [ShieldErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Signer/Signer_API.swift
+++ b/Sources/AWSSDKSwift/Services/Signer/Signer_API.swift
@@ -11,7 +11,7 @@ public struct Signer {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct Signer {
             apiVersion: "2017-08-25",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [SignerErrorType.self]
+            possibleErrorTypes: [SignerErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/SimpleDB/SimpleDB_API.swift
+++ b/Sources/AWSSDKSwift/Services/SimpleDB/SimpleDB_API.swift
@@ -11,7 +11,7 @@ public struct SimpleDB {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct SimpleDB {
             endpoint: endpoint,
             serviceEndpoints: ["us-east-1": "sdb.amazonaws.com"],
             middlewares: middlewares,
-            possibleErrorTypes: [SimpleDBErrorType.self]
+            possibleErrorTypes: [SimpleDBErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Snowball/Snowball_API.swift
+++ b/Sources/AWSSDKSwift/Services/Snowball/Snowball_API.swift
@@ -11,7 +11,7 @@ public struct Snowball {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct Snowball {
             apiVersion: "2016-06-30",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [SnowballErrorType.self]
+            possibleErrorTypes: [SnowballErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/StorageGateway/StorageGateway_API.swift
+++ b/Sources/AWSSDKSwift/Services/StorageGateway/StorageGateway_API.swift
@@ -11,7 +11,7 @@ public struct StorageGateway {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct StorageGateway {
             apiVersion: "2013-06-30",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [StorageGatewayErrorType.self]
+            possibleErrorTypes: [StorageGatewayErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Support/Support_API.swift
+++ b/Sources/AWSSDKSwift/Services/Support/Support_API.swift
@@ -11,7 +11,7 @@ public struct Support {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -25,7 +25,8 @@ public struct Support {
             serviceEndpoints: ["aws-global": "support.us-east-1.amazonaws.com"],
             partitionEndpoint: "aws-global",
             middlewares: middlewares,
-            possibleErrorTypes: [SupportErrorType.self]
+            possibleErrorTypes: [SupportErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Textract/Textract_API.swift
+++ b/Sources/AWSSDKSwift/Services/Textract/Textract_API.swift
@@ -11,7 +11,7 @@ public struct Textract {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct Textract {
             apiVersion: "2018-06-27",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [TextractErrorType.self]
+            possibleErrorTypes: [TextractErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/TranscribeService/TranscribeService_API.swift
+++ b/Sources/AWSSDKSwift/Services/TranscribeService/TranscribeService_API.swift
@@ -11,7 +11,7 @@ public struct TranscribeService {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct TranscribeService {
             apiVersion: "2017-10-26",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [TranscribeServiceErrorType.self]
+            possibleErrorTypes: [TranscribeServiceErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Transfer/Transfer_API.swift
+++ b/Sources/AWSSDKSwift/Services/Transfer/Transfer_API.swift
@@ -11,7 +11,7 @@ public struct Transfer {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct Transfer {
             apiVersion: "2018-11-05",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [TransferErrorType.self]
+            possibleErrorTypes: [TransferErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/Translate/Translate_API.swift
+++ b/Sources/AWSSDKSwift/Services/Translate/Translate_API.swift
@@ -11,7 +11,7 @@ public struct Translate {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -24,7 +24,8 @@ public struct Translate {
             endpoint: endpoint,
             serviceEndpoints: ["us-east-1-fips": "translate-fips.us-east-1.amazonaws.com", "us-east-2-fips": "translate-fips.us-east-2.amazonaws.com", "us-west-2-fips": "translate-fips.us-west-2.amazonaws.com"],
             middlewares: middlewares,
-            possibleErrorTypes: [TranslateErrorType.self]
+            possibleErrorTypes: [TranslateErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/WAF/WAF_API.swift
+++ b/Sources/AWSSDKSwift/Services/WAF/WAF_API.swift
@@ -11,7 +11,7 @@ public struct WAF {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -25,7 +25,8 @@ public struct WAF {
             serviceEndpoints: ["aws-global": "waf.amazonaws.com"],
             partitionEndpoint: "aws-global",
             middlewares: middlewares,
-            possibleErrorTypes: [WAFErrorType.self]
+            possibleErrorTypes: [WAFErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/WAFRegional/WAFRegional_API.swift
+++ b/Sources/AWSSDKSwift/Services/WAFRegional/WAFRegional_API.swift
@@ -11,7 +11,7 @@ public struct WAFRegional {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct WAFRegional {
             apiVersion: "2016-11-28",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [WAFRegionalErrorType.self]
+            possibleErrorTypes: [WAFRegionalErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/WorkDocs/WorkDocs_API.swift
+++ b/Sources/AWSSDKSwift/Services/WorkDocs/WorkDocs_API.swift
@@ -11,7 +11,7 @@ public struct WorkDocs {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct WorkDocs {
             apiVersion: "2016-05-01",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [WorkDocsErrorType.self]
+            possibleErrorTypes: [WorkDocsErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/WorkLink/WorkLink_API.swift
+++ b/Sources/AWSSDKSwift/Services/WorkLink/WorkLink_API.swift
@@ -11,7 +11,7 @@ public struct WorkLink {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct WorkLink {
             apiVersion: "2018-09-25",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [WorkLinkErrorType.self]
+            possibleErrorTypes: [WorkLinkErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/WorkMail/WorkMail_API.swift
+++ b/Sources/AWSSDKSwift/Services/WorkMail/WorkMail_API.swift
@@ -11,7 +11,7 @@ public struct WorkMail {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct WorkMail {
             apiVersion: "2017-10-01",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [WorkMailErrorType.self]
+            possibleErrorTypes: [WorkMailErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/WorkMailMessageFlow/WorkMailMessageFlow_API.swift
+++ b/Sources/AWSSDKSwift/Services/WorkMailMessageFlow/WorkMailMessageFlow_API.swift
@@ -11,7 +11,7 @@ public struct WorkMailMessageFlow {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct WorkMailMessageFlow {
             apiVersion: "2019-05-01",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [WorkMailMessageFlowErrorType.self]
+            possibleErrorTypes: [WorkMailMessageFlowErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/WorkSpaces/WorkSpaces_API.swift
+++ b/Sources/AWSSDKSwift/Services/WorkSpaces/WorkSpaces_API.swift
@@ -11,7 +11,7 @@ public struct WorkSpaces {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -23,7 +23,8 @@ public struct WorkSpaces {
             apiVersion: "2015-04-08",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [WorkSpacesErrorType.self]
+            possibleErrorTypes: [WorkSpacesErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Sources/AWSSDKSwift/Services/XRay/XRay_API.swift
+++ b/Sources/AWSSDKSwift/Services/XRay/XRay_API.swift
@@ -11,7 +11,7 @@ public struct XRay {
 
     public let client: AWSClient
 
-    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = []) {
+    public init(accessKeyId: String? = nil, secretAccessKey: String? = nil, sessionToken: String? = nil, region: AWSSDKSwiftCore.Region? = nil, endpoint: String? = nil, middlewares: [AWSServiceMiddleware] = [], eventLoopGroupProvider: AWSClient.EventLoopGroupProvider) {
         self.client = AWSClient(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -22,7 +22,8 @@ public struct XRay {
             apiVersion: "2016-04-12",
             endpoint: endpoint,
             middlewares: middlewares,
-            possibleErrorTypes: [XRayErrorType.self]
+            possibleErrorTypes: [XRayErrorType.self],
+            eventLoopGroupProvider: eventLoopGroupProvider
         )
     }
 

--- a/Tests/AWSSDKSwiftTests/AWSRequestTests.swift
+++ b/Tests/AWSSDKSwiftTests/AWSRequestTests.swift
@@ -79,14 +79,14 @@ class AWSRequestTests: XCTestCase {
         let lifecycleConfiguration = S3.BucketLifecycleConfiguration(rules: rules)
         let request = S3.PutBucketLifecycleConfigurationRequest(bucket: "bucket", lifecycleConfiguration: lifecycleConfiguration)
 
-        testAWSShapeRequest(client:S3().client, operation: "PutBucketLifecycleConfiguration", path: "/{Bucket}?lifecycle", httpMethod: "PUT", input: request, expected: expectedResult)
+        testAWSShapeRequest(client:S3(eventLoopGroupProvider: .useAWSClientShared).client, operation: "PutBucketLifecycleConfiguration", path: "/{Bucket}?lifecycle", httpMethod: "PUT", input: request, expected: expectedResult)
     }
 
     func testSNSCreateTopic() {
         let expectedResult = "Action=CreateTopic&Attributes.entry.1.key=TestAttribute&Attributes.entry.1.value=TestValue&Name=TestTopic&Tags.member.1.Key=tag1&Tags.member.1.Value=23&Tags.member.2.Key=tag2&Tags.member.2.Value=true&Version=2010-03-31"
         let request = SNS.CreateTopicInput(attributes: ["TestAttribute":"TestValue"], name: "TestTopic", tags: [SNS.Tag(key:"tag1", value:"23"), SNS.Tag(key:"tag2", value:"true")])
 
-        testAWSShapeRequest(client: SNS().client, operation: "CreateTopic", path: "/", httpMethod: "POST", input: request, expected: expectedResult)
+        testAWSShapeRequest(client: SNS(eventLoopGroupProvider: .useAWSClientShared).client, operation: "CreateTopic", path: "/", httpMethod: "POST", input: request, expected: expectedResult)
     }
 
     func testCloudFrontCreateDistribution() {
@@ -100,14 +100,14 @@ class AWSRequestTests: XCTestCase {
         let distribution = CloudFront.DistributionConfig(callerReference:"test", comment:"", defaultCacheBehavior: defaultCacheBehavior, enabled:true, origins: origins)
         let request = CloudFront.CreateDistributionRequest(distributionConfig: distribution)
 
-        testAWSShapeRequest(client: CloudFront().client, operation: "CreateDistribution2019_03_26", path: "/2019-03-26/distribution", httpMethod: "POST", input: request, expected: expectedResult)
+        testAWSShapeRequest(client: CloudFront(eventLoopGroupProvider: .useAWSClientShared).client, operation: "CreateDistribution2019_03_26", path: "/2019-03-26/distribution", httpMethod: "POST", input: request, expected: expectedResult)
     }
 
     func testEC2CreateImage() {
         let expectedResult = "Action=CreateImage&Version=2016-11-15&instanceId=i-123123&name=TestInstance"
         let request = EC2.CreateImageRequest(instanceId:"i-123123", name:"TestInstance")
 
-        testAWSShapeRequest(client: EC2().client, operation: "CreateImage", path: "/", httpMethod: "POST", input: request, expected: expectedResult)
+        testAWSShapeRequest(client: EC2(eventLoopGroupProvider: .useAWSClientShared).client, operation: "CreateImage", path: "/", httpMethod: "POST", input: request, expected: expectedResult)
     }
 
     func testEC2CreateInstanceExportTask() {
@@ -115,14 +115,14 @@ class AWSRequestTests: XCTestCase {
         let exportToS3Task = EC2.ExportToS3TaskSpecification(s3Bucket:"testBucket")
         let request = EC2.CreateInstanceExportTaskRequest(exportToS3Task: exportToS3Task, instanceId: "i-123123")
 
-        testAWSShapeRequest(client: EC2().client, operation: "CreateInstanceExportTask", path: "/", httpMethod: "POST", input: request, expected: expectedResult)
+        testAWSShapeRequest(client: EC2(eventLoopGroupProvider: .useAWSClientShared).client, operation: "CreateInstanceExportTask", path: "/", httpMethod: "POST", input: request, expected: expectedResult)
     }
 
     func testIAMSimulateCustomPolicy() {
         let expectedResult = "Action=SimulateCustomPolicy&ActionNames.member.1=s3%2A&ActionNames.member.2=iam%2A&PolicyInputList.member.1=testPolicy&Version=2010-05-08"
         let request = IAM.SimulateCustomPolicyRequest(actionNames: ["s3*", "iam*"], policyInputList: ["testPolicy"])
 
-        testAWSShapeRequest(client: IAM().client, operation: "SimulateCustomPolicy", input: request, expected: expectedResult)
+        testAWSShapeRequest(client: IAM(eventLoopGroupProvider: .useAWSClientShared).client, operation: "SimulateCustomPolicy", input: request, expected: expectedResult)
     }
 
     func testSESSendEmail() {
@@ -131,7 +131,7 @@ class AWSRequestTests: XCTestCase {
         let message = SES.Message(body:SES.Body(text:SES.Content(data:"Testing 1,2,1,2")), subject:SES.Content(data:"Testing"))
         let request = SES.SendEmailRequest(destination: destination, message: message, source: "me@gmail.com")
 
-        testAWSShapeRequest(client: SES().client, operation: "SendEmail", input: request, expected: expectedResult)
+        testAWSShapeRequest(client: SES(eventLoopGroupProvider: .useAWSClientShared).client, operation: "SendEmail", input: request, expected: expectedResult)
     }
 
     // VALIDATION TESTS
@@ -139,37 +139,37 @@ class AWSRequestTests: XCTestCase {
     func testS3GetObjectAclValidate() {
         // string length
         let request = S3.GetObjectAclRequest(bucket:"testbucket", key:"")
-        testAWSValidationFail(client: S3().client, operation: "GetObjectAcl", input: request)
+        testAWSValidationFail(client: S3(eventLoopGroupProvider: .useAWSClientShared).client, operation: "GetObjectAcl", input: request)
     }
     
     func testIAMAttachGroupPolicyValidate() {
         // regular expression fail
         let request = IAM.AttachGroupPolicyRequest(groupName: ":MY:GROUP", policyArn: "arn://3948574985/unvalidated")
-        testAWSValidationFail(client: IAM().client, operation: "AttachGroupPolicy", input: request)
+        testAWSValidationFail(client: IAM(eventLoopGroupProvider: .useAWSClientShared).client, operation: "AttachGroupPolicy", input: request)
         // string length
         let request2 = IAM.AttachGroupPolicyRequest(groupName: "MYGROUP", policyArn: "arn:tooshort")
-        testAWSValidationFail(client: IAM().client, operation: "AttachGroupPolicy", input: request2)
+        testAWSValidationFail(client: IAM(eventLoopGroupProvider: .useAWSClientShared).client, operation: "AttachGroupPolicy", input: request2)
         // regular expression success
         let request3 = IAM.AttachGroupPolicyRequest(groupName: "MY-GR_OU+P", policyArn: "arn://3948574985/unvalidated")
-        testAWSValidationSuccess(client: IAM().client, operation: "AttachGroupPolicy", input: request3)
+        testAWSValidationSuccess(client: IAM(eventLoopGroupProvider: .useAWSClientShared).client, operation: "AttachGroupPolicy", input: request3)
     }
 
     func testCloudFrontListTagsForResourceValidate() {
         // arn regular expressions, expect arn:aws(-cn)?:cloudfront::[0-9]+:.*
         let request = CloudFront.ListTagsForResourceRequest(resource: "test")
-        testAWSValidationFail(client: CloudFront().client, operation: "ListTagsForResource", input: request)
+        testAWSValidationFail(client: CloudFront(eventLoopGroupProvider: .useAWSClientShared).client, operation: "ListTagsForResource", input: request)
         let request2 = CloudFront.ListTagsForResourceRequest(resource: "arn:aws::58979345:test")
-        testAWSValidationFail(client: CloudFront().client, operation: "ListTagsForResource", input: request2)
+        testAWSValidationFail(client: CloudFront(eventLoopGroupProvider: .useAWSClientShared).client, operation: "ListTagsForResource", input: request2)
         let request3 = CloudFront.ListTagsForResourceRequest(resource: "arn:aws:cloudfront::58979345")
-        testAWSValidationFail(client: CloudFront().client, operation: "ListTagsForResource", input: request3)
+        testAWSValidationFail(client: CloudFront(eventLoopGroupProvider: .useAWSClientShared).client, operation: "ListTagsForResource", input: request3)
         let successRequest = CloudFront.ListTagsForResourceRequest(resource: "arn:aws:cloudfront::58979345:test")
-        testAWSValidationSuccess(client: CloudFront().client, operation: "ListTagsForResource", input: successRequest)
+        testAWSValidationSuccess(client: CloudFront(eventLoopGroupProvider: .useAWSClientShared).client, operation: "ListTagsForResource", input: successRequest)
     }
     
     func testACMAddTagsToCertificateValidate() {
         // test validating array members
         let request = ACM.AddTagsToCertificateRequest(certificateArn: "arn:aws:acm:region:123456789012:certificate/12345678-1234-1234-1234-123456789012", tags: [ACM.Tag(key:"hello", value:"1"), ACM.Tag(key:"?hello?", value:"1")])
-        testAWSValidationFail(client: ACM().client, operation: "AddTagsToCertificate", input: request)
+        testAWSValidationFail(client: ACM(eventLoopGroupProvider: .useAWSClientShared).client, operation: "AddTagsToCertificate", input: request)
     }
     
     func testCloudFrontCreateDistributionValidate() {
@@ -180,7 +180,7 @@ class AWSRequestTests: XCTestCase {
         let origins = CloudFront.Origins(items:[], quantity:0)
         let distribution = CloudFront.DistributionConfig(callerReference:"test", comment:"", defaultCacheBehavior: defaultCacheBehavior, enabled:true, origins: origins)
         let request = CloudFront.CreateDistributionRequest(distributionConfig: distribution)
-        testAWSValidationFail(client: CloudFront().client, operation: "CreateDistribution", input: request)
+        testAWSValidationFail(client: CloudFront(eventLoopGroupProvider: .useAWSClientShared).client, operation: "CreateDistribution", input: request)
     }
     
     static var allTests : [(String, (AWSRequestTests) -> () throws -> Void)] {

--- a/Tests/AWSSDKSwiftTests/Services/Dynamodb/DynamoDBTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/Dynamodb/DynamoDBTests.swift
@@ -23,7 +23,8 @@ class DynamoDBTests: XCTestCase {
             accessKeyId: "key",
             secretAccessKey: "secret",
             region: .apnortheast1,
-            endpoint: "http://localhost:8000"
+            endpoint: "http://localhost:8000",
+            eventLoopGroupProvider: .useAWSClientShared
         )
     }
 

--- a/Tests/AWSSDKSwiftTests/Services/S3/S3Tests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/S3/S3Tests.swift
@@ -26,7 +26,8 @@ class S3Tests: XCTestCase {
             accessKeyId: "key",
             secretAccessKey: "secret",
             region: .apnortheast1,
-            endpoint: "http://localhost:4569"
+            endpoint: "http://localhost:4569",
+            eventLoopGroupProvider: .useAWSClientShared
         )
     }
 
@@ -154,7 +155,7 @@ class S3Tests: XCTestCase {
             responses.append(response)
         }
         
-        _ = try EventLoopFuture.whenAllSucceed(responses, on: AWSClient.eventGroup.next()).wait()
+        _ = try EventLoopFuture.whenAllSucceed(responses, on: client.client.eventLoopGroup.next()).wait()
     }
 
     static var allTests : [(String, (S3Tests) -> () throws -> Void)] {


### PR DESCRIPTION
- Added eventLoopGroupProvider parameter to all service client initialisers
- Fixed S3 multipart code to work with changes. I removed the `on eventLoop` parameter from functions as we can provide custom eventLoopGroup at client initialisation
  

