### PR TITLE
CodeGeneration uses operation model key for function name

### DIFF
--- a/CodeGenerator/Sources/CodeGenerator/AWSService.swift
+++ b/CodeGenerator/Sources/CodeGenerator/AWSService.swift
@@ -337,7 +337,7 @@ struct AWSService {
     private func parseOperation(shapes: [Shape]) throws -> ([Operation], [ErrorShape])  {
         var operations: [Operation] = []
         var errorShapeNames: [String] = []
-        for (_, json) in apiJSON["operations"].dictionaryValue {
+        for (name, json) in apiJSON["operations"].dictionaryValue {
             for json in json["errors"].arrayValue {
                 let shape = json["shape"].stringValue
                 if !errorShapeNames.contains(shape) {
@@ -371,7 +371,8 @@ struct AWSService {
             }
 
             let operation = Operation(
-                name: json["name"].stringValue,
+                name: name,
+                operationName: json["name"].stringValue,
                 httpMethod: json["http"]["method"].stringValue,
                 path: json["http"]["requestUri"].stringValue,
                 inputShape: inputShape,

--- a/CodeGenerator/Sources/CodeGenerator/CodeGenerator.swift
+++ b/CodeGenerator/Sources/CodeGenerator/CodeGenerator.swift
@@ -292,7 +292,7 @@ extension AWSService {
                 funcName: operation.name.toSwiftVariableCase(),
                 inputShape: operation.inputShape?.swiftTypeName,
                 outputShape: operation.outputShape?.swiftTypeName,
-                name: operation.name,
+                name: operation.operationName,
                 path: operation.path,
                 httpMethod: operation.httpMethod,
                 deprecated: operation.deprecatedMessage))

--- a/CodeGenerator/Sources/CodeGenerator/Doc/Operation.swift
+++ b/CodeGenerator/Sources/CodeGenerator/Doc/Operation.swift
@@ -8,14 +8,16 @@
 
 public struct Operation {
     public let name: String
+    public let operationName: String
     public let httpMethod: String
     public let path: String
     public let inputShape: Shape?
     public let outputShape: Shape?
     public let deprecatedMessage: String?
     
-    public init(name: String, httpMethod: String, path: String, inputShape: Shape?, outputShape: Shape?, deprecatedMessage : String? = nil){
+    public init(name: String, operationName: String, httpMethod: String, path: String, inputShape: Shape?, outputShape: Shape?, deprecatedMessage : String? = nil){
         self.name = name
+        self.operationName = operationName
         self.httpMethod = httpMethod
         self.path = path
         self.inputShape = inputShape

--- a/Sources/AWSSDKSwift/Services/CloudFront/CloudFront_API.swift
+++ b/Sources/AWSSDKSwift/Services/CloudFront/CloudFront_API.swift
@@ -29,183 +29,228 @@ public struct CloudFront {
         )
     }
 
-    public func createCloudFrontOriginAccessIdentity20190326(_ input: CreateCloudFrontOriginAccessIdentityRequest) -> Future<CreateCloudFrontOriginAccessIdentityResult> {
+    ///  Creates a new origin access identity. If you're using Amazon S3 for your origin, you can use an origin access identity to require users to access your content using a CloudFront URL instead of the Amazon S3 URL. For more information about how to use origin access identities, see Serving Private Content through CloudFront in the Amazon CloudFront Developer Guide.
+    public func createCloudFrontOriginAccessIdentity(_ input: CreateCloudFrontOriginAccessIdentityRequest) -> Future<CreateCloudFrontOriginAccessIdentityResult> {
         return client.send(operation: "CreateCloudFrontOriginAccessIdentity2019_03_26", path: "/2019-03-26/origin-access-identity/cloudfront", httpMethod: "POST", input: input)
     }
 
-    public func createDistribution20190326(_ input: CreateDistributionRequest) -> Future<CreateDistributionResult> {
+    ///  Creates a new web distribution. You create a CloudFront distribution to tell CloudFront where you want content to be delivered from, and the details about how to track and manage content delivery. Send a POST request to the /CloudFront API version/distribution/distribution ID resource.  When you update a distribution, there are more required fields than when you create a distribution. When you update your distribution by using UpdateDistribution, follow the steps included in the documentation to get the current configuration and then make your updates. This helps to make sure that you include all of the required fields. To view a summary, see Required Fields for Create Distribution and Update Distribution in the Amazon CloudFront Developer Guide. 
+    public func createDistribution(_ input: CreateDistributionRequest) -> Future<CreateDistributionResult> {
         return client.send(operation: "CreateDistribution2019_03_26", path: "/2019-03-26/distribution", httpMethod: "POST", input: input)
     }
 
-    public func createDistributionWithTags20190326(_ input: CreateDistributionWithTagsRequest) -> Future<CreateDistributionWithTagsResult> {
+    ///  Create a new distribution with tags.
+    public func createDistributionWithTags(_ input: CreateDistributionWithTagsRequest) -> Future<CreateDistributionWithTagsResult> {
         return client.send(operation: "CreateDistributionWithTags2019_03_26", path: "/2019-03-26/distribution?WithTags", httpMethod: "POST", input: input)
     }
 
-    public func createFieldLevelEncryptionConfig20190326(_ input: CreateFieldLevelEncryptionConfigRequest) -> Future<CreateFieldLevelEncryptionConfigResult> {
+    ///  Create a new field-level encryption configuration.
+    public func createFieldLevelEncryptionConfig(_ input: CreateFieldLevelEncryptionConfigRequest) -> Future<CreateFieldLevelEncryptionConfigResult> {
         return client.send(operation: "CreateFieldLevelEncryptionConfig2019_03_26", path: "/2019-03-26/field-level-encryption", httpMethod: "POST", input: input)
     }
 
-    public func createFieldLevelEncryptionProfile20190326(_ input: CreateFieldLevelEncryptionProfileRequest) -> Future<CreateFieldLevelEncryptionProfileResult> {
+    ///  Create a field-level encryption profile.
+    public func createFieldLevelEncryptionProfile(_ input: CreateFieldLevelEncryptionProfileRequest) -> Future<CreateFieldLevelEncryptionProfileResult> {
         return client.send(operation: "CreateFieldLevelEncryptionProfile2019_03_26", path: "/2019-03-26/field-level-encryption-profile", httpMethod: "POST", input: input)
     }
 
-    public func createInvalidation20190326(_ input: CreateInvalidationRequest) -> Future<CreateInvalidationResult> {
+    ///  Create a new invalidation. 
+    public func createInvalidation(_ input: CreateInvalidationRequest) -> Future<CreateInvalidationResult> {
         return client.send(operation: "CreateInvalidation2019_03_26", path: "/2019-03-26/distribution/{DistributionId}/invalidation", httpMethod: "POST", input: input)
     }
 
-    public func createPublicKey20190326(_ input: CreatePublicKeyRequest) -> Future<CreatePublicKeyResult> {
+    ///  Add a new public key to CloudFront to use, for example, for field-level encryption. You can add a maximum of 10 public keys with one AWS account.
+    public func createPublicKey(_ input: CreatePublicKeyRequest) -> Future<CreatePublicKeyResult> {
         return client.send(operation: "CreatePublicKey2019_03_26", path: "/2019-03-26/public-key", httpMethod: "POST", input: input)
     }
 
-    public func createStreamingDistribution20190326(_ input: CreateStreamingDistributionRequest) -> Future<CreateStreamingDistributionResult> {
+    ///  Creates a new RTMP distribution. An RTMP distribution is similar to a web distribution, but an RTMP distribution streams media files using the Adobe Real-Time Messaging Protocol (RTMP) instead of serving files using HTTP.  To create a new distribution, submit a POST request to the CloudFront API version/distribution resource. The request body must include a document with a StreamingDistributionConfig element. The response echoes the StreamingDistributionConfig element and returns other information about the RTMP distribution. To get the status of your request, use the GET StreamingDistribution API action. When the value of Enabled is true and the value of Status is Deployed, your distribution is ready. A distribution usually deploys in less than 15 minutes. For more information about web distributions, see Working with RTMP Distributions in the Amazon CloudFront Developer Guide.  Beginning with the 2012-05-05 version of the CloudFront API, we made substantial changes to the format of the XML document that you include in the request body when you create or update a web distribution or an RTMP distribution, and when you invalidate objects. With previous versions of the API, we discovered that it was too easy to accidentally delete one or more values for an element that accepts multiple values, for example, CNAMEs and trusted signers. Our changes for the 2012-05-05 release are intended to prevent these accidental deletions and to notify you when there's a mismatch between the number of values you say you're specifying in the Quantity element and the number of values specified. 
+    public func createStreamingDistribution(_ input: CreateStreamingDistributionRequest) -> Future<CreateStreamingDistributionResult> {
         return client.send(operation: "CreateStreamingDistribution2019_03_26", path: "/2019-03-26/streaming-distribution", httpMethod: "POST", input: input)
     }
 
-    public func createStreamingDistributionWithTags20190326(_ input: CreateStreamingDistributionWithTagsRequest) -> Future<CreateStreamingDistributionWithTagsResult> {
+    ///  Create a new streaming distribution with tags.
+    public func createStreamingDistributionWithTags(_ input: CreateStreamingDistributionWithTagsRequest) -> Future<CreateStreamingDistributionWithTagsResult> {
         return client.send(operation: "CreateStreamingDistributionWithTags2019_03_26", path: "/2019-03-26/streaming-distribution?WithTags", httpMethod: "POST", input: input)
     }
 
-    @discardableResult public func deleteCloudFrontOriginAccessIdentity20190326(_ input: DeleteCloudFrontOriginAccessIdentityRequest) -> Future<Void> {
+    ///  Delete an origin access identity. 
+    @discardableResult public func deleteCloudFrontOriginAccessIdentity(_ input: DeleteCloudFrontOriginAccessIdentityRequest) -> Future<Void> {
         return client.send(operation: "DeleteCloudFrontOriginAccessIdentity2019_03_26", path: "/2019-03-26/origin-access-identity/cloudfront/{Id}", httpMethod: "DELETE", input: input)
     }
 
-    @discardableResult public func deleteDistribution20190326(_ input: DeleteDistributionRequest) -> Future<Void> {
+    ///  Delete a distribution. 
+    @discardableResult public func deleteDistribution(_ input: DeleteDistributionRequest) -> Future<Void> {
         return client.send(operation: "DeleteDistribution2019_03_26", path: "/2019-03-26/distribution/{Id}", httpMethod: "DELETE", input: input)
     }
 
-    @discardableResult public func deleteFieldLevelEncryptionConfig20190326(_ input: DeleteFieldLevelEncryptionConfigRequest) -> Future<Void> {
+    ///  Remove a field-level encryption configuration.
+    @discardableResult public func deleteFieldLevelEncryptionConfig(_ input: DeleteFieldLevelEncryptionConfigRequest) -> Future<Void> {
         return client.send(operation: "DeleteFieldLevelEncryptionConfig2019_03_26", path: "/2019-03-26/field-level-encryption/{Id}", httpMethod: "DELETE", input: input)
     }
 
-    @discardableResult public func deleteFieldLevelEncryptionProfile20190326(_ input: DeleteFieldLevelEncryptionProfileRequest) -> Future<Void> {
+    ///  Remove a field-level encryption profile.
+    @discardableResult public func deleteFieldLevelEncryptionProfile(_ input: DeleteFieldLevelEncryptionProfileRequest) -> Future<Void> {
         return client.send(operation: "DeleteFieldLevelEncryptionProfile2019_03_26", path: "/2019-03-26/field-level-encryption-profile/{Id}", httpMethod: "DELETE", input: input)
     }
 
-    @discardableResult public func deletePublicKey20190326(_ input: DeletePublicKeyRequest) -> Future<Void> {
+    ///  Remove a public key you previously added to CloudFront.
+    @discardableResult public func deletePublicKey(_ input: DeletePublicKeyRequest) -> Future<Void> {
         return client.send(operation: "DeletePublicKey2019_03_26", path: "/2019-03-26/public-key/{Id}", httpMethod: "DELETE", input: input)
     }
 
-    @discardableResult public func deleteStreamingDistribution20190326(_ input: DeleteStreamingDistributionRequest) -> Future<Void> {
+    ///  Delete a streaming distribution. To delete an RTMP distribution using the CloudFront API, perform the following steps.  To delete an RTMP distribution using the CloudFront API:   Disable the RTMP distribution.   Submit a GET Streaming Distribution Config request to get the current configuration and the Etag header for the distribution.    Update the XML document that was returned in the response to your GET Streaming Distribution Config request to change the value of Enabled to false.   Submit a PUT Streaming Distribution Config request to update the configuration for your distribution. In the request body, include the XML document that you updated in Step 3. Then set the value of the HTTP If-Match header to the value of the ETag header that CloudFront returned when you submitted the GET Streaming Distribution Config request in Step 2.   Review the response to the PUT Streaming Distribution Config request to confirm that the distribution was successfully disabled.   Submit a GET Streaming Distribution Config request to confirm that your changes have propagated. When propagation is complete, the value of Status is Deployed.   Submit a DELETE Streaming Distribution request. Set the value of the HTTP If-Match header to the value of the ETag header that CloudFront returned when you submitted the GET Streaming Distribution Config request in Step 2.   Review the response to your DELETE Streaming Distribution request to confirm that the distribution was successfully deleted.   For information about deleting a distribution using the CloudFront console, see Deleting a Distribution in the Amazon CloudFront Developer Guide.
+    @discardableResult public func deleteStreamingDistribution(_ input: DeleteStreamingDistributionRequest) -> Future<Void> {
         return client.send(operation: "DeleteStreamingDistribution2019_03_26", path: "/2019-03-26/streaming-distribution/{Id}", httpMethod: "DELETE", input: input)
     }
 
-    public func getCloudFrontOriginAccessIdentity20190326(_ input: GetCloudFrontOriginAccessIdentityRequest) -> Future<GetCloudFrontOriginAccessIdentityResult> {
+    ///  Get the information about an origin access identity. 
+    public func getCloudFrontOriginAccessIdentity(_ input: GetCloudFrontOriginAccessIdentityRequest) -> Future<GetCloudFrontOriginAccessIdentityResult> {
         return client.send(operation: "GetCloudFrontOriginAccessIdentity2019_03_26", path: "/2019-03-26/origin-access-identity/cloudfront/{Id}", httpMethod: "GET", input: input)
     }
 
-    public func getCloudFrontOriginAccessIdentityConfig20190326(_ input: GetCloudFrontOriginAccessIdentityConfigRequest) -> Future<GetCloudFrontOriginAccessIdentityConfigResult> {
+    ///  Get the configuration information about an origin access identity. 
+    public func getCloudFrontOriginAccessIdentityConfig(_ input: GetCloudFrontOriginAccessIdentityConfigRequest) -> Future<GetCloudFrontOriginAccessIdentityConfigResult> {
         return client.send(operation: "GetCloudFrontOriginAccessIdentityConfig2019_03_26", path: "/2019-03-26/origin-access-identity/cloudfront/{Id}/config", httpMethod: "GET", input: input)
     }
 
-    public func getDistribution20190326(_ input: GetDistributionRequest) -> Future<GetDistributionResult> {
+    ///  Get the information about a distribution.
+    public func getDistribution(_ input: GetDistributionRequest) -> Future<GetDistributionResult> {
         return client.send(operation: "GetDistribution2019_03_26", path: "/2019-03-26/distribution/{Id}", httpMethod: "GET", input: input)
     }
 
-    public func getDistributionConfig20190326(_ input: GetDistributionConfigRequest) -> Future<GetDistributionConfigResult> {
+    ///  Get the configuration information about a distribution. 
+    public func getDistributionConfig(_ input: GetDistributionConfigRequest) -> Future<GetDistributionConfigResult> {
         return client.send(operation: "GetDistributionConfig2019_03_26", path: "/2019-03-26/distribution/{Id}/config", httpMethod: "GET", input: input)
     }
 
-    public func getFieldLevelEncryption20190326(_ input: GetFieldLevelEncryptionRequest) -> Future<GetFieldLevelEncryptionResult> {
+    ///  Get the field-level encryption configuration information.
+    public func getFieldLevelEncryption(_ input: GetFieldLevelEncryptionRequest) -> Future<GetFieldLevelEncryptionResult> {
         return client.send(operation: "GetFieldLevelEncryption2019_03_26", path: "/2019-03-26/field-level-encryption/{Id}", httpMethod: "GET", input: input)
     }
 
-    public func getFieldLevelEncryptionConfig20190326(_ input: GetFieldLevelEncryptionConfigRequest) -> Future<GetFieldLevelEncryptionConfigResult> {
+    ///  Get the field-level encryption configuration information.
+    public func getFieldLevelEncryptionConfig(_ input: GetFieldLevelEncryptionConfigRequest) -> Future<GetFieldLevelEncryptionConfigResult> {
         return client.send(operation: "GetFieldLevelEncryptionConfig2019_03_26", path: "/2019-03-26/field-level-encryption/{Id}/config", httpMethod: "GET", input: input)
     }
 
-    public func getFieldLevelEncryptionProfile20190326(_ input: GetFieldLevelEncryptionProfileRequest) -> Future<GetFieldLevelEncryptionProfileResult> {
+    ///  Get the field-level encryption profile information.
+    public func getFieldLevelEncryptionProfile(_ input: GetFieldLevelEncryptionProfileRequest) -> Future<GetFieldLevelEncryptionProfileResult> {
         return client.send(operation: "GetFieldLevelEncryptionProfile2019_03_26", path: "/2019-03-26/field-level-encryption-profile/{Id}", httpMethod: "GET", input: input)
     }
 
-    public func getFieldLevelEncryptionProfileConfig20190326(_ input: GetFieldLevelEncryptionProfileConfigRequest) -> Future<GetFieldLevelEncryptionProfileConfigResult> {
+    ///  Get the field-level encryption profile configuration information.
+    public func getFieldLevelEncryptionProfileConfig(_ input: GetFieldLevelEncryptionProfileConfigRequest) -> Future<GetFieldLevelEncryptionProfileConfigResult> {
         return client.send(operation: "GetFieldLevelEncryptionProfileConfig2019_03_26", path: "/2019-03-26/field-level-encryption-profile/{Id}/config", httpMethod: "GET", input: input)
     }
 
-    public func getInvalidation20190326(_ input: GetInvalidationRequest) -> Future<GetInvalidationResult> {
+    ///  Get the information about an invalidation. 
+    public func getInvalidation(_ input: GetInvalidationRequest) -> Future<GetInvalidationResult> {
         return client.send(operation: "GetInvalidation2019_03_26", path: "/2019-03-26/distribution/{DistributionId}/invalidation/{Id}", httpMethod: "GET", input: input)
     }
 
-    public func getPublicKey20190326(_ input: GetPublicKeyRequest) -> Future<GetPublicKeyResult> {
+    ///  Get the public key information.
+    public func getPublicKey(_ input: GetPublicKeyRequest) -> Future<GetPublicKeyResult> {
         return client.send(operation: "GetPublicKey2019_03_26", path: "/2019-03-26/public-key/{Id}", httpMethod: "GET", input: input)
     }
 
-    public func getPublicKeyConfig20190326(_ input: GetPublicKeyConfigRequest) -> Future<GetPublicKeyConfigResult> {
+    ///  Return public key configuration informaation
+    public func getPublicKeyConfig(_ input: GetPublicKeyConfigRequest) -> Future<GetPublicKeyConfigResult> {
         return client.send(operation: "GetPublicKeyConfig2019_03_26", path: "/2019-03-26/public-key/{Id}/config", httpMethod: "GET", input: input)
     }
 
-    public func getStreamingDistribution20190326(_ input: GetStreamingDistributionRequest) -> Future<GetStreamingDistributionResult> {
+    ///  Gets information about a specified RTMP distribution, including the distribution configuration.
+    public func getStreamingDistribution(_ input: GetStreamingDistributionRequest) -> Future<GetStreamingDistributionResult> {
         return client.send(operation: "GetStreamingDistribution2019_03_26", path: "/2019-03-26/streaming-distribution/{Id}", httpMethod: "GET", input: input)
     }
 
-    public func getStreamingDistributionConfig20190326(_ input: GetStreamingDistributionConfigRequest) -> Future<GetStreamingDistributionConfigResult> {
+    ///  Get the configuration information about a streaming distribution. 
+    public func getStreamingDistributionConfig(_ input: GetStreamingDistributionConfigRequest) -> Future<GetStreamingDistributionConfigResult> {
         return client.send(operation: "GetStreamingDistributionConfig2019_03_26", path: "/2019-03-26/streaming-distribution/{Id}/config", httpMethod: "GET", input: input)
     }
 
-    public func listCloudFrontOriginAccessIdentities20190326(_ input: ListCloudFrontOriginAccessIdentitiesRequest) -> Future<ListCloudFrontOriginAccessIdentitiesResult> {
+    ///  Lists origin access identities.
+    public func listCloudFrontOriginAccessIdentities(_ input: ListCloudFrontOriginAccessIdentitiesRequest) -> Future<ListCloudFrontOriginAccessIdentitiesResult> {
         return client.send(operation: "ListCloudFrontOriginAccessIdentities2019_03_26", path: "/2019-03-26/origin-access-identity/cloudfront", httpMethod: "GET", input: input)
     }
 
-    public func listDistributions20190326(_ input: ListDistributionsRequest) -> Future<ListDistributionsResult> {
+    ///  List CloudFront distributions.
+    public func listDistributions(_ input: ListDistributionsRequest) -> Future<ListDistributionsResult> {
         return client.send(operation: "ListDistributions2019_03_26", path: "/2019-03-26/distribution", httpMethod: "GET", input: input)
     }
 
-    public func listDistributionsByWebACLId20190326(_ input: ListDistributionsByWebACLIdRequest) -> Future<ListDistributionsByWebACLIdResult> {
+    ///  List the distributions that are associated with a specified AWS WAF web ACL. 
+    public func listDistributionsByWebACLId(_ input: ListDistributionsByWebACLIdRequest) -> Future<ListDistributionsByWebACLIdResult> {
         return client.send(operation: "ListDistributionsByWebACLId2019_03_26", path: "/2019-03-26/distributionsByWebACLId/{WebACLId}", httpMethod: "GET", input: input)
     }
 
-    public func listFieldLevelEncryptionConfigs20190326(_ input: ListFieldLevelEncryptionConfigsRequest) -> Future<ListFieldLevelEncryptionConfigsResult> {
+    ///  List all field-level encryption configurations that have been created in CloudFront for this account.
+    public func listFieldLevelEncryptionConfigs(_ input: ListFieldLevelEncryptionConfigsRequest) -> Future<ListFieldLevelEncryptionConfigsResult> {
         return client.send(operation: "ListFieldLevelEncryptionConfigs2019_03_26", path: "/2019-03-26/field-level-encryption", httpMethod: "GET", input: input)
     }
 
-    public func listFieldLevelEncryptionProfiles20190326(_ input: ListFieldLevelEncryptionProfilesRequest) -> Future<ListFieldLevelEncryptionProfilesResult> {
+    ///  Request a list of field-level encryption profiles that have been created in CloudFront for this account.
+    public func listFieldLevelEncryptionProfiles(_ input: ListFieldLevelEncryptionProfilesRequest) -> Future<ListFieldLevelEncryptionProfilesResult> {
         return client.send(operation: "ListFieldLevelEncryptionProfiles2019_03_26", path: "/2019-03-26/field-level-encryption-profile", httpMethod: "GET", input: input)
     }
 
-    public func listInvalidations20190326(_ input: ListInvalidationsRequest) -> Future<ListInvalidationsResult> {
+    ///  Lists invalidation batches. 
+    public func listInvalidations(_ input: ListInvalidationsRequest) -> Future<ListInvalidationsResult> {
         return client.send(operation: "ListInvalidations2019_03_26", path: "/2019-03-26/distribution/{DistributionId}/invalidation", httpMethod: "GET", input: input)
     }
 
-    public func listPublicKeys20190326(_ input: ListPublicKeysRequest) -> Future<ListPublicKeysResult> {
+    ///  List all public keys that have been added to CloudFront for this account.
+    public func listPublicKeys(_ input: ListPublicKeysRequest) -> Future<ListPublicKeysResult> {
         return client.send(operation: "ListPublicKeys2019_03_26", path: "/2019-03-26/public-key", httpMethod: "GET", input: input)
     }
 
-    public func listStreamingDistributions20190326(_ input: ListStreamingDistributionsRequest) -> Future<ListStreamingDistributionsResult> {
+    ///  List streaming distributions. 
+    public func listStreamingDistributions(_ input: ListStreamingDistributionsRequest) -> Future<ListStreamingDistributionsResult> {
         return client.send(operation: "ListStreamingDistributions2019_03_26", path: "/2019-03-26/streaming-distribution", httpMethod: "GET", input: input)
     }
 
-    public func listTagsForResource20190326(_ input: ListTagsForResourceRequest) -> Future<ListTagsForResourceResult> {
+    ///  List tags for a CloudFront resource.
+    public func listTagsForResource(_ input: ListTagsForResourceRequest) -> Future<ListTagsForResourceResult> {
         return client.send(operation: "ListTagsForResource2019_03_26", path: "/2019-03-26/tagging", httpMethod: "GET", input: input)
     }
 
-    @discardableResult public func tagResource20190326(_ input: TagResourceRequest) -> Future<Void> {
+    ///  Add tags to a CloudFront resource.
+    @discardableResult public func tagResource(_ input: TagResourceRequest) -> Future<Void> {
         return client.send(operation: "TagResource2019_03_26", path: "/2019-03-26/tagging?Operation=Tag", httpMethod: "POST", input: input)
     }
 
-    @discardableResult public func untagResource20190326(_ input: UntagResourceRequest) -> Future<Void> {
+    ///  Remove tags from a CloudFront resource.
+    @discardableResult public func untagResource(_ input: UntagResourceRequest) -> Future<Void> {
         return client.send(operation: "UntagResource2019_03_26", path: "/2019-03-26/tagging?Operation=Untag", httpMethod: "POST", input: input)
     }
 
-    public func updateCloudFrontOriginAccessIdentity20190326(_ input: UpdateCloudFrontOriginAccessIdentityRequest) -> Future<UpdateCloudFrontOriginAccessIdentityResult> {
+    ///  Update an origin access identity. 
+    public func updateCloudFrontOriginAccessIdentity(_ input: UpdateCloudFrontOriginAccessIdentityRequest) -> Future<UpdateCloudFrontOriginAccessIdentityResult> {
         return client.send(operation: "UpdateCloudFrontOriginAccessIdentity2019_03_26", path: "/2019-03-26/origin-access-identity/cloudfront/{Id}/config", httpMethod: "PUT", input: input)
     }
 
-    public func updateDistribution20190326(_ input: UpdateDistributionRequest) -> Future<UpdateDistributionResult> {
+    ///  Updates the configuration for a web distribution.   When you update a distribution, there are more required fields than when you create a distribution. When you update your distribution by using this API action, follow the steps here to get the current configuration and then make your updates, to make sure that you include all of the required fields. To view a summary, see Required Fields for Create Distribution and Update Distribution in the Amazon CloudFront Developer Guide.  The update process includes getting the current distribution configuration, updating the XML document that is returned to make your changes, and then submitting an UpdateDistribution request to make the updates. For information about updating a distribution using the CloudFront console instead, see Creating a Distribution in the Amazon CloudFront Developer Guide.  To update a web distribution using the CloudFront API    Submit a GetDistributionConfig request to get the current configuration and an Etag header for the distribution.  If you update the distribution again, you must get a new Etag header.    Update the XML document that was returned in the response to your GetDistributionConfig request to include your changes.   When you edit the XML file, be aware of the following:   You must strip out the ETag parameter that is returned.   Additional fields are required when you update a distribution. There may be fields included in the XML file for features that you haven't configured for your distribution. This is expected and required to successfully update the distribution.   You can't change the value of CallerReference. If you try to change this value, CloudFront returns an IllegalUpdate error.    The new configuration replaces the existing configuration; the values that you specify in an UpdateDistribution request are not merged into your existing configuration. When you add, delete, or replace values in an element that allows multiple values (for example, CNAME), you must specify all of the values that you want to appear in the updated distribution. In addition, you must update the corresponding Quantity element.      Submit an UpdateDistribution request to update the configuration for your distribution:   In the request body, include the XML document that you updated in Step 2. The request body must include an XML document with a DistributionConfig element.   Set the value of the HTTP If-Match header to the value of the ETag header that CloudFront returned when you submitted the GetDistributionConfig request in Step 1.     Review the response to the UpdateDistribution request to confirm that the configuration was successfully updated.   Optional: Submit a GetDistribution request to confirm that your changes have propagated. When propagation is complete, the value of Status is Deployed.  
+    public func updateDistribution(_ input: UpdateDistributionRequest) -> Future<UpdateDistributionResult> {
         return client.send(operation: "UpdateDistribution2019_03_26", path: "/2019-03-26/distribution/{Id}/config", httpMethod: "PUT", input: input)
     }
 
-    public func updateFieldLevelEncryptionConfig20190326(_ input: UpdateFieldLevelEncryptionConfigRequest) -> Future<UpdateFieldLevelEncryptionConfigResult> {
+    ///  Update a field-level encryption configuration. 
+    public func updateFieldLevelEncryptionConfig(_ input: UpdateFieldLevelEncryptionConfigRequest) -> Future<UpdateFieldLevelEncryptionConfigResult> {
         return client.send(operation: "UpdateFieldLevelEncryptionConfig2019_03_26", path: "/2019-03-26/field-level-encryption/{Id}/config", httpMethod: "PUT", input: input)
     }
 
-    public func updateFieldLevelEncryptionProfile20190326(_ input: UpdateFieldLevelEncryptionProfileRequest) -> Future<UpdateFieldLevelEncryptionProfileResult> {
+    ///  Update a field-level encryption profile. 
+    public func updateFieldLevelEncryptionProfile(_ input: UpdateFieldLevelEncryptionProfileRequest) -> Future<UpdateFieldLevelEncryptionProfileResult> {
         return client.send(operation: "UpdateFieldLevelEncryptionProfile2019_03_26", path: "/2019-03-26/field-level-encryption-profile/{Id}/config", httpMethod: "PUT", input: input)
     }
 
-    public func updatePublicKey20190326(_ input: UpdatePublicKeyRequest) -> Future<UpdatePublicKeyResult> {
+    ///  Update public key information. Note that the only value you can change is the comment.
+    public func updatePublicKey(_ input: UpdatePublicKeyRequest) -> Future<UpdatePublicKeyResult> {
         return client.send(operation: "UpdatePublicKey2019_03_26", path: "/2019-03-26/public-key/{Id}/config", httpMethod: "PUT", input: input)
     }
 
-    public func updateStreamingDistribution20190326(_ input: UpdateStreamingDistributionRequest) -> Future<UpdateStreamingDistributionResult> {
+    ///  Update a streaming distribution. 
+    public func updateStreamingDistribution(_ input: UpdateStreamingDistributionRequest) -> Future<UpdateStreamingDistributionResult> {
         return client.send(operation: "UpdateStreamingDistribution2019_03_26", path: "/2019-03-26/streaming-distribution/{Id}/config", httpMethod: "PUT", input: input)
     }
 }


### PR DESCRIPTION
It was using the "name" field which is actually the operation name. Sometimes this included an api version in the name and made the function names a little awkward.

This only affected CloudFront. It also has the added bonus of catching a little more documentation.  