### PR TITLE
The XML namespace can be in operations part of json models

### DIFF
--- a/CodeGenerator/Sources/CodeGenerator/AWSService.swift
+++ b/CodeGenerator/Sources/CodeGenerator/AWSService.swift
@@ -172,6 +172,7 @@ struct AWSService {
                 structure[_struct["shape"].stringValue] = try shapeType(from: shapeJSON, level: level+1)
             }
 
+            var xmlNamespace: String? = nil
             let members: [Member] = json["members"].dictionaryValue.compactMap { name, memberJSON in
                 if memberJSON["deprecated"].bool == true {
                     return nil
@@ -218,8 +219,8 @@ struct AWSService {
                 if memberJSON["idempotencyToken"].bool == true {
                     options.insert(.idempotencyToken)
                 }
-                if let xmlNamespace = memberJSON["xmlNamespace"]["uri"].string {
-                    addShapeOperation(shapeName: shape.name, operation: SetXMLNamespaceOperation(xmlNamespace: xmlNamespace))
+                if let memberXMLNamespace = memberJSON["xmlNamespace"]["uri"].string {
+                    xmlNamespace = memberXMLNamespace
                 }
                 
                 return Member(
@@ -232,7 +233,7 @@ struct AWSService {
                 )
             }.sorted{ $0.name.lowercased() < $1.name.lowercased() }
 
-            let shape = StructureShape(members: members, payload: json["payload"].string)
+            let shape = StructureShape(members: members, payload: json["payload"].string, xmlNamespace: xmlNamespace)
             type = .structure(shape)
 
         case "map":

--- a/CodeGenerator/Sources/CodeGenerator/Doc/Member.swift
+++ b/CodeGenerator/Sources/CodeGenerator/Doc/Member.swift
@@ -34,16 +34,14 @@ public struct Member {
     public let shape: Shape
     public let location: Location?
     public let shapeEncoding: ShapeEncoding?
-    public let xmlNamespace: XMLNamespace?
     public let options: Options
     
-    public init(name: String, required: Bool, shape: Shape, location: Location?, shapeEncoding: ShapeEncoding?, xmlNamespace: XMLNamespace?, options: Options){
+    public init(name: String, required: Bool, shape: Shape, location: Location?, shapeEncoding: ShapeEncoding?, options: Options){
         self.name = name
         self.required = required
         self.shape = shape
         self.location = location
         self.shapeEncoding = shapeEncoding
-        self.xmlNamespace = xmlNamespace
         self.options = options
     }
 }

--- a/CodeGenerator/Sources/CodeGenerator/Doc/Operation.swift
+++ b/CodeGenerator/Sources/CodeGenerator/Doc/Operation.swift
@@ -14,8 +14,16 @@ public struct Operation {
     public let inputShape: Shape?
     public let outputShape: Shape?
     public let deprecatedMessage: String?
-    
-    public init(name: String, operationName: String, httpMethod: String, path: String, inputShape: Shape?, outputShape: Shape?, deprecatedMessage : String? = nil){
+
+    public init(
+        name: String,
+        operationName: String,
+        httpMethod: String,
+        path: String,
+        inputShape: Shape?,
+        outputShape: Shape?,
+        deprecatedMessage : String? = nil
+    ) {
         self.name = name
         self.operationName = operationName
         self.httpMethod = httpMethod

--- a/CodeGenerator/Sources/CodeGenerator/Doc/Shape.swift
+++ b/CodeGenerator/Sources/CodeGenerator/Doc/Shape.swift
@@ -14,7 +14,7 @@ public enum ShapeTypeError: Error {
 
 public class Shape {
     public let name: String
-    public let type: ShapeType
+    public var type: ShapeType
     public var usedInInput : Bool = false
     public var usedInOutput : Bool = false
 

--- a/CodeGenerator/Sources/CodeGenerator/Doc/Shape.swift
+++ b/CodeGenerator/Sources/CodeGenerator/Doc/Shape.swift
@@ -36,19 +36,8 @@ public class StructureShape {
     }
 }
 
-public typealias XMLAttribute = [String: [String: String]] // ["elementName": ["key": "value", ...]]
-
 public struct XMLNamespace {
-    public let locationName: String
     public let attributeMap: [String: Any]
-    
-    public var attributes: XMLAttribute {
-        var dict: [String: String] = [:]
-        attributeMap.forEach {
-            dict[$0.key] = "\($0.value)"
-        }
-        return [locationName: dict]
-    }
     
     public init?(dictionary: [String: Any]) {
         if let attributeMap = dictionary["xmlNamespace"] as? [String: Any] {
@@ -57,12 +46,6 @@ public struct XMLNamespace {
         else {
             return nil
         }
-        
-        guard let name = dictionary["locationName"] as? String else {
-            return nil
-        }
-        
-        self.locationName = name
     }
 }
 
@@ -100,4 +83,29 @@ public indirect enum ShapeType {
     case timestamp
     case `enum`([String])
     case unhandledType
+}
+
+/// Operation to be applied to shapes after everything has loaded
+protocol ShapeOperation {
+    func process(_ shape: Shape) -> Shape
+}
+
+/// SetXMLNamespace post process operation to be applied to shapes after everything has loaded
+struct SetXMLNamespaceOperation: ShapeOperation {
+    let xmlNamespace: String
+
+    func process(_ shape: Shape) -> Shape {
+        if case .structure(let shapeStructure) = shape.type {
+            precondition(shapeStructure.xmlNamespace == nil || shapeStructure.xmlNamespace == xmlNamespace,
+                         "Two different XML namespaces being applied to the same shape")
+            shape.type = .structure(
+                StructureShape(
+                    members: shapeStructure.members,
+                    payload: shapeStructure.payload,
+                    xmlNamespace: xmlNamespace
+                )
+            )
+        }
+        return shape
+    }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -228,7 +228,7 @@ let package = Package(
         .library(name: "AWSXRay", targets: ["AWSXRay"])
     ],
     dependencies: [
-        .package(url: "https://github.com/swift-aws/aws-sdk-swift-core.git", .upToNextMinor(from: "4.2.0"))
+        .package(url: "https://github.com/swift-aws/aws-sdk-swift-core.git", .branch("master"))
     ],
     targets: [
         .target(name: "AWSACM", dependencies: ["AWSSDKSwiftCore"], path: "./Sources/AWSSDKSwift/Services/ACM"),

--- a/Sources/AWSSDKSwift/Services/CloudFront/CloudFront_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/CloudFront/CloudFront_Shapes.swift
@@ -348,6 +348,7 @@ extension CloudFront {
     }
 
     public struct CloudFrontOriginAccessIdentityConfig: AWSShape {
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "CallerReference", required: true, type: .string), 
             AWSShapeMember(label: "Comment", required: true, type: .string)
@@ -556,7 +557,6 @@ extension CloudFront {
     public struct CreateCloudFrontOriginAccessIdentityRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "CloudFrontOriginAccessIdentityConfig"
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "CloudFrontOriginAccessIdentityConfig", location: .body(locationName: "CloudFrontOriginAccessIdentityConfig"), required: true, type: .structure)
         ]
@@ -605,7 +605,6 @@ extension CloudFront {
     public struct CreateDistributionRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "DistributionConfig"
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "DistributionConfig", location: .body(locationName: "DistributionConfig"), required: true, type: .structure)
         ]
@@ -658,7 +657,6 @@ extension CloudFront {
     public struct CreateDistributionWithTagsRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "DistributionConfigWithTags"
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "DistributionConfigWithTags", location: .body(locationName: "DistributionConfigWithTags"), required: true, type: .structure)
         ]
@@ -711,7 +709,6 @@ extension CloudFront {
     public struct CreateFieldLevelEncryptionConfigRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "FieldLevelEncryptionConfig"
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "FieldLevelEncryptionConfig", location: .body(locationName: "FieldLevelEncryptionConfig"), required: true, type: .structure)
         ]
@@ -760,7 +757,6 @@ extension CloudFront {
     public struct CreateFieldLevelEncryptionProfileRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "FieldLevelEncryptionProfileConfig"
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "FieldLevelEncryptionProfileConfig", location: .body(locationName: "FieldLevelEncryptionProfileConfig"), required: true, type: .structure)
         ]
@@ -809,7 +805,6 @@ extension CloudFront {
     public struct CreateInvalidationRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "InvalidationBatch"
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "DistributionId", location: .uri(locationName: "DistributionId"), required: true, type: .string), 
             AWSShapeMember(label: "InvalidationBatch", location: .body(locationName: "InvalidationBatch"), required: true, type: .structure)
@@ -858,7 +853,6 @@ extension CloudFront {
     public struct CreatePublicKeyRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "PublicKeyConfig"
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "PublicKeyConfig", location: .body(locationName: "PublicKeyConfig"), required: true, type: .structure)
         ]
@@ -907,7 +901,6 @@ extension CloudFront {
     public struct CreateStreamingDistributionRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "StreamingDistributionConfig"
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "StreamingDistributionConfig", location: .body(locationName: "StreamingDistributionConfig"), required: true, type: .structure)
         ]
@@ -956,7 +949,6 @@ extension CloudFront {
     public struct CreateStreamingDistributionWithTagsRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "StreamingDistributionConfigWithTags"
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "StreamingDistributionConfigWithTags", location: .body(locationName: "StreamingDistributionConfigWithTags"), required: true, type: .structure)
         ]
@@ -1385,6 +1377,7 @@ extension CloudFront {
     }
 
     public struct DistributionConfig: AWSShape {
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Aliases", required: false, type: .structure), 
             AWSShapeMember(label: "CacheBehaviors", required: false, type: .structure), 
@@ -1487,6 +1480,7 @@ extension CloudFront {
     }
 
     public struct DistributionConfigWithTags: AWSShape {
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "DistributionConfig", required: true, type: .structure), 
             AWSShapeMember(label: "Tags", required: true, type: .structure)
@@ -1744,6 +1738,7 @@ extension CloudFront {
     }
 
     public struct FieldLevelEncryptionConfig: AWSShape {
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "CallerReference", required: true, type: .string), 
             AWSShapeMember(label: "Comment", required: false, type: .string), 
@@ -1835,6 +1830,7 @@ extension CloudFront {
     }
 
     public struct FieldLevelEncryptionProfileConfig: AWSShape {
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "CallerReference", required: true, type: .string), 
             AWSShapeMember(label: "Comment", required: false, type: .string), 
@@ -2641,6 +2637,7 @@ extension CloudFront {
     }
 
     public struct InvalidationBatch: AWSShape {
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "CallerReference", required: true, type: .string), 
             AWSShapeMember(label: "Paths", required: true, type: .structure)
@@ -3499,6 +3496,7 @@ extension CloudFront {
     }
 
     public struct PublicKeyConfig: AWSShape {
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "CallerReference", required: true, type: .string), 
             AWSShapeMember(label: "Comment", required: false, type: .string), 
@@ -3839,6 +3837,7 @@ extension CloudFront {
     }
 
     public struct StreamingDistributionConfig: AWSShape {
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Aliases", required: false, type: .structure), 
             AWSShapeMember(label: "CallerReference", required: true, type: .string), 
@@ -3891,6 +3890,7 @@ extension CloudFront {
     }
 
     public struct StreamingDistributionConfigWithTags: AWSShape {
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "StreamingDistributionConfig", required: true, type: .structure), 
             AWSShapeMember(label: "Tags", required: true, type: .structure)
@@ -4084,6 +4084,7 @@ extension CloudFront {
     }
 
     public struct TagKeys: AWSShape {
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Items", required: false, type: .list, encoding: .list(member:"Key"))
         ]
@@ -4111,7 +4112,6 @@ extension CloudFront {
     public struct TagResourceRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "Tags"
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Resource", location: .querystring(locationName: "Resource"), required: true, type: .string), 
             AWSShapeMember(label: "Tags", location: .body(locationName: "Tags"), required: true, type: .structure)
@@ -4139,6 +4139,7 @@ extension CloudFront {
     }
 
     public struct Tags: AWSShape {
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Items", required: false, type: .list, encoding: .list(member:"Tag"))
         ]
@@ -4191,7 +4192,6 @@ extension CloudFront {
     public struct UntagResourceRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "TagKeys"
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Resource", location: .querystring(locationName: "Resource"), required: true, type: .string), 
             AWSShapeMember(label: "TagKeys", location: .body(locationName: "TagKeys"), required: true, type: .structure)
@@ -4221,7 +4221,6 @@ extension CloudFront {
     public struct UpdateCloudFrontOriginAccessIdentityRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "CloudFrontOriginAccessIdentityConfig"
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "CloudFrontOriginAccessIdentityConfig", location: .body(locationName: "CloudFrontOriginAccessIdentityConfig"), required: true, type: .structure), 
             AWSShapeMember(label: "Id", location: .uri(locationName: "Id"), required: true, type: .string), 
@@ -4275,7 +4274,6 @@ extension CloudFront {
     public struct UpdateDistributionRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "DistributionConfig"
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "DistributionConfig", location: .body(locationName: "DistributionConfig"), required: true, type: .structure), 
             AWSShapeMember(label: "Id", location: .uri(locationName: "Id"), required: true, type: .string), 
@@ -4333,7 +4331,6 @@ extension CloudFront {
     public struct UpdateFieldLevelEncryptionConfigRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "FieldLevelEncryptionConfig"
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "FieldLevelEncryptionConfig", location: .body(locationName: "FieldLevelEncryptionConfig"), required: true, type: .structure), 
             AWSShapeMember(label: "Id", location: .uri(locationName: "Id"), required: true, type: .string), 
@@ -4387,7 +4384,6 @@ extension CloudFront {
     public struct UpdateFieldLevelEncryptionProfileRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "FieldLevelEncryptionProfileConfig"
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "FieldLevelEncryptionProfileConfig", location: .body(locationName: "FieldLevelEncryptionProfileConfig"), required: true, type: .structure), 
             AWSShapeMember(label: "Id", location: .uri(locationName: "Id"), required: true, type: .string), 
@@ -4441,7 +4437,6 @@ extension CloudFront {
     public struct UpdatePublicKeyRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "PublicKeyConfig"
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Id", location: .uri(locationName: "Id"), required: true, type: .string), 
             AWSShapeMember(label: "IfMatch", location: .header(locationName: "If-Match"), required: false, type: .string), 
@@ -4495,7 +4490,6 @@ extension CloudFront {
     public struct UpdateStreamingDistributionRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "StreamingDistributionConfig"
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Id", location: .uri(locationName: "Id"), required: true, type: .string), 
             AWSShapeMember(label: "IfMatch", location: .header(locationName: "If-Match"), required: false, type: .string), 

--- a/Sources/AWSSDKSwift/Services/CloudFront/CloudFront_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/CloudFront/CloudFront_Shapes.swift
@@ -348,7 +348,6 @@ extension CloudFront {
     }
 
     public struct CloudFrontOriginAccessIdentityConfig: AWSShape {
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "CallerReference", required: true, type: .string), 
             AWSShapeMember(label: "Comment", required: true, type: .string)
@@ -557,6 +556,7 @@ extension CloudFront {
     public struct CreateCloudFrontOriginAccessIdentityRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "CloudFrontOriginAccessIdentityConfig"
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "CloudFrontOriginAccessIdentityConfig", location: .body(locationName: "CloudFrontOriginAccessIdentityConfig"), required: true, type: .structure)
         ]
@@ -605,6 +605,7 @@ extension CloudFront {
     public struct CreateDistributionRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "DistributionConfig"
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "DistributionConfig", location: .body(locationName: "DistributionConfig"), required: true, type: .structure)
         ]
@@ -657,6 +658,7 @@ extension CloudFront {
     public struct CreateDistributionWithTagsRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "DistributionConfigWithTags"
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "DistributionConfigWithTags", location: .body(locationName: "DistributionConfigWithTags"), required: true, type: .structure)
         ]
@@ -709,6 +711,7 @@ extension CloudFront {
     public struct CreateFieldLevelEncryptionConfigRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "FieldLevelEncryptionConfig"
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "FieldLevelEncryptionConfig", location: .body(locationName: "FieldLevelEncryptionConfig"), required: true, type: .structure)
         ]
@@ -757,6 +760,7 @@ extension CloudFront {
     public struct CreateFieldLevelEncryptionProfileRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "FieldLevelEncryptionProfileConfig"
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "FieldLevelEncryptionProfileConfig", location: .body(locationName: "FieldLevelEncryptionProfileConfig"), required: true, type: .structure)
         ]
@@ -805,6 +809,7 @@ extension CloudFront {
     public struct CreateInvalidationRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "InvalidationBatch"
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "DistributionId", location: .uri(locationName: "DistributionId"), required: true, type: .string), 
             AWSShapeMember(label: "InvalidationBatch", location: .body(locationName: "InvalidationBatch"), required: true, type: .structure)
@@ -853,6 +858,7 @@ extension CloudFront {
     public struct CreatePublicKeyRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "PublicKeyConfig"
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "PublicKeyConfig", location: .body(locationName: "PublicKeyConfig"), required: true, type: .structure)
         ]
@@ -901,6 +907,7 @@ extension CloudFront {
     public struct CreateStreamingDistributionRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "StreamingDistributionConfig"
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "StreamingDistributionConfig", location: .body(locationName: "StreamingDistributionConfig"), required: true, type: .structure)
         ]
@@ -949,6 +956,7 @@ extension CloudFront {
     public struct CreateStreamingDistributionWithTagsRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "StreamingDistributionConfigWithTags"
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "StreamingDistributionConfigWithTags", location: .body(locationName: "StreamingDistributionConfigWithTags"), required: true, type: .structure)
         ]
@@ -1377,7 +1385,6 @@ extension CloudFront {
     }
 
     public struct DistributionConfig: AWSShape {
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Aliases", required: false, type: .structure), 
             AWSShapeMember(label: "CacheBehaviors", required: false, type: .structure), 
@@ -1480,7 +1487,6 @@ extension CloudFront {
     }
 
     public struct DistributionConfigWithTags: AWSShape {
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "DistributionConfig", required: true, type: .structure), 
             AWSShapeMember(label: "Tags", required: true, type: .structure)
@@ -1738,7 +1744,6 @@ extension CloudFront {
     }
 
     public struct FieldLevelEncryptionConfig: AWSShape {
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "CallerReference", required: true, type: .string), 
             AWSShapeMember(label: "Comment", required: false, type: .string), 
@@ -1830,7 +1835,6 @@ extension CloudFront {
     }
 
     public struct FieldLevelEncryptionProfileConfig: AWSShape {
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "CallerReference", required: true, type: .string), 
             AWSShapeMember(label: "Comment", required: false, type: .string), 
@@ -2637,7 +2641,6 @@ extension CloudFront {
     }
 
     public struct InvalidationBatch: AWSShape {
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "CallerReference", required: true, type: .string), 
             AWSShapeMember(label: "Paths", required: true, type: .structure)
@@ -3496,7 +3499,6 @@ extension CloudFront {
     }
 
     public struct PublicKeyConfig: AWSShape {
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "CallerReference", required: true, type: .string), 
             AWSShapeMember(label: "Comment", required: false, type: .string), 
@@ -3837,7 +3839,6 @@ extension CloudFront {
     }
 
     public struct StreamingDistributionConfig: AWSShape {
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Aliases", required: false, type: .structure), 
             AWSShapeMember(label: "CallerReference", required: true, type: .string), 
@@ -3890,7 +3891,6 @@ extension CloudFront {
     }
 
     public struct StreamingDistributionConfigWithTags: AWSShape {
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "StreamingDistributionConfig", required: true, type: .structure), 
             AWSShapeMember(label: "Tags", required: true, type: .structure)
@@ -4084,7 +4084,6 @@ extension CloudFront {
     }
 
     public struct TagKeys: AWSShape {
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Items", required: false, type: .list, encoding: .list(member:"Key"))
         ]
@@ -4112,6 +4111,7 @@ extension CloudFront {
     public struct TagResourceRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "Tags"
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Resource", location: .querystring(locationName: "Resource"), required: true, type: .string), 
             AWSShapeMember(label: "Tags", location: .body(locationName: "Tags"), required: true, type: .structure)
@@ -4139,7 +4139,6 @@ extension CloudFront {
     }
 
     public struct Tags: AWSShape {
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Items", required: false, type: .list, encoding: .list(member:"Tag"))
         ]
@@ -4192,6 +4191,7 @@ extension CloudFront {
     public struct UntagResourceRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "TagKeys"
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Resource", location: .querystring(locationName: "Resource"), required: true, type: .string), 
             AWSShapeMember(label: "TagKeys", location: .body(locationName: "TagKeys"), required: true, type: .structure)
@@ -4221,6 +4221,7 @@ extension CloudFront {
     public struct UpdateCloudFrontOriginAccessIdentityRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "CloudFrontOriginAccessIdentityConfig"
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "CloudFrontOriginAccessIdentityConfig", location: .body(locationName: "CloudFrontOriginAccessIdentityConfig"), required: true, type: .structure), 
             AWSShapeMember(label: "Id", location: .uri(locationName: "Id"), required: true, type: .string), 
@@ -4274,6 +4275,7 @@ extension CloudFront {
     public struct UpdateDistributionRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "DistributionConfig"
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "DistributionConfig", location: .body(locationName: "DistributionConfig"), required: true, type: .structure), 
             AWSShapeMember(label: "Id", location: .uri(locationName: "Id"), required: true, type: .string), 
@@ -4331,6 +4333,7 @@ extension CloudFront {
     public struct UpdateFieldLevelEncryptionConfigRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "FieldLevelEncryptionConfig"
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "FieldLevelEncryptionConfig", location: .body(locationName: "FieldLevelEncryptionConfig"), required: true, type: .structure), 
             AWSShapeMember(label: "Id", location: .uri(locationName: "Id"), required: true, type: .string), 
@@ -4384,6 +4387,7 @@ extension CloudFront {
     public struct UpdateFieldLevelEncryptionProfileRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "FieldLevelEncryptionProfileConfig"
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "FieldLevelEncryptionProfileConfig", location: .body(locationName: "FieldLevelEncryptionProfileConfig"), required: true, type: .structure), 
             AWSShapeMember(label: "Id", location: .uri(locationName: "Id"), required: true, type: .string), 
@@ -4437,6 +4441,7 @@ extension CloudFront {
     public struct UpdatePublicKeyRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "PublicKeyConfig"
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Id", location: .uri(locationName: "Id"), required: true, type: .string), 
             AWSShapeMember(label: "IfMatch", location: .header(locationName: "If-Match"), required: false, type: .string), 
@@ -4490,6 +4495,7 @@ extension CloudFront {
     public struct UpdateStreamingDistributionRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "StreamingDistributionConfig"
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Id", location: .uri(locationName: "Id"), required: true, type: .string), 
             AWSShapeMember(label: "IfMatch", location: .header(locationName: "If-Match"), required: false, type: .string), 

--- a/Sources/AWSSDKSwift/Services/Route53/Route53_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/Route53/Route53_Shapes.swift
@@ -280,6 +280,7 @@ extension Route53 {
     }
 
     public struct AssociateVPCWithHostedZoneRequest: AWSShape {
+        public static let _xmlNamespace: String? = "https://route53.amazonaws.com/doc/2013-04-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Comment", required: false, type: .string), 
             AWSShapeMember(label: "HostedZoneId", location: .uri(locationName: "Id"), required: true, type: .string), 
@@ -417,6 +418,7 @@ extension Route53 {
     }
 
     public struct ChangeResourceRecordSetsRequest: AWSShape {
+        public static let _xmlNamespace: String? = "https://route53.amazonaws.com/doc/2013-04-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "ChangeBatch", required: true, type: .structure), 
             AWSShapeMember(label: "HostedZoneId", location: .uri(locationName: "Id"), required: true, type: .string)
@@ -461,6 +463,7 @@ extension Route53 {
     }
 
     public struct ChangeTagsForResourceRequest: AWSShape {
+        public static let _xmlNamespace: String? = "https://route53.amazonaws.com/doc/2013-04-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "AddTags", required: false, type: .list, encoding: .list(member:"Tag")), 
             AWSShapeMember(label: "RemoveTagKeys", required: false, type: .list, encoding: .list(member:"Key")), 
@@ -567,6 +570,7 @@ extension Route53 {
     }
 
     public struct CreateHealthCheckRequest: AWSShape {
+        public static let _xmlNamespace: String? = "https://route53.amazonaws.com/doc/2013-04-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "CallerReference", required: true, type: .string), 
             AWSShapeMember(label: "HealthCheckConfig", required: true, type: .structure)
@@ -617,6 +621,7 @@ extension Route53 {
     }
 
     public struct CreateHostedZoneRequest: AWSShape {
+        public static let _xmlNamespace: String? = "https://route53.amazonaws.com/doc/2013-04-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "CallerReference", required: true, type: .string), 
             AWSShapeMember(label: "DelegationSetId", required: false, type: .string), 
@@ -700,6 +705,7 @@ extension Route53 {
     }
 
     public struct CreateQueryLoggingConfigRequest: AWSShape {
+        public static let _xmlNamespace: String? = "https://route53.amazonaws.com/doc/2013-04-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "CloudWatchLogsLogGroupArn", required: true, type: .string), 
             AWSShapeMember(label: "HostedZoneId", required: true, type: .string)
@@ -748,6 +754,7 @@ extension Route53 {
     }
 
     public struct CreateReusableDelegationSetRequest: AWSShape {
+        public static let _xmlNamespace: String? = "https://route53.amazonaws.com/doc/2013-04-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "CallerReference", required: true, type: .string), 
             AWSShapeMember(label: "HostedZoneId", required: false, type: .string)
@@ -798,6 +805,7 @@ extension Route53 {
     }
 
     public struct CreateTrafficPolicyInstanceRequest: AWSShape {
+        public static let _xmlNamespace: String? = "https://route53.amazonaws.com/doc/2013-04-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "HostedZoneId", required: true, type: .string), 
             AWSShapeMember(label: "Name", required: true, type: .string), 
@@ -868,6 +876,7 @@ extension Route53 {
     }
 
     public struct CreateTrafficPolicyRequest: AWSShape {
+        public static let _xmlNamespace: String? = "https://route53.amazonaws.com/doc/2013-04-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Comment", required: false, type: .string), 
             AWSShapeMember(label: "Document", required: true, type: .string), 
@@ -923,6 +932,7 @@ extension Route53 {
     }
 
     public struct CreateTrafficPolicyVersionRequest: AWSShape {
+        public static let _xmlNamespace: String? = "https://route53.amazonaws.com/doc/2013-04-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Comment", required: false, type: .string), 
             AWSShapeMember(label: "Document", required: true, type: .string), 
@@ -979,6 +989,7 @@ extension Route53 {
     }
 
     public struct CreateVPCAssociationAuthorizationRequest: AWSShape {
+        public static let _xmlNamespace: String? = "https://route53.amazonaws.com/doc/2013-04-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "HostedZoneId", location: .uri(locationName: "Id"), required: true, type: .string), 
             AWSShapeMember(label: "VPC", required: true, type: .structure)
@@ -1248,6 +1259,7 @@ extension Route53 {
     }
 
     public struct DeleteVPCAssociationAuthorizationRequest: AWSShape {
+        public static let _xmlNamespace: String? = "https://route53.amazonaws.com/doc/2013-04-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "HostedZoneId", location: .uri(locationName: "Id"), required: true, type: .string), 
             AWSShapeMember(label: "VPC", required: true, type: .structure)
@@ -1305,6 +1317,7 @@ extension Route53 {
     }
 
     public struct DisassociateVPCFromHostedZoneRequest: AWSShape {
+        public static let _xmlNamespace: String? = "https://route53.amazonaws.com/doc/2013-04-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Comment", required: false, type: .string), 
             AWSShapeMember(label: "HostedZoneId", location: .uri(locationName: "Id"), required: true, type: .string), 
@@ -2923,6 +2936,7 @@ extension Route53 {
     }
 
     public struct ListTagsForResourcesRequest: AWSShape {
+        public static let _xmlNamespace: String? = "https://route53.amazonaws.com/doc/2013-04-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "ResourceIds", required: true, type: .list, encoding: .list(member:"ResourceId")), 
             AWSShapeMember(label: "ResourceType", location: .uri(locationName: "ResourceType"), required: true, type: .enum)
@@ -3872,6 +3886,7 @@ extension Route53 {
     }
 
     public struct UpdateHealthCheckRequest: AWSShape {
+        public static let _xmlNamespace: String? = "https://route53.amazonaws.com/doc/2013-04-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "AlarmIdentifier", required: false, type: .structure), 
             AWSShapeMember(label: "ChildHealthChecks", required: false, type: .list, encoding: .list(member:"ChildHealthCheck")), 
@@ -4010,6 +4025,7 @@ extension Route53 {
     }
 
     public struct UpdateHostedZoneCommentRequest: AWSShape {
+        public static let _xmlNamespace: String? = "https://route53.amazonaws.com/doc/2013-04-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Comment", required: false, type: .string), 
             AWSShapeMember(label: "Id", location: .uri(locationName: "Id"), required: true, type: .string)
@@ -4054,6 +4070,7 @@ extension Route53 {
     }
 
     public struct UpdateTrafficPolicyCommentRequest: AWSShape {
+        public static let _xmlNamespace: String? = "https://route53.amazonaws.com/doc/2013-04-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Comment", required: true, type: .string), 
             AWSShapeMember(label: "Id", location: .uri(locationName: "Id"), required: true, type: .string), 
@@ -4106,6 +4123,7 @@ extension Route53 {
     }
 
     public struct UpdateTrafficPolicyInstanceRequest: AWSShape {
+        public static let _xmlNamespace: String? = "https://route53.amazonaws.com/doc/2013-04-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Id", location: .uri(locationName: "Id"), required: true, type: .string), 
             AWSShapeMember(label: "TrafficPolicyId", required: true, type: .string), 

--- a/Sources/AWSSDKSwift/Services/S3/S3_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/S3/S3_Shapes.swift
@@ -441,6 +441,7 @@ extension S3 {
     }
 
     public struct AccelerateConfiguration: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Status", required: false, type: .enum)
         ]
@@ -458,6 +459,7 @@ extension S3 {
     }
 
     public struct AccessControlPolicy: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Grants", location: .body(locationName: "AccessControlList"), required: false, type: .list, encoding: .list(member:"Grant")), 
             AWSShapeMember(label: "Owner", required: false, type: .structure)
@@ -525,6 +527,7 @@ extension S3 {
     }
 
     public struct AnalyticsConfiguration: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Filter", required: false, type: .structure), 
             AWSShapeMember(label: "Id", required: true, type: .string), 
@@ -659,6 +662,7 @@ extension S3 {
     }
 
     public struct BucketLifecycleConfiguration: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Rules", location: .body(locationName: "Rule"), required: true, type: .list, encoding: .flatList)
         ]
@@ -682,6 +686,7 @@ extension S3 {
     }
 
     public struct BucketLoggingStatus: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "LoggingEnabled", required: false, type: .structure)
         ]
@@ -698,6 +703,7 @@ extension S3 {
     }
 
     public struct CORSConfiguration: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "CORSRules", location: .body(locationName: "CORSRule"), required: true, type: .list, encoding: .flatList)
         ]
@@ -942,7 +948,6 @@ extension S3 {
     public struct CompleteMultipartUploadRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "MultipartUpload"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "Key", location: .uri(locationName: "Key"), required: true, type: .string), 
@@ -983,6 +988,7 @@ extension S3 {
     }
 
     public struct CompletedMultipartUpload: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Parts", location: .body(locationName: "Part"), required: false, type: .list, encoding: .flatList)
         ]
@@ -1352,6 +1358,7 @@ extension S3 {
     }
 
     public struct CreateBucketConfiguration: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "LocationConstraint", required: false, type: .enum)
         ]
@@ -1388,7 +1395,6 @@ extension S3 {
     public struct CreateBucketRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "CreateBucketConfiguration"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "ACL", location: .header(locationName: "x-amz-acl"), required: false, type: .enum), 
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
@@ -1689,6 +1695,7 @@ extension S3 {
     }
 
     public struct Delete: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Objects", location: .body(locationName: "Object"), required: true, type: .list, encoding: .flatList), 
             AWSShapeMember(label: "Quiet", required: false, type: .boolean)
@@ -2120,7 +2127,6 @@ extension S3 {
     public struct DeleteObjectsRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "Delete"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "BypassGovernanceRetention", location: .header(locationName: "x-amz-bypass-governance-retention"), required: false, type: .boolean), 
@@ -4092,6 +4098,7 @@ extension S3 {
     }
 
     public struct InventoryConfiguration: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Destination", required: true, type: .structure), 
             AWSShapeMember(label: "Filter", required: false, type: .structure), 
@@ -4313,6 +4320,7 @@ extension S3 {
     }
 
     public struct LifecycleConfiguration: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Rules", location: .body(locationName: "Rule"), required: true, type: .list, encoding: .flatList)
         ]
@@ -5356,6 +5364,7 @@ extension S3 {
     }
 
     public struct MetricsConfiguration: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Filter", required: false, type: .structure), 
             AWSShapeMember(label: "Id", required: true, type: .string)
@@ -5495,6 +5504,7 @@ extension S3 {
     }
 
     public struct NotificationConfiguration: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "LambdaFunctionConfigurations", location: .body(locationName: "CloudFunctionConfiguration"), required: false, type: .list, encoding: .flatList), 
             AWSShapeMember(label: "QueueConfigurations", location: .body(locationName: "QueueConfiguration"), required: false, type: .list, encoding: .flatList), 
@@ -5522,6 +5532,7 @@ extension S3 {
     }
 
     public struct NotificationConfigurationDeprecated: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "CloudFunctionConfiguration", required: false, type: .structure), 
             AWSShapeMember(label: "QueueConfiguration", required: false, type: .structure), 
@@ -5633,6 +5644,7 @@ extension S3 {
     }
 
     public struct ObjectLockConfiguration: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "ObjectLockEnabled", required: false, type: .enum), 
             AWSShapeMember(label: "Rule", required: false, type: .structure)
@@ -5655,6 +5667,7 @@ extension S3 {
     }
 
     public struct ObjectLockLegalHold: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Status", required: false, type: .enum)
         ]
@@ -5672,6 +5685,7 @@ extension S3 {
     }
 
     public struct ObjectLockRetention: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Mode", required: false, type: .enum), 
             AWSShapeMember(label: "RetainUntilDate", required: false, type: .timestamp)
@@ -5885,6 +5899,7 @@ extension S3 {
     }
 
     public struct PublicAccessBlockConfiguration: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "BlockPublicAcls", location: .body(locationName: "BlockPublicAcls"), required: false, type: .boolean), 
             AWSShapeMember(label: "BlockPublicPolicy", location: .body(locationName: "BlockPublicPolicy"), required: false, type: .boolean), 
@@ -5919,7 +5934,6 @@ extension S3 {
     public struct PutBucketAccelerateConfigurationRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "AccelerateConfiguration"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "AccelerateConfiguration", location: .body(locationName: "AccelerateConfiguration"), required: true, type: .structure), 
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string)
@@ -5944,7 +5958,6 @@ extension S3 {
     public struct PutBucketAclRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "AccessControlPolicy"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "AccessControlPolicy", location: .body(locationName: "AccessControlPolicy"), required: false, type: .structure), 
             AWSShapeMember(label: "ACL", location: .header(locationName: "x-amz-acl"), required: false, type: .enum), 
@@ -6004,7 +6017,6 @@ extension S3 {
     public struct PutBucketAnalyticsConfigurationRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "AnalyticsConfiguration"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "AnalyticsConfiguration", location: .body(locationName: "AnalyticsConfiguration"), required: true, type: .structure), 
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
@@ -6038,7 +6050,6 @@ extension S3 {
     public struct PutBucketCorsRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "CORSConfiguration"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "ContentMD5", location: .header(locationName: "Content-MD5"), required: false, type: .string), 
@@ -6068,7 +6079,6 @@ extension S3 {
     public struct PutBucketEncryptionRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "ServerSideEncryptionConfiguration"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "ContentMD5", location: .header(locationName: "Content-MD5"), required: false, type: .string), 
@@ -6097,7 +6107,6 @@ extension S3 {
     public struct PutBucketInventoryConfigurationRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "InventoryConfiguration"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "Id", location: .querystring(locationName: "id"), required: true, type: .string), 
@@ -6127,7 +6136,6 @@ extension S3 {
     public struct PutBucketLifecycleConfigurationRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "LifecycleConfiguration"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "LifecycleConfiguration", location: .body(locationName: "LifecycleConfiguration"), required: false, type: .structure)
@@ -6156,7 +6164,6 @@ extension S3 {
     public struct PutBucketLifecycleRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "LifecycleConfiguration"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "ContentMD5", location: .header(locationName: "Content-MD5"), required: false, type: .string), 
@@ -6183,7 +6190,6 @@ extension S3 {
     public struct PutBucketLoggingRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "BucketLoggingStatus"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "BucketLoggingStatus", location: .body(locationName: "BucketLoggingStatus"), required: true, type: .structure), 
@@ -6213,7 +6219,6 @@ extension S3 {
     public struct PutBucketMetricsConfigurationRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "MetricsConfiguration"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "Id", location: .querystring(locationName: "id"), required: true, type: .string), 
@@ -6247,7 +6252,6 @@ extension S3 {
     public struct PutBucketNotificationConfigurationRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "NotificationConfiguration"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "NotificationConfiguration", location: .body(locationName: "NotificationConfiguration"), required: true, type: .structure)
@@ -6271,7 +6275,6 @@ extension S3 {
     public struct PutBucketNotificationRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "NotificationConfiguration"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "ContentMD5", location: .header(locationName: "Content-MD5"), required: false, type: .string), 
@@ -6335,7 +6338,6 @@ extension S3 {
     public struct PutBucketReplicationRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "ReplicationConfiguration"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "ContentMD5", location: .header(locationName: "Content-MD5"), required: false, type: .string), 
@@ -6372,7 +6374,6 @@ extension S3 {
     public struct PutBucketRequestPaymentRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "RequestPaymentConfiguration"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "ContentMD5", location: .header(locationName: "Content-MD5"), required: false, type: .string), 
@@ -6402,7 +6403,6 @@ extension S3 {
     public struct PutBucketTaggingRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "Tagging"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "ContentMD5", location: .header(locationName: "Content-MD5"), required: false, type: .string), 
@@ -6436,7 +6436,6 @@ extension S3 {
     public struct PutBucketVersioningRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "VersioningConfiguration"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "ContentMD5", location: .header(locationName: "Content-MD5"), required: false, type: .string), 
@@ -6471,7 +6470,6 @@ extension S3 {
     public struct PutBucketWebsiteRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "WebsiteConfiguration"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "ContentMD5", location: .header(locationName: "Content-MD5"), required: false, type: .string), 
@@ -6521,7 +6519,6 @@ extension S3 {
     public struct PutObjectAclRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "AccessControlPolicy"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "AccessControlPolicy", location: .body(locationName: "AccessControlPolicy"), required: false, type: .structure), 
             AWSShapeMember(label: "ACL", location: .header(locationName: "x-amz-acl"), required: false, type: .enum), 
@@ -6615,7 +6612,6 @@ extension S3 {
     public struct PutObjectLegalHoldRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "LegalHold"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "ContentMD5", location: .header(locationName: "Content-MD5"), required: false, type: .string), 
@@ -6679,7 +6675,6 @@ extension S3 {
     public struct PutObjectLockConfigurationRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "ObjectLockConfiguration"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "ContentMD5", location: .header(locationName: "Content-MD5"), required: false, type: .string), 
@@ -6957,7 +6952,6 @@ extension S3 {
     public struct PutObjectRetentionRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "Retention"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "BypassGovernanceRetention", location: .header(locationName: "x-amz-bypass-governance-retention"), required: false, type: .boolean), 
@@ -7027,7 +7021,6 @@ extension S3 {
     public struct PutObjectTaggingRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "Tagging"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "ContentMD5", location: .header(locationName: "Content-MD5"), required: false, type: .string), 
@@ -7072,7 +7065,6 @@ extension S3 {
     public struct PutPublicAccessBlockRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "PublicAccessBlockConfiguration"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "ContentMD5", location: .header(locationName: "Content-MD5"), required: false, type: .string), 
@@ -7215,6 +7207,7 @@ extension S3 {
     }
 
     public struct ReplicationConfiguration: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Role", required: true, type: .string), 
             AWSShapeMember(label: "Rules", location: .body(locationName: "Rule"), required: true, type: .list, encoding: .flatList)
@@ -7395,6 +7388,7 @@ extension S3 {
     }
 
     public struct RequestPaymentConfiguration: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Payer", required: true, type: .enum)
         ]
@@ -7452,7 +7446,6 @@ extension S3 {
     public struct RestoreObjectRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "RestoreRequest"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "Key", location: .uri(locationName: "Key"), required: true, type: .string), 
@@ -7493,6 +7486,7 @@ extension S3 {
     }
 
     public struct RestoreRequest: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Days", required: false, type: .integer), 
             AWSShapeMember(label: "Description", required: false, type: .string), 
@@ -7859,6 +7853,7 @@ extension S3 {
     }
 
     public struct ServerSideEncryptionConfiguration: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Rules", location: .body(locationName: "Rule"), required: true, type: .list, encoding: .flatList)
         ]
@@ -7992,6 +7987,7 @@ extension S3 {
     }
 
     public struct Tagging: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "TagSet", required: true, type: .list, encoding: .list(member:"Tag"))
         ]
@@ -8382,6 +8378,7 @@ extension S3 {
     }
 
     public struct VersioningConfiguration: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "MFADelete", location: .body(locationName: "MfaDelete"), required: false, type: .enum), 
             AWSShapeMember(label: "Status", required: false, type: .enum)
@@ -8404,6 +8401,7 @@ extension S3 {
     }
 
     public struct WebsiteConfiguration: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "ErrorDocument", required: false, type: .structure), 
             AWSShapeMember(label: "IndexDocument", required: false, type: .structure), 

--- a/Sources/AWSSDKSwift/Services/S3/S3_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/S3/S3_Shapes.swift
@@ -7733,6 +7733,7 @@ extension S3 {
     }
 
     public struct SelectObjectContentRequest: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "Expression", required: true, type: .string), 

--- a/Sources/AWSSDKSwift/Services/S3/S3_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/S3/S3_Shapes.swift
@@ -441,7 +441,6 @@ extension S3 {
     }
 
     public struct AccelerateConfiguration: AWSShape {
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Status", required: false, type: .enum)
         ]
@@ -459,7 +458,6 @@ extension S3 {
     }
 
     public struct AccessControlPolicy: AWSShape {
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Grants", location: .body(locationName: "AccessControlList"), required: false, type: .list, encoding: .list(member:"Grant")), 
             AWSShapeMember(label: "Owner", required: false, type: .structure)
@@ -527,7 +525,6 @@ extension S3 {
     }
 
     public struct AnalyticsConfiguration: AWSShape {
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Filter", required: false, type: .structure), 
             AWSShapeMember(label: "Id", required: true, type: .string), 
@@ -662,7 +659,6 @@ extension S3 {
     }
 
     public struct BucketLifecycleConfiguration: AWSShape {
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Rules", location: .body(locationName: "Rule"), required: true, type: .list, encoding: .flatList)
         ]
@@ -686,7 +682,6 @@ extension S3 {
     }
 
     public struct BucketLoggingStatus: AWSShape {
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "LoggingEnabled", required: false, type: .structure)
         ]
@@ -703,7 +698,6 @@ extension S3 {
     }
 
     public struct CORSConfiguration: AWSShape {
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "CORSRules", location: .body(locationName: "CORSRule"), required: true, type: .list, encoding: .flatList)
         ]
@@ -948,6 +942,7 @@ extension S3 {
     public struct CompleteMultipartUploadRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "MultipartUpload"
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "Key", location: .uri(locationName: "Key"), required: true, type: .string), 
@@ -988,7 +983,6 @@ extension S3 {
     }
 
     public struct CompletedMultipartUpload: AWSShape {
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Parts", location: .body(locationName: "Part"), required: false, type: .list, encoding: .flatList)
         ]
@@ -1358,7 +1352,6 @@ extension S3 {
     }
 
     public struct CreateBucketConfiguration: AWSShape {
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "LocationConstraint", required: false, type: .enum)
         ]
@@ -1395,6 +1388,7 @@ extension S3 {
     public struct CreateBucketRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "CreateBucketConfiguration"
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "ACL", location: .header(locationName: "x-amz-acl"), required: false, type: .enum), 
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
@@ -1695,7 +1689,6 @@ extension S3 {
     }
 
     public struct Delete: AWSShape {
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Objects", location: .body(locationName: "Object"), required: true, type: .list, encoding: .flatList), 
             AWSShapeMember(label: "Quiet", required: false, type: .boolean)
@@ -2127,6 +2120,7 @@ extension S3 {
     public struct DeleteObjectsRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "Delete"
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "BypassGovernanceRetention", location: .header(locationName: "x-amz-bypass-governance-retention"), required: false, type: .boolean), 
@@ -4098,7 +4092,6 @@ extension S3 {
     }
 
     public struct InventoryConfiguration: AWSShape {
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Destination", required: true, type: .structure), 
             AWSShapeMember(label: "Filter", required: false, type: .structure), 
@@ -4320,7 +4313,6 @@ extension S3 {
     }
 
     public struct LifecycleConfiguration: AWSShape {
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Rules", location: .body(locationName: "Rule"), required: true, type: .list, encoding: .flatList)
         ]
@@ -5364,7 +5356,6 @@ extension S3 {
     }
 
     public struct MetricsConfiguration: AWSShape {
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Filter", required: false, type: .structure), 
             AWSShapeMember(label: "Id", required: true, type: .string)
@@ -5504,7 +5495,6 @@ extension S3 {
     }
 
     public struct NotificationConfiguration: AWSShape {
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "LambdaFunctionConfigurations", location: .body(locationName: "CloudFunctionConfiguration"), required: false, type: .list, encoding: .flatList), 
             AWSShapeMember(label: "QueueConfigurations", location: .body(locationName: "QueueConfiguration"), required: false, type: .list, encoding: .flatList), 
@@ -5532,7 +5522,6 @@ extension S3 {
     }
 
     public struct NotificationConfigurationDeprecated: AWSShape {
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "CloudFunctionConfiguration", required: false, type: .structure), 
             AWSShapeMember(label: "QueueConfiguration", required: false, type: .structure), 
@@ -5644,7 +5633,6 @@ extension S3 {
     }
 
     public struct ObjectLockConfiguration: AWSShape {
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "ObjectLockEnabled", required: false, type: .enum), 
             AWSShapeMember(label: "Rule", required: false, type: .structure)
@@ -5667,7 +5655,6 @@ extension S3 {
     }
 
     public struct ObjectLockLegalHold: AWSShape {
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Status", required: false, type: .enum)
         ]
@@ -5685,7 +5672,6 @@ extension S3 {
     }
 
     public struct ObjectLockRetention: AWSShape {
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Mode", required: false, type: .enum), 
             AWSShapeMember(label: "RetainUntilDate", required: false, type: .timestamp)
@@ -5899,7 +5885,6 @@ extension S3 {
     }
 
     public struct PublicAccessBlockConfiguration: AWSShape {
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "BlockPublicAcls", location: .body(locationName: "BlockPublicAcls"), required: false, type: .boolean), 
             AWSShapeMember(label: "BlockPublicPolicy", location: .body(locationName: "BlockPublicPolicy"), required: false, type: .boolean), 
@@ -5934,6 +5919,7 @@ extension S3 {
     public struct PutBucketAccelerateConfigurationRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "AccelerateConfiguration"
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "AccelerateConfiguration", location: .body(locationName: "AccelerateConfiguration"), required: true, type: .structure), 
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string)
@@ -5958,6 +5944,7 @@ extension S3 {
     public struct PutBucketAclRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "AccessControlPolicy"
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "AccessControlPolicy", location: .body(locationName: "AccessControlPolicy"), required: false, type: .structure), 
             AWSShapeMember(label: "ACL", location: .header(locationName: "x-amz-acl"), required: false, type: .enum), 
@@ -6017,6 +6004,7 @@ extension S3 {
     public struct PutBucketAnalyticsConfigurationRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "AnalyticsConfiguration"
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "AnalyticsConfiguration", location: .body(locationName: "AnalyticsConfiguration"), required: true, type: .structure), 
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
@@ -6050,6 +6038,7 @@ extension S3 {
     public struct PutBucketCorsRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "CORSConfiguration"
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "ContentMD5", location: .header(locationName: "Content-MD5"), required: false, type: .string), 
@@ -6079,6 +6068,7 @@ extension S3 {
     public struct PutBucketEncryptionRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "ServerSideEncryptionConfiguration"
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "ContentMD5", location: .header(locationName: "Content-MD5"), required: false, type: .string), 
@@ -6107,6 +6097,7 @@ extension S3 {
     public struct PutBucketInventoryConfigurationRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "InventoryConfiguration"
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "Id", location: .querystring(locationName: "id"), required: true, type: .string), 
@@ -6136,6 +6127,7 @@ extension S3 {
     public struct PutBucketLifecycleConfigurationRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "LifecycleConfiguration"
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "LifecycleConfiguration", location: .body(locationName: "LifecycleConfiguration"), required: false, type: .structure)
@@ -6164,6 +6156,7 @@ extension S3 {
     public struct PutBucketLifecycleRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "LifecycleConfiguration"
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "ContentMD5", location: .header(locationName: "Content-MD5"), required: false, type: .string), 
@@ -6190,6 +6183,7 @@ extension S3 {
     public struct PutBucketLoggingRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "BucketLoggingStatus"
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "BucketLoggingStatus", location: .body(locationName: "BucketLoggingStatus"), required: true, type: .structure), 
@@ -6219,6 +6213,7 @@ extension S3 {
     public struct PutBucketMetricsConfigurationRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "MetricsConfiguration"
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "Id", location: .querystring(locationName: "id"), required: true, type: .string), 
@@ -6252,6 +6247,7 @@ extension S3 {
     public struct PutBucketNotificationConfigurationRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "NotificationConfiguration"
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "NotificationConfiguration", location: .body(locationName: "NotificationConfiguration"), required: true, type: .structure)
@@ -6275,6 +6271,7 @@ extension S3 {
     public struct PutBucketNotificationRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "NotificationConfiguration"
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "ContentMD5", location: .header(locationName: "Content-MD5"), required: false, type: .string), 
@@ -6338,6 +6335,7 @@ extension S3 {
     public struct PutBucketReplicationRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "ReplicationConfiguration"
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "ContentMD5", location: .header(locationName: "Content-MD5"), required: false, type: .string), 
@@ -6374,6 +6372,7 @@ extension S3 {
     public struct PutBucketRequestPaymentRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "RequestPaymentConfiguration"
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "ContentMD5", location: .header(locationName: "Content-MD5"), required: false, type: .string), 
@@ -6403,6 +6402,7 @@ extension S3 {
     public struct PutBucketTaggingRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "Tagging"
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "ContentMD5", location: .header(locationName: "Content-MD5"), required: false, type: .string), 
@@ -6436,6 +6436,7 @@ extension S3 {
     public struct PutBucketVersioningRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "VersioningConfiguration"
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "ContentMD5", location: .header(locationName: "Content-MD5"), required: false, type: .string), 
@@ -6470,6 +6471,7 @@ extension S3 {
     public struct PutBucketWebsiteRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "WebsiteConfiguration"
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "ContentMD5", location: .header(locationName: "Content-MD5"), required: false, type: .string), 
@@ -6519,6 +6521,7 @@ extension S3 {
     public struct PutObjectAclRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "AccessControlPolicy"
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "AccessControlPolicy", location: .body(locationName: "AccessControlPolicy"), required: false, type: .structure), 
             AWSShapeMember(label: "ACL", location: .header(locationName: "x-amz-acl"), required: false, type: .enum), 
@@ -6612,6 +6615,7 @@ extension S3 {
     public struct PutObjectLegalHoldRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "LegalHold"
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "ContentMD5", location: .header(locationName: "Content-MD5"), required: false, type: .string), 
@@ -6675,6 +6679,7 @@ extension S3 {
     public struct PutObjectLockConfigurationRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "ObjectLockConfiguration"
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "ContentMD5", location: .header(locationName: "Content-MD5"), required: false, type: .string), 
@@ -6952,6 +6957,7 @@ extension S3 {
     public struct PutObjectRetentionRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "Retention"
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "BypassGovernanceRetention", location: .header(locationName: "x-amz-bypass-governance-retention"), required: false, type: .boolean), 
@@ -7021,6 +7027,7 @@ extension S3 {
     public struct PutObjectTaggingRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "Tagging"
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "ContentMD5", location: .header(locationName: "Content-MD5"), required: false, type: .string), 
@@ -7065,6 +7072,7 @@ extension S3 {
     public struct PutPublicAccessBlockRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "PublicAccessBlockConfiguration"
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "ContentMD5", location: .header(locationName: "Content-MD5"), required: false, type: .string), 
@@ -7207,7 +7215,6 @@ extension S3 {
     }
 
     public struct ReplicationConfiguration: AWSShape {
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Role", required: true, type: .string), 
             AWSShapeMember(label: "Rules", location: .body(locationName: "Rule"), required: true, type: .list, encoding: .flatList)
@@ -7388,7 +7395,6 @@ extension S3 {
     }
 
     public struct RequestPaymentConfiguration: AWSShape {
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Payer", required: true, type: .enum)
         ]
@@ -7446,6 +7452,7 @@ extension S3 {
     public struct RestoreObjectRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "RestoreRequest"
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Bucket", location: .uri(locationName: "Bucket"), required: true, type: .string), 
             AWSShapeMember(label: "Key", location: .uri(locationName: "Key"), required: true, type: .string), 
@@ -7486,7 +7493,6 @@ extension S3 {
     }
 
     public struct RestoreRequest: AWSShape {
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Days", required: false, type: .integer), 
             AWSShapeMember(label: "Description", required: false, type: .string), 
@@ -7853,7 +7859,6 @@ extension S3 {
     }
 
     public struct ServerSideEncryptionConfiguration: AWSShape {
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "Rules", location: .body(locationName: "Rule"), required: true, type: .list, encoding: .flatList)
         ]
@@ -7987,7 +7992,6 @@ extension S3 {
     }
 
     public struct Tagging: AWSShape {
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "TagSet", required: true, type: .list, encoding: .list(member:"Tag"))
         ]
@@ -8378,7 +8382,6 @@ extension S3 {
     }
 
     public struct VersioningConfiguration: AWSShape {
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "MFADelete", location: .body(locationName: "MfaDelete"), required: false, type: .enum), 
             AWSShapeMember(label: "Status", required: false, type: .enum)
@@ -8401,7 +8404,6 @@ extension S3 {
     }
 
     public struct WebsiteConfiguration: AWSShape {
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "ErrorDocument", required: false, type: .structure), 
             AWSShapeMember(label: "IndexDocument", required: false, type: .structure), 

--- a/Sources/AWSSDKSwift/Services/S3Control/S3Control_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/S3Control/S3Control_Shapes.swift
@@ -1156,7 +1156,6 @@ extension S3Control {
     }
 
     public struct PublicAccessBlockConfiguration: AWSShape {
-        public static let _xmlNamespace: String? = "http://awss3control.amazonaws.com/doc/2018-08-20/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "BlockPublicAcls", location: .body(locationName: "BlockPublicAcls"), required: false, type: .boolean), 
             AWSShapeMember(label: "BlockPublicPolicy", location: .body(locationName: "BlockPublicPolicy"), required: false, type: .boolean), 
@@ -1225,6 +1224,7 @@ extension S3Control {
     public struct PutPublicAccessBlockRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "PublicAccessBlockConfiguration"
+        public static let _xmlNamespace: String? = "http://awss3control.amazonaws.com/doc/2018-08-20/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "AccountId", location: .header(locationName: "x-amz-account-id"), required: true, type: .string), 
             AWSShapeMember(label: "PublicAccessBlockConfiguration", location: .body(locationName: "PublicAccessBlockConfiguration"), required: true, type: .structure)

--- a/Sources/AWSSDKSwift/Services/S3Control/S3Control_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/S3Control/S3Control_Shapes.swift
@@ -171,6 +171,7 @@ extension S3Control {
     }
 
     public struct CreateAccessPointRequest: AWSShape {
+        public static let _xmlNamespace: String? = "http://awss3control.amazonaws.com/doc/2018-08-20/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "AccountId", location: .header(locationName: "x-amz-account-id"), required: true, type: .string), 
             AWSShapeMember(label: "Bucket", required: true, type: .string), 
@@ -216,6 +217,7 @@ extension S3Control {
     }
 
     public struct CreateJobRequest: AWSShape {
+        public static let _xmlNamespace: String? = "http://awss3control.amazonaws.com/doc/2018-08-20/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "AccountId", location: .header(locationName: "x-amz-account-id"), required: true, type: .string), 
             AWSShapeMember(label: "ClientRequestToken", required: true, type: .string), 
@@ -1186,6 +1188,7 @@ extension S3Control {
     }
 
     public struct PutAccessPointPolicyRequest: AWSShape {
+        public static let _xmlNamespace: String? = "http://awss3control.amazonaws.com/doc/2018-08-20/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "AccountId", location: .header(locationName: "x-amz-account-id"), required: true, type: .string), 
             AWSShapeMember(label: "Name", location: .uri(locationName: "name"), required: true, type: .string), 

--- a/Sources/AWSSDKSwift/Services/S3Control/S3Control_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/S3Control/S3Control_Shapes.swift
@@ -1156,6 +1156,7 @@ extension S3Control {
     }
 
     public struct PublicAccessBlockConfiguration: AWSShape {
+        public static let _xmlNamespace: String? = "http://awss3control.amazonaws.com/doc/2018-08-20/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "BlockPublicAcls", location: .body(locationName: "BlockPublicAcls"), required: false, type: .boolean), 
             AWSShapeMember(label: "BlockPublicPolicy", location: .body(locationName: "BlockPublicPolicy"), required: false, type: .boolean), 
@@ -1224,7 +1225,6 @@ extension S3Control {
     public struct PutPublicAccessBlockRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "PublicAccessBlockConfiguration"
-        public static let _xmlNamespace: String? = "http://awss3control.amazonaws.com/doc/2018-08-20/"
         public static var _members: [AWSShapeMember] = [
             AWSShapeMember(label: "AccountId", location: .header(locationName: "x-amz-account-id"), required: true, type: .string), 
             AWSShapeMember(label: "PublicAccessBlockConfiguration", location: .body(locationName: "PublicAccessBlockConfiguration"), required: true, type: .structure)

--- a/Tests/AWSSDKSwiftTests/Services/S3/S3Tests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/S3/S3Tests.swift
@@ -12,7 +12,10 @@ import NIO
 @testable import AWSSDKSwiftCore
 @testable import AWSS3
 
-// testing xml service
+// testing S3 service
+enum S3TestErrors: Error {
+    case error(String)
+}
 
 class S3Tests: XCTestCase {
 
@@ -139,7 +142,6 @@ class S3Tests: XCTestCase {
                 ).wait()
                 XCTFail("testMultiPartDownloadFailure: should have failed")
             } catch is AWSError {
-                // expected case
             } catch {
                 XCTFail("testMultiPartDownloadFailure: Unexpected error")
             }
@@ -312,8 +314,8 @@ class S3Tests: XCTestCase {
                     }
                     .flatMapThrowing { response in
                         print("Get \(objectName)")
-                        guard let body = response.body else {throw AWSError(message: "Get \(objectName) failed", rawBody: "") }
-                        guard text == String(data: body, encoding: .utf8) else {throw AWSError(message: "Get \(objectName) contents is incorrect", rawBody: "") }
+                        guard let body = response.body else {throw S3TestErrors.error("Get \(objectName) failed") }
+                        guard text == String(data: body, encoding: .utf8) else {throw S3TestErrors.error("Get \(objectName) contents is incorrect") }
                         return
                 }
                 responses.append(response)


### PR DESCRIPTION
We were missing a case where the XML namespace was not being set for input shapes. 

The xml namespace can be listed in the operations part of the json models. Previously we were ignoring this. Now when parsing the operations we edit the shape structure to include this namespace