### PR TITLE
Move xmlNamespace to Payload object

### DIFF
--- a/CodeGenerator/Sources/CodeGenerator/AWSService.swift
+++ b/CodeGenerator/Sources/CodeGenerator/AWSService.swift
@@ -173,7 +173,6 @@ struct AWSService {
                 structure[_struct["shape"].stringValue] = try shapeType(from: shapeJSON, level: level+1)
             }
 
-            var xmlNamespace: String? = nil
             let members: [Member] = json["members"].dictionaryValue.compactMap { name, memberJSON in
                 if memberJSON["deprecated"].bool == true {
                     return nil
@@ -227,7 +226,7 @@ struct AWSService {
                     options.insert(.idempotencyToken)
                 }
                 if let memberXMLNamespace = memberJSON["xmlNamespace"]["uri"].string {
-                    xmlNamespace = memberXMLNamespace
+                    addShapeOperation(shapeName: shapeName, operation: SetXMLNamespaceOperation(xmlNamespace: memberXMLNamespace))
                 }
 
                 return Member(
@@ -240,7 +239,7 @@ struct AWSService {
                 )
             }.sorted{ $0.name.lowercased() < $1.name.lowercased() }
 
-            let shape = StructureShape(members: members, payload: json["payload"].string, xmlNamespace: xmlNamespace)
+            let shape = StructureShape(members: members, payload: json["payload"].string, xmlNamespace: nil)
             type = .structure(shape)
 
         case "map":
@@ -412,15 +411,6 @@ struct AWSService {
                 if let index = shapes.firstIndex(where: { inputShapeName == $0.name }) {
                     if let xmlNamespace = json["input"]["xmlNamespace"]["uri"].string {
                         addShapeOperation(shapeName: inputShapeName, operation: SetXMLNamespaceOperation(xmlNamespace: xmlNamespace))
-/*                        if case .structure(let shapeStructure) = shapes[index].type {
-                            shapes[index].type = .structure(
-                                StructureShape(
-                                    members: shapeStructure.members,
-                                    payload: shapeStructure.payload,
-                                    xmlNamespace: xmlNamespace
-                                )
-                            )
-                        }*/
                     }
                     setShapeUsed(shape: shapes[index], inInput: true)
                     inputShape = shapes[index]

--- a/CodeGenerator/Sources/CodeGenerator/CodeGenerator.swift
+++ b/CodeGenerator/Sources/CodeGenerator/CodeGenerator.swift
@@ -389,9 +389,6 @@ extension AWSService {
         let encoding = member.shapeEncoding?.enumStyleDescription()
         var location = member.location
         
-        if shape.name == "CreateAppResponse" {
-            print(shape)
-        }
         // if member has collection encoding ie the codingkey will be needed, or name has been force to output then add a Location.body
         if (encoding != nil || forceOutput) && location == nil {
             location = .body(locationName: member.name)
@@ -481,7 +478,7 @@ extension AWSService {
 
             memberContexts.append(memberContext)
 
-            if let awsShapeMemberContext = generateAWSShapeMemberContext(member, shape: shape, forceOutput: type.payload == member.name && shape.response) {
+            if let awsShapeMemberContext = generateAWSShapeMemberContext(member, shape: shape, forceOutput: type.payload == member.name) {
                 awsShapeMemberContexts.append(awsShapeMemberContext)
             }
 

--- a/CodeGenerator/Sources/CodeGenerator/CodeGenerator.swift
+++ b/CodeGenerator/Sources/CodeGenerator/CodeGenerator.swift
@@ -388,16 +388,17 @@ extension AWSService {
     func generateAWSShapeMemberContext(_ member: Member, shape: Shape, forceOutput: Bool) -> AWSShapeMemberContext? {
         let encoding = member.shapeEncoding?.enumStyleDescription()
         var location = member.location
-        // if member has collection encoding ie the codingkey will be needed, then add a Location.body
-        if encoding != nil && location == nil {
+        
+        if shape.name == "CreateAppResponse" {
+            print(shape)
+        }
+        // if member has collection encoding ie the codingkey will be needed, or name has been force to output then add a Location.body
+        if (encoding != nil || forceOutput) && location == nil {
             location = .body(locationName: member.name)
         }
         // remove location if equal to body and name is same as variable name
         if case .body(let name) = location, name == member.name.toSwiftLabelCase() {
-            // if not forcing output or encoding isn't set clear the location
-            if forceOutput == false || encoding != nil {
-                location = nil
-            }
+            location = nil
         }
         guard location != nil || encoding != nil else { return nil }
         return AWSShapeMemberContext(
@@ -480,7 +481,7 @@ extension AWSService {
 
             memberContexts.append(memberContext)
 
-            if let awsShapeMemberContext = generateAWSShapeMemberContext(member, shape: shape, forceOutput: type.payload == member.name) {
+            if let awsShapeMemberContext = generateAWSShapeMemberContext(member, shape: shape, forceOutput: type.payload == member.name && shape.response) {
                 awsShapeMemberContexts.append(awsShapeMemberContext)
             }
 

--- a/Package.swift
+++ b/Package.swift
@@ -228,7 +228,7 @@ let package = Package(
         .library(name: "AWSXRay", targets: ["AWSXRay"])
     ],
     dependencies: [
-        .package(url: "https://github.com/swift-aws/aws-sdk-swift-core.git", .branch("master"))
+        .package(url: "https://github.com/swift-aws/aws-sdk-swift-core.git", .branch("awsshape-encoder-ext"))
     ],
     targets: [
         .target(name: "AWSACM", dependencies: ["AWSSDKSwiftCore"], path: "./Sources/AWSSDKSwift/Services/ACM"),

--- a/Package.swift
+++ b/Package.swift
@@ -228,7 +228,7 @@ let package = Package(
         .library(name: "AWSXRay", targets: ["AWSXRay"])
     ],
     dependencies: [
-        .package(url: "https://github.com/swift-aws/aws-sdk-swift-core.git", .branch("awsshape-encoder-ext"))
+        .package(url: "https://github.com/swift-aws/aws-sdk-swift-core.git", .branch("master"))
     ],
     targets: [
         .target(name: "AWSACM", dependencies: ["AWSSDKSwiftCore"], path: "./Sources/AWSSDKSwift/Services/ACM"),

--- a/Sources/AWSSDKSwift/Services/CloudFront/CloudFront_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/CloudFront/CloudFront_Shapes.swift
@@ -517,6 +517,7 @@ extension CloudFront {
         /// The key for the payload
         public static let payloadPath: String? = "cloudFrontOriginAccessIdentity"
         public static var _encoding = [
+            AWSMemberEncoding(label: "cloudFrontOriginAccessIdentity", location: .body(locationName: "CloudFrontOriginAccessIdentity")), 
             AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag")), 
             AWSMemberEncoding(label: "location", location: .header(locationName: "Location"))
         ]
@@ -568,6 +569,7 @@ extension CloudFront {
         /// The key for the payload
         public static let payloadPath: String? = "distribution"
         public static var _encoding = [
+            AWSMemberEncoding(label: "distribution", location: .body(locationName: "Distribution")), 
             AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag")), 
             AWSMemberEncoding(label: "location", location: .header(locationName: "Location"))
         ]
@@ -619,6 +621,7 @@ extension CloudFront {
         /// The key for the payload
         public static let payloadPath: String? = "distribution"
         public static var _encoding = [
+            AWSMemberEncoding(label: "distribution", location: .body(locationName: "Distribution")), 
             AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag")), 
             AWSMemberEncoding(label: "location", location: .header(locationName: "Location"))
         ]
@@ -667,6 +670,7 @@ extension CloudFront {
         public static let payloadPath: String? = "fieldLevelEncryption"
         public static var _encoding = [
             AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag")), 
+            AWSMemberEncoding(label: "fieldLevelEncryption", location: .body(locationName: "FieldLevelEncryption")), 
             AWSMemberEncoding(label: "location", location: .header(locationName: "Location"))
         ]
 
@@ -714,6 +718,7 @@ extension CloudFront {
         public static let payloadPath: String? = "fieldLevelEncryptionProfile"
         public static var _encoding = [
             AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag")), 
+            AWSMemberEncoding(label: "fieldLevelEncryptionProfile", location: .body(locationName: "FieldLevelEncryptionProfile")), 
             AWSMemberEncoding(label: "location", location: .header(locationName: "Location"))
         ]
 
@@ -765,6 +770,7 @@ extension CloudFront {
         /// The key for the payload
         public static let payloadPath: String? = "invalidation"
         public static var _encoding = [
+            AWSMemberEncoding(label: "invalidation", location: .body(locationName: "Invalidation")), 
             AWSMemberEncoding(label: "location", location: .header(locationName: "Location"))
         ]
 
@@ -808,7 +814,8 @@ extension CloudFront {
         public static let payloadPath: String? = "publicKey"
         public static var _encoding = [
             AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag")), 
-            AWSMemberEncoding(label: "location", location: .header(locationName: "Location"))
+            AWSMemberEncoding(label: "location", location: .header(locationName: "Location")), 
+            AWSMemberEncoding(label: "publicKey", location: .body(locationName: "PublicKey"))
         ]
 
         /// The current version of the public key. For example: E2QWRUHAPOMQZL.
@@ -855,7 +862,8 @@ extension CloudFront {
         public static let payloadPath: String? = "streamingDistribution"
         public static var _encoding = [
             AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag")), 
-            AWSMemberEncoding(label: "location", location: .header(locationName: "Location"))
+            AWSMemberEncoding(label: "location", location: .header(locationName: "Location")), 
+            AWSMemberEncoding(label: "streamingDistribution", location: .body(locationName: "StreamingDistribution"))
         ]
 
         /// The current version of the streaming distribution created.
@@ -906,7 +914,8 @@ extension CloudFront {
         public static let payloadPath: String? = "streamingDistribution"
         public static var _encoding = [
             AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag")), 
-            AWSMemberEncoding(label: "location", location: .header(locationName: "Location"))
+            AWSMemberEncoding(label: "location", location: .header(locationName: "Location")), 
+            AWSMemberEncoding(label: "streamingDistribution", location: .body(locationName: "StreamingDistribution"))
         ]
 
         /// The current version of the distribution created.
@@ -1859,6 +1868,7 @@ extension CloudFront {
         /// The key for the payload
         public static let payloadPath: String? = "cloudFrontOriginAccessIdentityConfig"
         public static var _encoding = [
+            AWSMemberEncoding(label: "cloudFrontOriginAccessIdentityConfig", location: .body(locationName: "CloudFrontOriginAccessIdentityConfig")), 
             AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag"))
         ]
 
@@ -1899,6 +1909,7 @@ extension CloudFront {
         /// The key for the payload
         public static let payloadPath: String? = "cloudFrontOriginAccessIdentity"
         public static var _encoding = [
+            AWSMemberEncoding(label: "cloudFrontOriginAccessIdentity", location: .body(locationName: "CloudFrontOriginAccessIdentity")), 
             AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag"))
         ]
 
@@ -1939,6 +1950,7 @@ extension CloudFront {
         /// The key for the payload
         public static let payloadPath: String? = "distributionConfig"
         public static var _encoding = [
+            AWSMemberEncoding(label: "distributionConfig", location: .body(locationName: "DistributionConfig")), 
             AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag"))
         ]
 
@@ -1979,6 +1991,7 @@ extension CloudFront {
         /// The key for the payload
         public static let payloadPath: String? = "distribution"
         public static var _encoding = [
+            AWSMemberEncoding(label: "distribution", location: .body(locationName: "Distribution")), 
             AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag"))
         ]
 
@@ -2019,7 +2032,8 @@ extension CloudFront {
         /// The key for the payload
         public static let payloadPath: String? = "fieldLevelEncryptionConfig"
         public static var _encoding = [
-            AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag"))
+            AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag")), 
+            AWSMemberEncoding(label: "fieldLevelEncryptionConfig", location: .body(locationName: "FieldLevelEncryptionConfig"))
         ]
 
         /// The current version of the field level encryption configuration. For example: E2QWRUHAPOMQZL.
@@ -2059,7 +2073,8 @@ extension CloudFront {
         /// The key for the payload
         public static let payloadPath: String? = "fieldLevelEncryptionProfileConfig"
         public static var _encoding = [
-            AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag"))
+            AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag")), 
+            AWSMemberEncoding(label: "fieldLevelEncryptionProfileConfig", location: .body(locationName: "FieldLevelEncryptionProfileConfig"))
         ]
 
         /// The current version of the field-level encryption profile configuration result. For example: E2QWRUHAPOMQZL.
@@ -2099,7 +2114,8 @@ extension CloudFront {
         /// The key for the payload
         public static let payloadPath: String? = "fieldLevelEncryptionProfile"
         public static var _encoding = [
-            AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag"))
+            AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag")), 
+            AWSMemberEncoding(label: "fieldLevelEncryptionProfile", location: .body(locationName: "FieldLevelEncryptionProfile"))
         ]
 
         /// The current version of the field level encryption profile. For example: E2QWRUHAPOMQZL.
@@ -2139,7 +2155,8 @@ extension CloudFront {
         /// The key for the payload
         public static let payloadPath: String? = "fieldLevelEncryption"
         public static var _encoding = [
-            AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag"))
+            AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag")), 
+            AWSMemberEncoding(label: "fieldLevelEncryption", location: .body(locationName: "FieldLevelEncryption"))
         ]
 
         /// The current version of the field level encryption configuration. For example: E2QWRUHAPOMQZL.
@@ -2183,6 +2200,9 @@ extension CloudFront {
     public struct GetInvalidationResult: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "invalidation"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "invalidation", location: .body(locationName: "Invalidation"))
+        ]
 
         /// The invalidation's information. For more information, see Invalidation Complex Type. 
         public let invalidation: Invalidation?
@@ -2217,7 +2237,8 @@ extension CloudFront {
         /// The key for the payload
         public static let payloadPath: String? = "publicKeyConfig"
         public static var _encoding = [
-            AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag"))
+            AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag")), 
+            AWSMemberEncoding(label: "publicKeyConfig", location: .body(locationName: "PublicKeyConfig"))
         ]
 
         /// The current version of the public key configuration. For example: E2QWRUHAPOMQZL.
@@ -2257,7 +2278,8 @@ extension CloudFront {
         /// The key for the payload
         public static let payloadPath: String? = "publicKey"
         public static var _encoding = [
-            AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag"))
+            AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag")), 
+            AWSMemberEncoding(label: "publicKey", location: .body(locationName: "PublicKey"))
         ]
 
         /// The current version of the public key. For example: E2QWRUHAPOMQZL.
@@ -2297,7 +2319,8 @@ extension CloudFront {
         /// The key for the payload
         public static let payloadPath: String? = "streamingDistributionConfig"
         public static var _encoding = [
-            AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag"))
+            AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag")), 
+            AWSMemberEncoding(label: "streamingDistributionConfig", location: .body(locationName: "StreamingDistributionConfig"))
         ]
 
         /// The current version of the configuration. For example: E2QWRUHAPOMQZL. 
@@ -2337,7 +2360,8 @@ extension CloudFront {
         /// The key for the payload
         public static let payloadPath: String? = "streamingDistribution"
         public static var _encoding = [
-            AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag"))
+            AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag")), 
+            AWSMemberEncoding(label: "streamingDistribution", location: .body(locationName: "StreamingDistribution"))
         ]
 
         /// The current version of the streaming distribution's information. For example: E2QWRUHAPOMQZL.
@@ -2570,6 +2594,9 @@ extension CloudFront {
     public struct ListCloudFrontOriginAccessIdentitiesResult: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "cloudFrontOriginAccessIdentityList"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "cloudFrontOriginAccessIdentityList", location: .body(locationName: "CloudFrontOriginAccessIdentityList"))
+        ]
 
         /// The CloudFrontOriginAccessIdentityList type. 
         public let cloudFrontOriginAccessIdentityList: CloudFrontOriginAccessIdentityList?
@@ -2613,6 +2640,9 @@ extension CloudFront {
     public struct ListDistributionsByWebACLIdResult: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "distributionList"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "distributionList", location: .body(locationName: "DistributionList"))
+        ]
 
         /// The DistributionList type. 
         public let distributionList: DistributionList?
@@ -2651,6 +2681,9 @@ extension CloudFront {
     public struct ListDistributionsResult: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "distributionList"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "distributionList", location: .body(locationName: "DistributionList"))
+        ]
 
         /// The DistributionList type. 
         public let distributionList: DistributionList?
@@ -2689,6 +2722,9 @@ extension CloudFront {
     public struct ListFieldLevelEncryptionConfigsResult: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "fieldLevelEncryptionList"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "fieldLevelEncryptionList", location: .body(locationName: "FieldLevelEncryptionList"))
+        ]
 
         /// Returns a list of all field-level encryption configurations that have been created in CloudFront for this account.
         public let fieldLevelEncryptionList: FieldLevelEncryptionList?
@@ -2727,6 +2763,9 @@ extension CloudFront {
     public struct ListFieldLevelEncryptionProfilesResult: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "fieldLevelEncryptionProfileList"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "fieldLevelEncryptionProfileList", location: .body(locationName: "FieldLevelEncryptionProfileList"))
+        ]
 
         /// Returns a list of the field-level encryption profiles that have been created in CloudFront for this account.
         public let fieldLevelEncryptionProfileList: FieldLevelEncryptionProfileList?
@@ -2770,6 +2809,9 @@ extension CloudFront {
     public struct ListInvalidationsResult: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "invalidationList"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "invalidationList", location: .body(locationName: "InvalidationList"))
+        ]
 
         /// Information about invalidation batches. 
         public let invalidationList: InvalidationList?
@@ -2808,6 +2850,9 @@ extension CloudFront {
     public struct ListPublicKeysResult: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "publicKeyList"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "publicKeyList", location: .body(locationName: "PublicKeyList"))
+        ]
 
         /// Returns a list of all public keys that have been added to CloudFront for this account.
         public let publicKeyList: PublicKeyList?
@@ -2846,6 +2891,9 @@ extension CloudFront {
     public struct ListStreamingDistributionsResult: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "streamingDistributionList"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "streamingDistributionList", location: .body(locationName: "StreamingDistributionList"))
+        ]
 
         /// The StreamingDistributionList type. 
         public let streamingDistributionList: StreamingDistributionList?
@@ -2883,6 +2931,9 @@ extension CloudFront {
     public struct ListTagsForResourceResult: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "tags"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "tags", location: .body(locationName: "Tags"))
+        ]
 
         ///  A complex type that contains zero or more Tag elements.
         public let tags: Tags
@@ -3838,6 +3889,7 @@ extension CloudFront {
         /// The key for the payload
         public static let payloadPath: String? = "cloudFrontOriginAccessIdentity"
         public static var _encoding = [
+            AWSMemberEncoding(label: "cloudFrontOriginAccessIdentity", location: .body(locationName: "CloudFrontOriginAccessIdentity")), 
             AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag"))
         ]
 
@@ -3894,6 +3946,7 @@ extension CloudFront {
         /// The key for the payload
         public static let payloadPath: String? = "distribution"
         public static var _encoding = [
+            AWSMemberEncoding(label: "distribution", location: .body(locationName: "Distribution")), 
             AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag"))
         ]
 
@@ -3946,7 +3999,8 @@ extension CloudFront {
         /// The key for the payload
         public static let payloadPath: String? = "fieldLevelEncryption"
         public static var _encoding = [
-            AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag"))
+            AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag")), 
+            AWSMemberEncoding(label: "fieldLevelEncryption", location: .body(locationName: "FieldLevelEncryption"))
         ]
 
         /// The value of the ETag header that you received when updating the configuration. For example: E2QWRUHAPOMQZL.
@@ -3998,7 +4052,8 @@ extension CloudFront {
         /// The key for the payload
         public static let payloadPath: String? = "fieldLevelEncryptionProfile"
         public static var _encoding = [
-            AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag"))
+            AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag")), 
+            AWSMemberEncoding(label: "fieldLevelEncryptionProfile", location: .body(locationName: "FieldLevelEncryptionProfile"))
         ]
 
         /// The result of the field-level encryption profile request. 
@@ -4050,7 +4105,8 @@ extension CloudFront {
         /// The key for the payload
         public static let payloadPath: String? = "publicKey"
         public static var _encoding = [
-            AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag"))
+            AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag")), 
+            AWSMemberEncoding(label: "publicKey", location: .body(locationName: "PublicKey"))
         ]
 
         /// The current version of the update public key result. For example: E2QWRUHAPOMQZL.
@@ -4102,7 +4158,8 @@ extension CloudFront {
         /// The key for the payload
         public static let payloadPath: String? = "streamingDistribution"
         public static var _encoding = [
-            AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag"))
+            AWSMemberEncoding(label: "eTag", location: .header(locationName: "ETag")), 
+            AWSMemberEncoding(label: "streamingDistribution", location: .body(locationName: "StreamingDistribution"))
         ]
 
         /// The current version of the configuration. For example: E2QWRUHAPOMQZL.

--- a/Sources/AWSSDKSwift/Services/CloudFront/CloudFront_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/CloudFront/CloudFront_Shapes.swift
@@ -317,6 +317,7 @@ extension CloudFront {
     }
 
     public struct CloudFrontOriginAccessIdentityConfig: AWSShape {
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
 
         /// A unique value (for example, a date-time stamp) that ensures that the request can't be replayed. If the value of CallerReference is new (regardless of the content of the CloudFrontOriginAccessIdentityConfig object), a new origin access identity is created. If the CallerReference is a value already sent in a previous identity request, and the content of the CloudFrontOriginAccessIdentityConfig is identical to the original request (ignoring white space), the response includes the same information returned to the original request.  If the CallerReference is a value you already sent in a previous request to create an identity, but the content of the CloudFrontOriginAccessIdentityConfig is different from the original request, CloudFront returns a CloudFrontOriginAccessIdentityAlreadyExists error. 
         public let callerReference: String
@@ -496,7 +497,6 @@ extension CloudFront {
     public struct CreateCloudFrontOriginAccessIdentityRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "cloudFrontOriginAccessIdentityConfig"
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _encoding = [
             AWSMemberEncoding(label: "cloudFrontOriginAccessIdentityConfig", location: .body(locationName: "CloudFrontOriginAccessIdentityConfig"))
         ]
@@ -544,7 +544,6 @@ extension CloudFront {
     public struct CreateDistributionRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "distributionConfig"
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _encoding = [
             AWSMemberEncoding(label: "distributionConfig", location: .body(locationName: "DistributionConfig"))
         ]
@@ -596,7 +595,6 @@ extension CloudFront {
     public struct CreateDistributionWithTagsRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "distributionConfigWithTags"
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _encoding = [
             AWSMemberEncoding(label: "distributionConfigWithTags", location: .body(locationName: "DistributionConfigWithTags"))
         ]
@@ -648,7 +646,6 @@ extension CloudFront {
     public struct CreateFieldLevelEncryptionConfigRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "fieldLevelEncryptionConfig"
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _encoding = [
             AWSMemberEncoding(label: "fieldLevelEncryptionConfig", location: .body(locationName: "FieldLevelEncryptionConfig"))
         ]
@@ -696,7 +693,6 @@ extension CloudFront {
     public struct CreateFieldLevelEncryptionProfileRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "fieldLevelEncryptionProfileConfig"
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _encoding = [
             AWSMemberEncoding(label: "fieldLevelEncryptionProfileConfig", location: .body(locationName: "FieldLevelEncryptionProfileConfig"))
         ]
@@ -744,7 +740,6 @@ extension CloudFront {
     public struct CreateInvalidationRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "invalidationBatch"
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _encoding = [
             AWSMemberEncoding(label: "distributionId", location: .uri(locationName: "DistributionId")), 
             AWSMemberEncoding(label: "invalidationBatch", location: .body(locationName: "InvalidationBatch"))
@@ -792,7 +787,6 @@ extension CloudFront {
     public struct CreatePublicKeyRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "publicKeyConfig"
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _encoding = [
             AWSMemberEncoding(label: "publicKeyConfig", location: .body(locationName: "PublicKeyConfig"))
         ]
@@ -840,7 +834,6 @@ extension CloudFront {
     public struct CreateStreamingDistributionRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "streamingDistributionConfig"
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _encoding = [
             AWSMemberEncoding(label: "streamingDistributionConfig", location: .body(locationName: "StreamingDistributionConfig"))
         ]
@@ -888,7 +881,6 @@ extension CloudFront {
     public struct CreateStreamingDistributionWithTagsRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "streamingDistributionConfigWithTags"
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _encoding = [
             AWSMemberEncoding(label: "streamingDistributionConfigWithTags", location: .body(locationName: "StreamingDistributionConfigWithTags"))
         ]
@@ -1278,6 +1270,7 @@ extension CloudFront {
     }
 
     public struct DistributionConfig: AWSShape {
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
 
         /// A complex type that contains information about CNAMEs (alternate domain names), if any, for this distribution.
         public let aliases: Aliases?
@@ -1361,6 +1354,7 @@ extension CloudFront {
     }
 
     public struct DistributionConfigWithTags: AWSShape {
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
 
         /// A distribution configuration.
         public let distributionConfig: DistributionConfig
@@ -1579,6 +1573,7 @@ extension CloudFront {
     }
 
     public struct FieldLevelEncryptionConfig: AWSShape {
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
 
         /// A unique number that ensures the request can't be replayed.
         public let callerReference: String
@@ -1656,6 +1651,7 @@ extension CloudFront {
     }
 
     public struct FieldLevelEncryptionProfileConfig: AWSShape {
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
 
         /// A unique number that ensures that the request can't be replayed.
         public let callerReference: String
@@ -2408,6 +2404,7 @@ extension CloudFront {
     }
 
     public struct InvalidationBatch: AWSShape {
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
 
         /// A value that you specify to uniquely identify an invalidation request. CloudFront uses the value to prevent you from accidentally resubmitting an identical request. Whenever you create a new invalidation request, you must specify a new value for CallerReference and change other values in the request as applicable. One way to ensure that the value of CallerReference is unique is to use a timestamp, for example, 20120301090000. If you make a second invalidation request with the same value for CallerReference, and if the rest of the request is the same, CloudFront doesn't create a new invalidation request. Instead, CloudFront returns information about the invalidation request that you previously created with the same CallerReference. If CallerReference is a value you already sent in a previous invalidation batch request but the content of any Path is different from the original request, CloudFront returns an InvalidationBatchAlreadyExists error.
         public let callerReference: String
@@ -3179,6 +3176,7 @@ extension CloudFront {
     }
 
     public struct PublicKeyConfig: AWSShape {
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
 
         /// A unique number that ensures that the request can't be replayed.
         public let callerReference: String
@@ -3469,6 +3467,7 @@ extension CloudFront {
     }
 
     public struct StreamingDistributionConfig: AWSShape {
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
 
         /// A complex type that contains information about CNAMEs (alternate domain names), if any, for this streaming distribution. 
         public let aliases: Aliases?
@@ -3511,6 +3510,7 @@ extension CloudFront {
     }
 
     public struct StreamingDistributionConfigWithTags: AWSShape {
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
 
         /// A streaming distribution Configuration.
         public let streamingDistributionConfig: StreamingDistributionConfig
@@ -3673,6 +3673,7 @@ extension CloudFront {
     }
 
     public struct TagKeys: AWSShape {
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _encoding = [
             AWSMemberEncoding(label: "items", location: .body(locationName: "Items"), encoding: .list(member:"Key"))
         ]
@@ -3700,7 +3701,6 @@ extension CloudFront {
     public struct TagResourceRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "tags"
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _encoding = [
             AWSMemberEncoding(label: "resource", location: .querystring(locationName: "Resource")), 
             AWSMemberEncoding(label: "tags", location: .body(locationName: "Tags"))
@@ -3728,6 +3728,7 @@ extension CloudFront {
     }
 
     public struct Tags: AWSShape {
+        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _encoding = [
             AWSMemberEncoding(label: "items", location: .body(locationName: "Items"), encoding: .list(member:"Tag"))
         ]
@@ -3778,7 +3779,6 @@ extension CloudFront {
     public struct UntagResourceRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "tagKeys"
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _encoding = [
             AWSMemberEncoding(label: "resource", location: .querystring(locationName: "Resource")), 
             AWSMemberEncoding(label: "tagKeys", location: .body(locationName: "TagKeys"))
@@ -3808,7 +3808,6 @@ extension CloudFront {
     public struct UpdateCloudFrontOriginAccessIdentityRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "cloudFrontOriginAccessIdentityConfig"
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _encoding = [
             AWSMemberEncoding(label: "cloudFrontOriginAccessIdentityConfig", location: .body(locationName: "CloudFrontOriginAccessIdentityConfig")), 
             AWSMemberEncoding(label: "id", location: .uri(locationName: "Id")), 
@@ -3861,7 +3860,6 @@ extension CloudFront {
     public struct UpdateDistributionRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "distributionConfig"
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _encoding = [
             AWSMemberEncoding(label: "distributionConfig", location: .body(locationName: "DistributionConfig")), 
             AWSMemberEncoding(label: "id", location: .uri(locationName: "Id")), 
@@ -3918,7 +3916,6 @@ extension CloudFront {
     public struct UpdateFieldLevelEncryptionConfigRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "fieldLevelEncryptionConfig"
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _encoding = [
             AWSMemberEncoding(label: "fieldLevelEncryptionConfig", location: .body(locationName: "FieldLevelEncryptionConfig")), 
             AWSMemberEncoding(label: "id", location: .uri(locationName: "Id")), 
@@ -3971,7 +3968,6 @@ extension CloudFront {
     public struct UpdateFieldLevelEncryptionProfileRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "fieldLevelEncryptionProfileConfig"
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _encoding = [
             AWSMemberEncoding(label: "fieldLevelEncryptionProfileConfig", location: .body(locationName: "FieldLevelEncryptionProfileConfig")), 
             AWSMemberEncoding(label: "id", location: .uri(locationName: "Id")), 
@@ -4024,7 +4020,6 @@ extension CloudFront {
     public struct UpdatePublicKeyRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "publicKeyConfig"
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _encoding = [
             AWSMemberEncoding(label: "id", location: .uri(locationName: "Id")), 
             AWSMemberEncoding(label: "ifMatch", location: .header(locationName: "If-Match")), 
@@ -4077,7 +4072,6 @@ extension CloudFront {
     public struct UpdateStreamingDistributionRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "streamingDistributionConfig"
-        public static let _xmlNamespace: String? = "http://cloudfront.amazonaws.com/doc/2019-03-26/"
         public static var _encoding = [
             AWSMemberEncoding(label: "id", location: .uri(locationName: "Id")), 
             AWSMemberEncoding(label: "ifMatch", location: .header(locationName: "If-Match")), 

--- a/Sources/AWSSDKSwift/Services/Pinpoint/Pinpoint_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/Pinpoint/Pinpoint_Shapes.swift
@@ -1750,6 +1750,9 @@ extension Pinpoint {
     public struct CreateAppResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "applicationResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "applicationResponse", location: .body(locationName: "ApplicationResponse"))
+        ]
 
         public let applicationResponse: ApplicationResponse
 
@@ -1804,6 +1807,9 @@ extension Pinpoint {
     public struct CreateCampaignResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "campaignResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "campaignResponse", location: .body(locationName: "CampaignResponse"))
+        ]
 
         public let campaignResponse: CampaignResponse
 
@@ -1840,6 +1846,9 @@ extension Pinpoint {
     public struct CreateEmailTemplateResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "createTemplateMessageBody"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "createTemplateMessageBody", location: .body(locationName: "CreateTemplateMessageBody"))
+        ]
 
         public let createTemplateMessageBody: CreateTemplateMessageBody
 
@@ -1876,6 +1885,9 @@ extension Pinpoint {
     public struct CreateExportJobResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "exportJobResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "exportJobResponse", location: .body(locationName: "ExportJobResponse"))
+        ]
 
         public let exportJobResponse: ExportJobResponse
 
@@ -1912,6 +1924,9 @@ extension Pinpoint {
     public struct CreateImportJobResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "importJobResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "importJobResponse", location: .body(locationName: "ImportJobResponse"))
+        ]
 
         public let importJobResponse: ImportJobResponse
 
@@ -1948,6 +1963,9 @@ extension Pinpoint {
     public struct CreateJourneyResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "journeyResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "journeyResponse", location: .body(locationName: "JourneyResponse"))
+        ]
 
         public let journeyResponse: JourneyResponse
 
@@ -1984,6 +2002,9 @@ extension Pinpoint {
     public struct CreatePushTemplateResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "createTemplateMessageBody"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "createTemplateMessageBody", location: .body(locationName: "CreateTemplateMessageBody"))
+        ]
 
         public let createTemplateMessageBody: CreateTemplateMessageBody
 
@@ -2020,6 +2041,9 @@ extension Pinpoint {
     public struct CreateSegmentResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "segmentResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "segmentResponse", location: .body(locationName: "SegmentResponse"))
+        ]
 
         public let segmentResponse: SegmentResponse
 
@@ -2056,6 +2080,9 @@ extension Pinpoint {
     public struct CreateSmsTemplateResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "createTemplateMessageBody"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "createTemplateMessageBody", location: .body(locationName: "CreateTemplateMessageBody"))
+        ]
 
         public let createTemplateMessageBody: CreateTemplateMessageBody
 
@@ -2114,6 +2141,9 @@ extension Pinpoint {
     public struct CreateVoiceTemplateResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "createTemplateMessageBody"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "createTemplateMessageBody", location: .body(locationName: "CreateTemplateMessageBody"))
+        ]
 
         public let createTemplateMessageBody: CreateTemplateMessageBody
 
@@ -2231,6 +2261,9 @@ extension Pinpoint {
     public struct DeleteAdmChannelResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "aDMChannelResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "aDMChannelResponse", location: .body(locationName: "ADMChannelResponse"))
+        ]
 
         public let aDMChannelResponse: ADMChannelResponse
 
@@ -2262,6 +2295,9 @@ extension Pinpoint {
     public struct DeleteApnsChannelResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "aPNSChannelResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "aPNSChannelResponse", location: .body(locationName: "APNSChannelResponse"))
+        ]
 
         public let aPNSChannelResponse: APNSChannelResponse
 
@@ -2293,6 +2329,9 @@ extension Pinpoint {
     public struct DeleteApnsSandboxChannelResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "aPNSSandboxChannelResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "aPNSSandboxChannelResponse", location: .body(locationName: "APNSSandboxChannelResponse"))
+        ]
 
         public let aPNSSandboxChannelResponse: APNSSandboxChannelResponse
 
@@ -2324,6 +2363,9 @@ extension Pinpoint {
     public struct DeleteApnsVoipChannelResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "aPNSVoipChannelResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "aPNSVoipChannelResponse", location: .body(locationName: "APNSVoipChannelResponse"))
+        ]
 
         public let aPNSVoipChannelResponse: APNSVoipChannelResponse
 
@@ -2355,6 +2397,9 @@ extension Pinpoint {
     public struct DeleteApnsVoipSandboxChannelResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "aPNSVoipSandboxChannelResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "aPNSVoipSandboxChannelResponse", location: .body(locationName: "APNSVoipSandboxChannelResponse"))
+        ]
 
         public let aPNSVoipSandboxChannelResponse: APNSVoipSandboxChannelResponse
 
@@ -2386,6 +2431,9 @@ extension Pinpoint {
     public struct DeleteAppResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "applicationResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "applicationResponse", location: .body(locationName: "ApplicationResponse"))
+        ]
 
         public let applicationResponse: ApplicationResponse
 
@@ -2417,6 +2465,9 @@ extension Pinpoint {
     public struct DeleteBaiduChannelResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "baiduChannelResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "baiduChannelResponse", location: .body(locationName: "BaiduChannelResponse"))
+        ]
 
         public let baiduChannelResponse: BaiduChannelResponse
 
@@ -2452,6 +2503,9 @@ extension Pinpoint {
     public struct DeleteCampaignResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "campaignResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "campaignResponse", location: .body(locationName: "CampaignResponse"))
+        ]
 
         public let campaignResponse: CampaignResponse
 
@@ -2483,6 +2537,9 @@ extension Pinpoint {
     public struct DeleteEmailChannelResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "emailChannelResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "emailChannelResponse", location: .body(locationName: "EmailChannelResponse"))
+        ]
 
         public let emailChannelResponse: EmailChannelResponse
 
@@ -2518,6 +2575,9 @@ extension Pinpoint {
     public struct DeleteEmailTemplateResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "messageBody"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "messageBody", location: .body(locationName: "MessageBody"))
+        ]
 
         public let messageBody: MessageBody
 
@@ -2553,6 +2613,9 @@ extension Pinpoint {
     public struct DeleteEndpointResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "endpointResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "endpointResponse", location: .body(locationName: "EndpointResponse"))
+        ]
 
         public let endpointResponse: EndpointResponse
 
@@ -2584,6 +2647,9 @@ extension Pinpoint {
     public struct DeleteEventStreamResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "eventStream"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "eventStream", location: .body(locationName: "EventStream"))
+        ]
 
         public let eventStream: EventStream
 
@@ -2615,6 +2681,9 @@ extension Pinpoint {
     public struct DeleteGcmChannelResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "gCMChannelResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "gCMChannelResponse", location: .body(locationName: "GCMChannelResponse"))
+        ]
 
         public let gCMChannelResponse: GCMChannelResponse
 
@@ -2650,6 +2719,9 @@ extension Pinpoint {
     public struct DeleteJourneyResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "journeyResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "journeyResponse", location: .body(locationName: "JourneyResponse"))
+        ]
 
         public let journeyResponse: JourneyResponse
 
@@ -2685,6 +2757,9 @@ extension Pinpoint {
     public struct DeletePushTemplateResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "messageBody"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "messageBody", location: .body(locationName: "MessageBody"))
+        ]
 
         public let messageBody: MessageBody
 
@@ -2720,6 +2795,9 @@ extension Pinpoint {
     public struct DeleteSegmentResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "segmentResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "segmentResponse", location: .body(locationName: "SegmentResponse"))
+        ]
 
         public let segmentResponse: SegmentResponse
 
@@ -2751,6 +2829,9 @@ extension Pinpoint {
     public struct DeleteSmsChannelResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "sMSChannelResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "sMSChannelResponse", location: .body(locationName: "SMSChannelResponse"))
+        ]
 
         public let sMSChannelResponse: SMSChannelResponse
 
@@ -2786,6 +2867,9 @@ extension Pinpoint {
     public struct DeleteSmsTemplateResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "messageBody"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "messageBody", location: .body(locationName: "MessageBody"))
+        ]
 
         public let messageBody: MessageBody
 
@@ -2821,6 +2905,9 @@ extension Pinpoint {
     public struct DeleteUserEndpointsResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "endpointsResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "endpointsResponse", location: .body(locationName: "EndpointsResponse"))
+        ]
 
         public let endpointsResponse: EndpointsResponse
 
@@ -2852,6 +2939,9 @@ extension Pinpoint {
     public struct DeleteVoiceChannelResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "voiceChannelResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "voiceChannelResponse", location: .body(locationName: "VoiceChannelResponse"))
+        ]
 
         public let voiceChannelResponse: VoiceChannelResponse
 
@@ -2887,6 +2977,9 @@ extension Pinpoint {
     public struct DeleteVoiceTemplateResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "messageBody"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "messageBody", location: .body(locationName: "MessageBody"))
+        ]
 
         public let messageBody: MessageBody
 
@@ -4114,6 +4207,9 @@ extension Pinpoint {
     public struct GetAdmChannelResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "aDMChannelResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "aDMChannelResponse", location: .body(locationName: "ADMChannelResponse"))
+        ]
 
         public let aDMChannelResponse: ADMChannelResponse
 
@@ -4145,6 +4241,9 @@ extension Pinpoint {
     public struct GetApnsChannelResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "aPNSChannelResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "aPNSChannelResponse", location: .body(locationName: "APNSChannelResponse"))
+        ]
 
         public let aPNSChannelResponse: APNSChannelResponse
 
@@ -4176,6 +4275,9 @@ extension Pinpoint {
     public struct GetApnsSandboxChannelResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "aPNSSandboxChannelResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "aPNSSandboxChannelResponse", location: .body(locationName: "APNSSandboxChannelResponse"))
+        ]
 
         public let aPNSSandboxChannelResponse: APNSSandboxChannelResponse
 
@@ -4207,6 +4309,9 @@ extension Pinpoint {
     public struct GetApnsVoipChannelResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "aPNSVoipChannelResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "aPNSVoipChannelResponse", location: .body(locationName: "APNSVoipChannelResponse"))
+        ]
 
         public let aPNSVoipChannelResponse: APNSVoipChannelResponse
 
@@ -4238,6 +4343,9 @@ extension Pinpoint {
     public struct GetApnsVoipSandboxChannelResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "aPNSVoipSandboxChannelResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "aPNSVoipSandboxChannelResponse", location: .body(locationName: "APNSVoipSandboxChannelResponse"))
+        ]
 
         public let aPNSVoipSandboxChannelResponse: APNSVoipSandboxChannelResponse
 
@@ -4269,6 +4377,9 @@ extension Pinpoint {
     public struct GetAppResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "applicationResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "applicationResponse", location: .body(locationName: "ApplicationResponse"))
+        ]
 
         public let applicationResponse: ApplicationResponse
 
@@ -4320,6 +4431,9 @@ extension Pinpoint {
     public struct GetApplicationDateRangeKpiResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "applicationDateRangeKpiResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "applicationDateRangeKpiResponse", location: .body(locationName: "ApplicationDateRangeKpiResponse"))
+        ]
 
         public let applicationDateRangeKpiResponse: ApplicationDateRangeKpiResponse
 
@@ -4351,6 +4465,9 @@ extension Pinpoint {
     public struct GetApplicationSettingsResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "applicationSettingsResource"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "applicationSettingsResource", location: .body(locationName: "ApplicationSettingsResource"))
+        ]
 
         public let applicationSettingsResource: ApplicationSettingsResource
 
@@ -4386,6 +4503,9 @@ extension Pinpoint {
     public struct GetAppsResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "applicationsResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "applicationsResponse", location: .body(locationName: "ApplicationsResponse"))
+        ]
 
         public let applicationsResponse: ApplicationsResponse
 
@@ -4417,6 +4537,9 @@ extension Pinpoint {
     public struct GetBaiduChannelResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "baiduChannelResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "baiduChannelResponse", location: .body(locationName: "BaiduChannelResponse"))
+        ]
 
         public let baiduChannelResponse: BaiduChannelResponse
 
@@ -4460,6 +4583,9 @@ extension Pinpoint {
     public struct GetCampaignActivitiesResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "activitiesResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "activitiesResponse", location: .body(locationName: "ActivitiesResponse"))
+        ]
 
         public let activitiesResponse: ActivitiesResponse
 
@@ -4515,6 +4641,9 @@ extension Pinpoint {
     public struct GetCampaignDateRangeKpiResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "campaignDateRangeKpiResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "campaignDateRangeKpiResponse", location: .body(locationName: "CampaignDateRangeKpiResponse"))
+        ]
 
         public let campaignDateRangeKpiResponse: CampaignDateRangeKpiResponse
 
@@ -4550,6 +4679,9 @@ extension Pinpoint {
     public struct GetCampaignResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "campaignResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "campaignResponse", location: .body(locationName: "CampaignResponse"))
+        ]
 
         public let campaignResponse: CampaignResponse
 
@@ -4589,6 +4721,9 @@ extension Pinpoint {
     public struct GetCampaignVersionResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "campaignResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "campaignResponse", location: .body(locationName: "CampaignResponse"))
+        ]
 
         public let campaignResponse: CampaignResponse
 
@@ -4632,6 +4767,9 @@ extension Pinpoint {
     public struct GetCampaignVersionsResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "campaignsResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "campaignsResponse", location: .body(locationName: "CampaignsResponse"))
+        ]
 
         public let campaignsResponse: CampaignsResponse
 
@@ -4671,6 +4809,9 @@ extension Pinpoint {
     public struct GetCampaignsResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "campaignsResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "campaignsResponse", location: .body(locationName: "CampaignsResponse"))
+        ]
 
         public let campaignsResponse: CampaignsResponse
 
@@ -4702,6 +4843,9 @@ extension Pinpoint {
     public struct GetChannelsResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "channelsResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "channelsResponse", location: .body(locationName: "ChannelsResponse"))
+        ]
 
         public let channelsResponse: ChannelsResponse
 
@@ -4733,6 +4877,9 @@ extension Pinpoint {
     public struct GetEmailChannelResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "emailChannelResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "emailChannelResponse", location: .body(locationName: "EmailChannelResponse"))
+        ]
 
         public let emailChannelResponse: EmailChannelResponse
 
@@ -4768,6 +4915,9 @@ extension Pinpoint {
     public struct GetEmailTemplateResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "emailTemplateResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "emailTemplateResponse", location: .body(locationName: "EmailTemplateResponse"))
+        ]
 
         public let emailTemplateResponse: EmailTemplateResponse
 
@@ -4803,6 +4953,9 @@ extension Pinpoint {
     public struct GetEndpointResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "endpointResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "endpointResponse", location: .body(locationName: "EndpointResponse"))
+        ]
 
         public let endpointResponse: EndpointResponse
 
@@ -4834,6 +4987,9 @@ extension Pinpoint {
     public struct GetEventStreamResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "eventStream"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "eventStream", location: .body(locationName: "EventStream"))
+        ]
 
         public let eventStream: EventStream
 
@@ -4869,6 +5025,9 @@ extension Pinpoint {
     public struct GetExportJobResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "exportJobResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "exportJobResponse", location: .body(locationName: "ExportJobResponse"))
+        ]
 
         public let exportJobResponse: ExportJobResponse
 
@@ -4908,6 +5067,9 @@ extension Pinpoint {
     public struct GetExportJobsResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "exportJobsResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "exportJobsResponse", location: .body(locationName: "ExportJobsResponse"))
+        ]
 
         public let exportJobsResponse: ExportJobsResponse
 
@@ -4939,6 +5101,9 @@ extension Pinpoint {
     public struct GetGcmChannelResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "gCMChannelResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "gCMChannelResponse", location: .body(locationName: "GCMChannelResponse"))
+        ]
 
         public let gCMChannelResponse: GCMChannelResponse
 
@@ -4974,6 +5139,9 @@ extension Pinpoint {
     public struct GetImportJobResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "importJobResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "importJobResponse", location: .body(locationName: "ImportJobResponse"))
+        ]
 
         public let importJobResponse: ImportJobResponse
 
@@ -5013,6 +5181,9 @@ extension Pinpoint {
     public struct GetImportJobsResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "importJobsResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "importJobsResponse", location: .body(locationName: "ImportJobsResponse"))
+        ]
 
         public let importJobsResponse: ImportJobsResponse
 
@@ -5068,6 +5239,9 @@ extension Pinpoint {
     public struct GetJourneyDateRangeKpiResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "journeyDateRangeKpiResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "journeyDateRangeKpiResponse", location: .body(locationName: "JourneyDateRangeKpiResponse"))
+        ]
 
         public let journeyDateRangeKpiResponse: JourneyDateRangeKpiResponse
 
@@ -5115,6 +5289,9 @@ extension Pinpoint {
     public struct GetJourneyExecutionActivityMetricsResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "journeyExecutionActivityMetricsResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "journeyExecutionActivityMetricsResponse", location: .body(locationName: "JourneyExecutionActivityMetricsResponse"))
+        ]
 
         public let journeyExecutionActivityMetricsResponse: JourneyExecutionActivityMetricsResponse
 
@@ -5158,6 +5335,9 @@ extension Pinpoint {
     public struct GetJourneyExecutionMetricsResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "journeyExecutionMetricsResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "journeyExecutionMetricsResponse", location: .body(locationName: "JourneyExecutionMetricsResponse"))
+        ]
 
         public let journeyExecutionMetricsResponse: JourneyExecutionMetricsResponse
 
@@ -5193,6 +5373,9 @@ extension Pinpoint {
     public struct GetJourneyResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "journeyResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "journeyResponse", location: .body(locationName: "JourneyResponse"))
+        ]
 
         public let journeyResponse: JourneyResponse
 
@@ -5228,6 +5411,9 @@ extension Pinpoint {
     public struct GetPushTemplateResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "pushNotificationTemplateResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "pushNotificationTemplateResponse", location: .body(locationName: "PushNotificationTemplateResponse"))
+        ]
 
         public let pushNotificationTemplateResponse: PushNotificationTemplateResponse
 
@@ -5271,6 +5457,9 @@ extension Pinpoint {
     public struct GetSegmentExportJobsResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "exportJobsResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "exportJobsResponse", location: .body(locationName: "ExportJobsResponse"))
+        ]
 
         public let exportJobsResponse: ExportJobsResponse
 
@@ -5314,6 +5503,9 @@ extension Pinpoint {
     public struct GetSegmentImportJobsResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "importJobsResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "importJobsResponse", location: .body(locationName: "ImportJobsResponse"))
+        ]
 
         public let importJobsResponse: ImportJobsResponse
 
@@ -5349,6 +5541,9 @@ extension Pinpoint {
     public struct GetSegmentResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "segmentResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "segmentResponse", location: .body(locationName: "SegmentResponse"))
+        ]
 
         public let segmentResponse: SegmentResponse
 
@@ -5388,6 +5583,9 @@ extension Pinpoint {
     public struct GetSegmentVersionResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "segmentResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "segmentResponse", location: .body(locationName: "SegmentResponse"))
+        ]
 
         public let segmentResponse: SegmentResponse
 
@@ -5431,6 +5629,9 @@ extension Pinpoint {
     public struct GetSegmentVersionsResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "segmentsResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "segmentsResponse", location: .body(locationName: "SegmentsResponse"))
+        ]
 
         public let segmentsResponse: SegmentsResponse
 
@@ -5470,6 +5671,9 @@ extension Pinpoint {
     public struct GetSegmentsResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "segmentsResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "segmentsResponse", location: .body(locationName: "SegmentsResponse"))
+        ]
 
         public let segmentsResponse: SegmentsResponse
 
@@ -5501,6 +5705,9 @@ extension Pinpoint {
     public struct GetSmsChannelResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "sMSChannelResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "sMSChannelResponse", location: .body(locationName: "SMSChannelResponse"))
+        ]
 
         public let sMSChannelResponse: SMSChannelResponse
 
@@ -5536,6 +5743,9 @@ extension Pinpoint {
     public struct GetSmsTemplateResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "sMSTemplateResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "sMSTemplateResponse", location: .body(locationName: "SMSTemplateResponse"))
+        ]
 
         public let sMSTemplateResponse: SMSTemplateResponse
 
@@ -5571,6 +5781,9 @@ extension Pinpoint {
     public struct GetUserEndpointsResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "endpointsResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "endpointsResponse", location: .body(locationName: "EndpointsResponse"))
+        ]
 
         public let endpointsResponse: EndpointsResponse
 
@@ -5602,6 +5815,9 @@ extension Pinpoint {
     public struct GetVoiceChannelResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "voiceChannelResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "voiceChannelResponse", location: .body(locationName: "VoiceChannelResponse"))
+        ]
 
         public let voiceChannelResponse: VoiceChannelResponse
 
@@ -5637,6 +5853,9 @@ extension Pinpoint {
     public struct GetVoiceTemplateResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "voiceTemplateResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "voiceTemplateResponse", location: .body(locationName: "VoiceTemplateResponse"))
+        ]
 
         public let voiceTemplateResponse: VoiceTemplateResponse
 
@@ -6139,6 +6358,9 @@ extension Pinpoint {
     public struct ListJourneysResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "journeysResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "journeysResponse", location: .body(locationName: "JourneysResponse"))
+        ]
 
         public let journeysResponse: JourneysResponse
 
@@ -6170,6 +6392,9 @@ extension Pinpoint {
     public struct ListTagsForResourceResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "tagsModel"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "tagsModel", location: .body(locationName: "TagsModel"))
+        ]
 
         public let tagsModel: TagsModel
 
@@ -6213,6 +6438,9 @@ extension Pinpoint {
     public struct ListTemplateVersionsResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "templateVersionsResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "templateVersionsResponse", location: .body(locationName: "TemplateVersionsResponse"))
+        ]
 
         public let templateVersionsResponse: TemplateVersionsResponse
 
@@ -6256,6 +6484,9 @@ extension Pinpoint {
     public struct ListTemplatesResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "templatesResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "templatesResponse", location: .body(locationName: "TemplatesResponse"))
+        ]
 
         public let templatesResponse: TemplatesResponse
 
@@ -6633,6 +6864,9 @@ extension Pinpoint {
     public struct PhoneNumberValidateResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "numberValidateResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "numberValidateResponse", location: .body(locationName: "NumberValidateResponse"))
+        ]
 
         public let numberValidateResponse: NumberValidateResponse
 
@@ -6831,6 +7065,9 @@ extension Pinpoint {
     public struct PutEventStreamResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "eventStream"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "eventStream", location: .body(locationName: "EventStream"))
+        ]
 
         public let eventStream: EventStream
 
@@ -6867,6 +7104,9 @@ extension Pinpoint {
     public struct PutEventsResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "eventsResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "eventsResponse", location: .body(locationName: "EventsResponse"))
+        ]
 
         public let eventsResponse: EventsResponse
 
@@ -6989,6 +7229,9 @@ extension Pinpoint {
     public struct RemoveAttributesResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "attributesResource"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "attributesResource", location: .body(locationName: "AttributesResource"))
+        ]
 
         public let attributesResource: AttributesResource
 
@@ -7590,6 +7833,9 @@ extension Pinpoint {
     public struct SendMessagesResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "messageResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "messageResponse", location: .body(locationName: "MessageResponse"))
+        ]
 
         public let messageResponse: MessageResponse
 
@@ -7678,6 +7924,9 @@ extension Pinpoint {
     public struct SendUsersMessagesResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "sendUsersMessageResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "sendUsersMessageResponse", location: .body(locationName: "SendUsersMessageResponse"))
+        ]
 
         public let sendUsersMessageResponse: SendUsersMessageResponse
 
@@ -8121,6 +8370,9 @@ extension Pinpoint {
     public struct UpdateAdmChannelResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "aDMChannelResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "aDMChannelResponse", location: .body(locationName: "ADMChannelResponse"))
+        ]
 
         public let aDMChannelResponse: ADMChannelResponse
 
@@ -8157,6 +8409,9 @@ extension Pinpoint {
     public struct UpdateApnsChannelResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "aPNSChannelResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "aPNSChannelResponse", location: .body(locationName: "APNSChannelResponse"))
+        ]
 
         public let aPNSChannelResponse: APNSChannelResponse
 
@@ -8193,6 +8448,9 @@ extension Pinpoint {
     public struct UpdateApnsSandboxChannelResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "aPNSSandboxChannelResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "aPNSSandboxChannelResponse", location: .body(locationName: "APNSSandboxChannelResponse"))
+        ]
 
         public let aPNSSandboxChannelResponse: APNSSandboxChannelResponse
 
@@ -8229,6 +8487,9 @@ extension Pinpoint {
     public struct UpdateApnsVoipChannelResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "aPNSVoipChannelResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "aPNSVoipChannelResponse", location: .body(locationName: "APNSVoipChannelResponse"))
+        ]
 
         public let aPNSVoipChannelResponse: APNSVoipChannelResponse
 
@@ -8265,6 +8526,9 @@ extension Pinpoint {
     public struct UpdateApnsVoipSandboxChannelResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "aPNSVoipSandboxChannelResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "aPNSVoipSandboxChannelResponse", location: .body(locationName: "APNSVoipSandboxChannelResponse"))
+        ]
 
         public let aPNSVoipSandboxChannelResponse: APNSVoipSandboxChannelResponse
 
@@ -8301,6 +8565,9 @@ extension Pinpoint {
     public struct UpdateApplicationSettingsResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "applicationSettingsResource"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "applicationSettingsResource", location: .body(locationName: "ApplicationSettingsResource"))
+        ]
 
         public let applicationSettingsResource: ApplicationSettingsResource
 
@@ -8351,6 +8618,9 @@ extension Pinpoint {
     public struct UpdateBaiduChannelResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "baiduChannelResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "baiduChannelResponse", location: .body(locationName: "BaiduChannelResponse"))
+        ]
 
         public let baiduChannelResponse: BaiduChannelResponse
 
@@ -8391,6 +8661,9 @@ extension Pinpoint {
     public struct UpdateCampaignResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "campaignResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "campaignResponse", location: .body(locationName: "CampaignResponse"))
+        ]
 
         public let campaignResponse: CampaignResponse
 
@@ -8427,6 +8700,9 @@ extension Pinpoint {
     public struct UpdateEmailChannelResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "emailChannelResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "emailChannelResponse", location: .body(locationName: "EmailChannelResponse"))
+        ]
 
         public let emailChannelResponse: EmailChannelResponse
 
@@ -8471,6 +8747,9 @@ extension Pinpoint {
     public struct UpdateEmailTemplateResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "messageBody"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "messageBody", location: .body(locationName: "MessageBody"))
+        ]
 
         public let messageBody: MessageBody
 
@@ -8511,6 +8790,9 @@ extension Pinpoint {
     public struct UpdateEndpointResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "messageBody"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "messageBody", location: .body(locationName: "MessageBody"))
+        ]
 
         public let messageBody: MessageBody
 
@@ -8547,6 +8829,9 @@ extension Pinpoint {
     public struct UpdateEndpointsBatchResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "messageBody"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "messageBody", location: .body(locationName: "MessageBody"))
+        ]
 
         public let messageBody: MessageBody
 
@@ -8583,6 +8868,9 @@ extension Pinpoint {
     public struct UpdateGcmChannelResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "gCMChannelResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "gCMChannelResponse", location: .body(locationName: "GCMChannelResponse"))
+        ]
 
         public let gCMChannelResponse: GCMChannelResponse
 
@@ -8623,6 +8911,9 @@ extension Pinpoint {
     public struct UpdateJourneyResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "journeyResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "journeyResponse", location: .body(locationName: "JourneyResponse"))
+        ]
 
         public let journeyResponse: JourneyResponse
 
@@ -8663,6 +8954,9 @@ extension Pinpoint {
     public struct UpdateJourneyStateResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "journeyResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "journeyResponse", location: .body(locationName: "JourneyResponse"))
+        ]
 
         public let journeyResponse: JourneyResponse
 
@@ -8707,6 +9001,9 @@ extension Pinpoint {
     public struct UpdatePushTemplateResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "messageBody"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "messageBody", location: .body(locationName: "MessageBody"))
+        ]
 
         public let messageBody: MessageBody
 
@@ -8747,6 +9044,9 @@ extension Pinpoint {
     public struct UpdateSegmentResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "segmentResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "segmentResponse", location: .body(locationName: "SegmentResponse"))
+        ]
 
         public let segmentResponse: SegmentResponse
 
@@ -8783,6 +9083,9 @@ extension Pinpoint {
     public struct UpdateSmsChannelResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "sMSChannelResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "sMSChannelResponse", location: .body(locationName: "SMSChannelResponse"))
+        ]
 
         public let sMSChannelResponse: SMSChannelResponse
 
@@ -8827,6 +9130,9 @@ extension Pinpoint {
     public struct UpdateSmsTemplateResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "messageBody"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "messageBody", location: .body(locationName: "MessageBody"))
+        ]
 
         public let messageBody: MessageBody
 
@@ -8867,6 +9173,9 @@ extension Pinpoint {
     public struct UpdateTemplateActiveVersionResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "messageBody"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "messageBody", location: .body(locationName: "MessageBody"))
+        ]
 
         public let messageBody: MessageBody
 
@@ -8903,6 +9212,9 @@ extension Pinpoint {
     public struct UpdateVoiceChannelResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "voiceChannelResponse"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "voiceChannelResponse", location: .body(locationName: "VoiceChannelResponse"))
+        ]
 
         public let voiceChannelResponse: VoiceChannelResponse
 
@@ -8947,6 +9259,9 @@ extension Pinpoint {
     public struct UpdateVoiceTemplateResponse: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "messageBody"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "messageBody", location: .body(locationName: "MessageBody"))
+        ]
 
         public let messageBody: MessageBody
 

--- a/Sources/AWSSDKSwift/Services/Pinpoint/Pinpoint_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/Pinpoint/Pinpoint_Shapes.swift
@@ -1735,6 +1735,9 @@ extension Pinpoint {
     public struct CreateAppRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "createApplicationRequest"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "createApplicationRequest", location: .body(locationName: "CreateApplicationRequest"))
+        ]
 
         public let createApplicationRequest: CreateApplicationRequest
 
@@ -1787,7 +1790,8 @@ extension Pinpoint {
         /// The key for the payload
         public static let payloadPath: String? = "writeCampaignRequest"
         public static var _encoding = [
-            AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id"))
+            AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id")), 
+            AWSMemberEncoding(label: "writeCampaignRequest", location: .body(locationName: "WriteCampaignRequest"))
         ]
 
         public let applicationId: String
@@ -1826,6 +1830,7 @@ extension Pinpoint {
         /// The key for the payload
         public static let payloadPath: String? = "emailTemplateRequest"
         public static var _encoding = [
+            AWSMemberEncoding(label: "emailTemplateRequest", location: .body(locationName: "EmailTemplateRequest")), 
             AWSMemberEncoding(label: "templateName", location: .uri(locationName: "template-name"))
         ]
 
@@ -1865,7 +1870,8 @@ extension Pinpoint {
         /// The key for the payload
         public static let payloadPath: String? = "exportJobRequest"
         public static var _encoding = [
-            AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id"))
+            AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id")), 
+            AWSMemberEncoding(label: "exportJobRequest", location: .body(locationName: "ExportJobRequest"))
         ]
 
         public let applicationId: String
@@ -1904,7 +1910,8 @@ extension Pinpoint {
         /// The key for the payload
         public static let payloadPath: String? = "importJobRequest"
         public static var _encoding = [
-            AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id"))
+            AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id")), 
+            AWSMemberEncoding(label: "importJobRequest", location: .body(locationName: "ImportJobRequest"))
         ]
 
         public let applicationId: String
@@ -1943,7 +1950,8 @@ extension Pinpoint {
         /// The key for the payload
         public static let payloadPath: String? = "writeJourneyRequest"
         public static var _encoding = [
-            AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id"))
+            AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id")), 
+            AWSMemberEncoding(label: "writeJourneyRequest", location: .body(locationName: "WriteJourneyRequest"))
         ]
 
         public let applicationId: String
@@ -1982,6 +1990,7 @@ extension Pinpoint {
         /// The key for the payload
         public static let payloadPath: String? = "pushNotificationTemplateRequest"
         public static var _encoding = [
+            AWSMemberEncoding(label: "pushNotificationTemplateRequest", location: .body(locationName: "PushNotificationTemplateRequest")), 
             AWSMemberEncoding(label: "templateName", location: .uri(locationName: "template-name"))
         ]
 
@@ -2021,7 +2030,8 @@ extension Pinpoint {
         /// The key for the payload
         public static let payloadPath: String? = "writeSegmentRequest"
         public static var _encoding = [
-            AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id"))
+            AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id")), 
+            AWSMemberEncoding(label: "writeSegmentRequest", location: .body(locationName: "WriteSegmentRequest"))
         ]
 
         public let applicationId: String
@@ -2060,6 +2070,7 @@ extension Pinpoint {
         /// The key for the payload
         public static let payloadPath: String? = "sMSTemplateRequest"
         public static var _encoding = [
+            AWSMemberEncoding(label: "sMSTemplateRequest", location: .body(locationName: "SMSTemplateRequest")), 
             AWSMemberEncoding(label: "templateName", location: .uri(locationName: "template-name"))
         ]
 
@@ -2121,7 +2132,8 @@ extension Pinpoint {
         /// The key for the payload
         public static let payloadPath: String? = "voiceTemplateRequest"
         public static var _encoding = [
-            AWSMemberEncoding(label: "templateName", location: .uri(locationName: "template-name"))
+            AWSMemberEncoding(label: "templateName", location: .uri(locationName: "template-name")), 
+            AWSMemberEncoding(label: "voiceTemplateRequest", location: .body(locationName: "VoiceTemplateRequest"))
         ]
 
         public let templateName: String
@@ -6849,6 +6861,9 @@ extension Pinpoint {
     public struct PhoneNumberValidateRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "numberValidateRequest"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "numberValidateRequest", location: .body(locationName: "NumberValidateRequest"))
+        ]
 
         public let numberValidateRequest: NumberValidateRequest
 
@@ -7045,7 +7060,8 @@ extension Pinpoint {
         /// The key for the payload
         public static let payloadPath: String? = "writeEventStream"
         public static var _encoding = [
-            AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id"))
+            AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id")), 
+            AWSMemberEncoding(label: "writeEventStream", location: .body(locationName: "WriteEventStream"))
         ]
 
         public let applicationId: String
@@ -7084,7 +7100,8 @@ extension Pinpoint {
         /// The key for the payload
         public static let payloadPath: String? = "eventsRequest"
         public static var _encoding = [
-            AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id"))
+            AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id")), 
+            AWSMemberEncoding(label: "eventsRequest", location: .body(locationName: "EventsRequest"))
         ]
 
         public let applicationId: String
@@ -7206,7 +7223,8 @@ extension Pinpoint {
         public static let payloadPath: String? = "updateAttributesRequest"
         public static var _encoding = [
             AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id")), 
-            AWSMemberEncoding(label: "attributeType", location: .uri(locationName: "attribute-type"))
+            AWSMemberEncoding(label: "attributeType", location: .uri(locationName: "attribute-type")), 
+            AWSMemberEncoding(label: "updateAttributesRequest", location: .body(locationName: "UpdateAttributesRequest"))
         ]
 
         public let applicationId: String
@@ -7813,7 +7831,8 @@ extension Pinpoint {
         /// The key for the payload
         public static let payloadPath: String? = "messageRequest"
         public static var _encoding = [
-            AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id"))
+            AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id")), 
+            AWSMemberEncoding(label: "messageRequest", location: .body(locationName: "MessageRequest"))
         ]
 
         public let applicationId: String
@@ -7904,7 +7923,8 @@ extension Pinpoint {
         /// The key for the payload
         public static let payloadPath: String? = "sendUsersMessageRequest"
         public static var _encoding = [
-            AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id"))
+            AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id")), 
+            AWSMemberEncoding(label: "sendUsersMessageRequest", location: .body(locationName: "SendUsersMessageRequest"))
         ]
 
         public let applicationId: String
@@ -8067,7 +8087,8 @@ extension Pinpoint {
         /// The key for the payload
         public static let payloadPath: String? = "tagsModel"
         public static var _encoding = [
-            AWSMemberEncoding(label: "resourceArn", location: .uri(locationName: "resource-arn"))
+            AWSMemberEncoding(label: "resourceArn", location: .uri(locationName: "resource-arn")), 
+            AWSMemberEncoding(label: "tagsModel", location: .body(locationName: "TagsModel"))
         ]
 
         public let resourceArn: String
@@ -8350,6 +8371,7 @@ extension Pinpoint {
         /// The key for the payload
         public static let payloadPath: String? = "aDMChannelRequest"
         public static var _encoding = [
+            AWSMemberEncoding(label: "aDMChannelRequest", location: .body(locationName: "ADMChannelRequest")), 
             AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id"))
         ]
 
@@ -8389,6 +8411,7 @@ extension Pinpoint {
         /// The key for the payload
         public static let payloadPath: String? = "aPNSChannelRequest"
         public static var _encoding = [
+            AWSMemberEncoding(label: "aPNSChannelRequest", location: .body(locationName: "APNSChannelRequest")), 
             AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id"))
         ]
 
@@ -8428,6 +8451,7 @@ extension Pinpoint {
         /// The key for the payload
         public static let payloadPath: String? = "aPNSSandboxChannelRequest"
         public static var _encoding = [
+            AWSMemberEncoding(label: "aPNSSandboxChannelRequest", location: .body(locationName: "APNSSandboxChannelRequest")), 
             AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id"))
         ]
 
@@ -8467,6 +8491,7 @@ extension Pinpoint {
         /// The key for the payload
         public static let payloadPath: String? = "aPNSVoipChannelRequest"
         public static var _encoding = [
+            AWSMemberEncoding(label: "aPNSVoipChannelRequest", location: .body(locationName: "APNSVoipChannelRequest")), 
             AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id"))
         ]
 
@@ -8506,6 +8531,7 @@ extension Pinpoint {
         /// The key for the payload
         public static let payloadPath: String? = "aPNSVoipSandboxChannelRequest"
         public static var _encoding = [
+            AWSMemberEncoding(label: "aPNSVoipSandboxChannelRequest", location: .body(locationName: "APNSVoipSandboxChannelRequest")), 
             AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id"))
         ]
 
@@ -8545,7 +8571,8 @@ extension Pinpoint {
         /// The key for the payload
         public static let payloadPath: String? = "writeApplicationSettingsRequest"
         public static var _encoding = [
-            AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id"))
+            AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id")), 
+            AWSMemberEncoding(label: "writeApplicationSettingsRequest", location: .body(locationName: "WriteApplicationSettingsRequest"))
         ]
 
         public let applicationId: String
@@ -8598,7 +8625,8 @@ extension Pinpoint {
         /// The key for the payload
         public static let payloadPath: String? = "baiduChannelRequest"
         public static var _encoding = [
-            AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id"))
+            AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id")), 
+            AWSMemberEncoding(label: "baiduChannelRequest", location: .body(locationName: "BaiduChannelRequest"))
         ]
 
         public let applicationId: String
@@ -8638,7 +8666,8 @@ extension Pinpoint {
         public static let payloadPath: String? = "writeCampaignRequest"
         public static var _encoding = [
             AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id")), 
-            AWSMemberEncoding(label: "campaignId", location: .uri(locationName: "campaign-id"))
+            AWSMemberEncoding(label: "campaignId", location: .uri(locationName: "campaign-id")), 
+            AWSMemberEncoding(label: "writeCampaignRequest", location: .body(locationName: "WriteCampaignRequest"))
         ]
 
         public let applicationId: String
@@ -8680,7 +8709,8 @@ extension Pinpoint {
         /// The key for the payload
         public static let payloadPath: String? = "emailChannelRequest"
         public static var _encoding = [
-            AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id"))
+            AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id")), 
+            AWSMemberEncoding(label: "emailChannelRequest", location: .body(locationName: "EmailChannelRequest"))
         ]
 
         public let applicationId: String
@@ -8720,6 +8750,7 @@ extension Pinpoint {
         public static let payloadPath: String? = "emailTemplateRequest"
         public static var _encoding = [
             AWSMemberEncoding(label: "createNewVersion", location: .querystring(locationName: "create-new-version")), 
+            AWSMemberEncoding(label: "emailTemplateRequest", location: .body(locationName: "EmailTemplateRequest")), 
             AWSMemberEncoding(label: "templateName", location: .uri(locationName: "template-name")), 
             AWSMemberEncoding(label: "version", location: .querystring(locationName: "version"))
         ]
@@ -8767,7 +8798,8 @@ extension Pinpoint {
         public static let payloadPath: String? = "endpointRequest"
         public static var _encoding = [
             AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id")), 
-            AWSMemberEncoding(label: "endpointId", location: .uri(locationName: "endpoint-id"))
+            AWSMemberEncoding(label: "endpointId", location: .uri(locationName: "endpoint-id")), 
+            AWSMemberEncoding(label: "endpointRequest", location: .body(locationName: "EndpointRequest"))
         ]
 
         public let applicationId: String
@@ -8809,7 +8841,8 @@ extension Pinpoint {
         /// The key for the payload
         public static let payloadPath: String? = "endpointBatchRequest"
         public static var _encoding = [
-            AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id"))
+            AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id")), 
+            AWSMemberEncoding(label: "endpointBatchRequest", location: .body(locationName: "EndpointBatchRequest"))
         ]
 
         public let applicationId: String
@@ -8848,7 +8881,8 @@ extension Pinpoint {
         /// The key for the payload
         public static let payloadPath: String? = "gCMChannelRequest"
         public static var _encoding = [
-            AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id"))
+            AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id")), 
+            AWSMemberEncoding(label: "gCMChannelRequest", location: .body(locationName: "GCMChannelRequest"))
         ]
 
         public let applicationId: String
@@ -8888,7 +8922,8 @@ extension Pinpoint {
         public static let payloadPath: String? = "writeJourneyRequest"
         public static var _encoding = [
             AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id")), 
-            AWSMemberEncoding(label: "journeyId", location: .uri(locationName: "journey-id"))
+            AWSMemberEncoding(label: "journeyId", location: .uri(locationName: "journey-id")), 
+            AWSMemberEncoding(label: "writeJourneyRequest", location: .body(locationName: "WriteJourneyRequest"))
         ]
 
         public let applicationId: String
@@ -8931,7 +8966,8 @@ extension Pinpoint {
         public static let payloadPath: String? = "journeyStateRequest"
         public static var _encoding = [
             AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id")), 
-            AWSMemberEncoding(label: "journeyId", location: .uri(locationName: "journey-id"))
+            AWSMemberEncoding(label: "journeyId", location: .uri(locationName: "journey-id")), 
+            AWSMemberEncoding(label: "journeyStateRequest", location: .body(locationName: "JourneyStateRequest"))
         ]
 
         public let applicationId: String
@@ -8974,6 +9010,7 @@ extension Pinpoint {
         public static let payloadPath: String? = "pushNotificationTemplateRequest"
         public static var _encoding = [
             AWSMemberEncoding(label: "createNewVersion", location: .querystring(locationName: "create-new-version")), 
+            AWSMemberEncoding(label: "pushNotificationTemplateRequest", location: .body(locationName: "PushNotificationTemplateRequest")), 
             AWSMemberEncoding(label: "templateName", location: .uri(locationName: "template-name")), 
             AWSMemberEncoding(label: "version", location: .querystring(locationName: "version"))
         ]
@@ -9021,7 +9058,8 @@ extension Pinpoint {
         public static let payloadPath: String? = "writeSegmentRequest"
         public static var _encoding = [
             AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id")), 
-            AWSMemberEncoding(label: "segmentId", location: .uri(locationName: "segment-id"))
+            AWSMemberEncoding(label: "segmentId", location: .uri(locationName: "segment-id")), 
+            AWSMemberEncoding(label: "writeSegmentRequest", location: .body(locationName: "WriteSegmentRequest"))
         ]
 
         public let applicationId: String
@@ -9063,7 +9101,8 @@ extension Pinpoint {
         /// The key for the payload
         public static let payloadPath: String? = "sMSChannelRequest"
         public static var _encoding = [
-            AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id"))
+            AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id")), 
+            AWSMemberEncoding(label: "sMSChannelRequest", location: .body(locationName: "SMSChannelRequest"))
         ]
 
         public let applicationId: String
@@ -9103,6 +9142,7 @@ extension Pinpoint {
         public static let payloadPath: String? = "sMSTemplateRequest"
         public static var _encoding = [
             AWSMemberEncoding(label: "createNewVersion", location: .querystring(locationName: "create-new-version")), 
+            AWSMemberEncoding(label: "sMSTemplateRequest", location: .body(locationName: "SMSTemplateRequest")), 
             AWSMemberEncoding(label: "templateName", location: .uri(locationName: "template-name")), 
             AWSMemberEncoding(label: "version", location: .querystring(locationName: "version"))
         ]
@@ -9149,6 +9189,7 @@ extension Pinpoint {
         /// The key for the payload
         public static let payloadPath: String? = "templateActiveVersionRequest"
         public static var _encoding = [
+            AWSMemberEncoding(label: "templateActiveVersionRequest", location: .body(locationName: "TemplateActiveVersionRequest")), 
             AWSMemberEncoding(label: "templateName", location: .uri(locationName: "template-name")), 
             AWSMemberEncoding(label: "templateType", location: .uri(locationName: "template-type"))
         ]
@@ -9192,7 +9233,8 @@ extension Pinpoint {
         /// The key for the payload
         public static let payloadPath: String? = "voiceChannelRequest"
         public static var _encoding = [
-            AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id"))
+            AWSMemberEncoding(label: "applicationId", location: .uri(locationName: "application-id")), 
+            AWSMemberEncoding(label: "voiceChannelRequest", location: .body(locationName: "VoiceChannelRequest"))
         ]
 
         public let applicationId: String
@@ -9233,7 +9275,8 @@ extension Pinpoint {
         public static var _encoding = [
             AWSMemberEncoding(label: "createNewVersion", location: .querystring(locationName: "create-new-version")), 
             AWSMemberEncoding(label: "templateName", location: .uri(locationName: "template-name")), 
-            AWSMemberEncoding(label: "version", location: .querystring(locationName: "version"))
+            AWSMemberEncoding(label: "version", location: .querystring(locationName: "version")), 
+            AWSMemberEncoding(label: "voiceTemplateRequest", location: .body(locationName: "VoiceTemplateRequest"))
         ]
 
         public let createNewVersion: Bool?

--- a/Sources/AWSSDKSwift/Services/S3/S3_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/S3/S3_Shapes.swift
@@ -438,6 +438,7 @@ extension S3 {
     }
 
     public struct AccelerateConfiguration: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
 
         /// Specifies the transfer acceleration status of the bucket.
         public let status: BucketAccelerateStatus?
@@ -452,6 +453,7 @@ extension S3 {
     }
 
     public struct AccessControlPolicy: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "grants", location: .body(locationName: "AccessControlList"), encoding: .list(member:"Grant"))
         ]
@@ -514,6 +516,7 @@ extension S3 {
     }
 
     public struct AnalyticsConfiguration: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
 
         /// The filter used to describe a set of objects for analyses. A filter must have exactly one prefix, one tag, or one conjunction (AnalyticsAndOperator). If no filter is provided, all objects will be considered in any analysis.
         public let filter: AnalyticsFilter?
@@ -625,6 +628,7 @@ extension S3 {
     }
 
     public struct BucketLifecycleConfiguration: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "rules", location: .body(locationName: "Rule"), encoding: .flatList)
         ]
@@ -648,6 +652,7 @@ extension S3 {
     }
 
     public struct BucketLoggingStatus: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
 
         public let loggingEnabled: LoggingEnabled?
 
@@ -661,6 +666,7 @@ extension S3 {
     }
 
     public struct CORSConfiguration: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "cORSRules", location: .body(locationName: "CORSRule"), encoding: .flatList)
         ]
@@ -878,7 +884,6 @@ extension S3 {
     public struct CompleteMultipartUploadRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "multipartUpload"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "bucket", location: .uri(locationName: "Bucket")), 
             AWSMemberEncoding(label: "key", location: .uri(locationName: "Key")), 
@@ -919,6 +924,7 @@ extension S3 {
     }
 
     public struct CompletedMultipartUpload: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "parts", location: .body(locationName: "Part"), encoding: .flatList)
         ]
@@ -1271,6 +1277,7 @@ extension S3 {
     }
 
     public struct CreateBucketConfiguration: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
 
         /// Specifies the Region where the bucket will be created. If you don't specify a Region, the bucket is created in the US East (N. Virginia) Region (us-east-1).
         public let locationConstraint: BucketLocationConstraint?
@@ -1304,7 +1311,6 @@ extension S3 {
     public struct CreateBucketRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "createBucketConfiguration"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "acl", location: .header(locationName: "x-amz-acl")), 
             AWSMemberEncoding(label: "bucket", location: .uri(locationName: "Bucket")), 
@@ -1598,6 +1604,7 @@ extension S3 {
     }
 
     public struct Delete: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "objects", location: .body(locationName: "Object"), encoding: .flatList)
         ]
@@ -2018,7 +2025,6 @@ extension S3 {
     public struct DeleteObjectsRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "delete"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "bucket", location: .uri(locationName: "Bucket")), 
             AWSMemberEncoding(label: "bypassGovernanceRetention", location: .header(locationName: "x-amz-bypass-governance-retention")), 
@@ -3876,6 +3882,7 @@ extension S3 {
     }
 
     public struct InventoryConfiguration: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "optionalFields", location: .body(locationName: "OptionalFields"), encoding: .list(member:"Field"))
         ]
@@ -4067,6 +4074,7 @@ extension S3 {
     }
 
     public struct LifecycleConfiguration: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "rules", location: .body(locationName: "Rule"), encoding: .flatList)
         ]
@@ -5024,6 +5032,7 @@ extension S3 {
     }
 
     public struct MetricsConfiguration: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
 
         /// Specifies a metrics configuration filter. The metrics configuration will only include objects that meet the filter's criteria. A filter must be a prefix, a tag, or a conjunction (MetricsAndOperator).
         public let filter: MetricsFilter?
@@ -5139,6 +5148,7 @@ extension S3 {
     }
 
     public struct NotificationConfiguration: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "lambdaFunctionConfigurations", location: .body(locationName: "CloudFunctionConfiguration"), encoding: .flatList), 
             AWSMemberEncoding(label: "queueConfigurations", location: .body(locationName: "QueueConfiguration"), encoding: .flatList), 
@@ -5166,6 +5176,7 @@ extension S3 {
     }
 
     public struct NotificationConfigurationDeprecated: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
 
         /// Container for specifying the AWS Lambda notification configuration.
         public let cloudFunctionConfiguration: CloudFunctionConfiguration?
@@ -5260,6 +5271,7 @@ extension S3 {
     }
 
     public struct ObjectLockConfiguration: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
 
         /// Indicates whether this bucket has an Object Lock configuration enabled.
         public let objectLockEnabled: ObjectLockEnabled?
@@ -5278,6 +5290,7 @@ extension S3 {
     }
 
     public struct ObjectLockLegalHold: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
 
         /// Indicates whether the specified object has a Legal Hold in place.
         public let status: ObjectLockLegalHoldStatus?
@@ -5292,6 +5305,7 @@ extension S3 {
     }
 
     public struct ObjectLockRetention: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
 
         /// Indicates the Retention mode for the specified object.
         public let mode: ObjectLockRetentionMode?
@@ -5471,6 +5485,7 @@ extension S3 {
     }
 
     public struct PublicAccessBlockConfiguration: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "blockPublicAcls", location: .body(locationName: "BlockPublicAcls")), 
             AWSMemberEncoding(label: "blockPublicPolicy", location: .body(locationName: "BlockPublicPolicy")), 
@@ -5505,7 +5520,6 @@ extension S3 {
     public struct PutBucketAccelerateConfigurationRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "accelerateConfiguration"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "accelerateConfiguration", location: .body(locationName: "AccelerateConfiguration")), 
             AWSMemberEncoding(label: "bucket", location: .uri(locationName: "Bucket"))
@@ -5530,7 +5544,6 @@ extension S3 {
     public struct PutBucketAclRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "accessControlPolicy"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "accessControlPolicy", location: .body(locationName: "AccessControlPolicy")), 
             AWSMemberEncoding(label: "acl", location: .header(locationName: "x-amz-acl")), 
@@ -5590,7 +5603,6 @@ extension S3 {
     public struct PutBucketAnalyticsConfigurationRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "analyticsConfiguration"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "analyticsConfiguration", location: .body(locationName: "AnalyticsConfiguration")), 
             AWSMemberEncoding(label: "bucket", location: .uri(locationName: "Bucket")), 
@@ -5624,7 +5636,6 @@ extension S3 {
     public struct PutBucketCorsRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "cORSConfiguration"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "bucket", location: .uri(locationName: "Bucket")), 
             AWSMemberEncoding(label: "contentMD5", location: .header(locationName: "Content-MD5")), 
@@ -5654,7 +5665,6 @@ extension S3 {
     public struct PutBucketEncryptionRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "serverSideEncryptionConfiguration"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "bucket", location: .uri(locationName: "Bucket")), 
             AWSMemberEncoding(label: "contentMD5", location: .header(locationName: "Content-MD5")), 
@@ -5683,7 +5693,6 @@ extension S3 {
     public struct PutBucketInventoryConfigurationRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "inventoryConfiguration"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "bucket", location: .uri(locationName: "Bucket")), 
             AWSMemberEncoding(label: "id", location: .querystring(locationName: "id")), 
@@ -5713,7 +5722,6 @@ extension S3 {
     public struct PutBucketLifecycleConfigurationRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "lifecycleConfiguration"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "bucket", location: .uri(locationName: "Bucket")), 
             AWSMemberEncoding(label: "lifecycleConfiguration", location: .body(locationName: "LifecycleConfiguration"))
@@ -5742,7 +5750,6 @@ extension S3 {
     public struct PutBucketLifecycleRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "lifecycleConfiguration"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "bucket", location: .uri(locationName: "Bucket")), 
             AWSMemberEncoding(label: "contentMD5", location: .header(locationName: "Content-MD5")), 
@@ -5769,7 +5776,6 @@ extension S3 {
     public struct PutBucketLoggingRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "bucketLoggingStatus"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "bucket", location: .uri(locationName: "Bucket")), 
             AWSMemberEncoding(label: "bucketLoggingStatus", location: .body(locationName: "BucketLoggingStatus")), 
@@ -5799,7 +5805,6 @@ extension S3 {
     public struct PutBucketMetricsConfigurationRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "metricsConfiguration"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "bucket", location: .uri(locationName: "Bucket")), 
             AWSMemberEncoding(label: "id", location: .querystring(locationName: "id")), 
@@ -5833,7 +5838,6 @@ extension S3 {
     public struct PutBucketNotificationConfigurationRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "notificationConfiguration"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "bucket", location: .uri(locationName: "Bucket")), 
             AWSMemberEncoding(label: "notificationConfiguration", location: .body(locationName: "NotificationConfiguration"))
@@ -5857,7 +5861,6 @@ extension S3 {
     public struct PutBucketNotificationRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "notificationConfiguration"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "bucket", location: .uri(locationName: "Bucket")), 
             AWSMemberEncoding(label: "contentMD5", location: .header(locationName: "Content-MD5")), 
@@ -5920,7 +5923,6 @@ extension S3 {
     public struct PutBucketReplicationRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "replicationConfiguration"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "bucket", location: .uri(locationName: "Bucket")), 
             AWSMemberEncoding(label: "contentMD5", location: .header(locationName: "Content-MD5")), 
@@ -5957,7 +5959,6 @@ extension S3 {
     public struct PutBucketRequestPaymentRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "requestPaymentConfiguration"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "bucket", location: .uri(locationName: "Bucket")), 
             AWSMemberEncoding(label: "contentMD5", location: .header(locationName: "Content-MD5")), 
@@ -5987,7 +5988,6 @@ extension S3 {
     public struct PutBucketTaggingRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "tagging"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "bucket", location: .uri(locationName: "Bucket")), 
             AWSMemberEncoding(label: "contentMD5", location: .header(locationName: "Content-MD5")), 
@@ -6021,7 +6021,6 @@ extension S3 {
     public struct PutBucketVersioningRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "versioningConfiguration"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "bucket", location: .uri(locationName: "Bucket")), 
             AWSMemberEncoding(label: "contentMD5", location: .header(locationName: "Content-MD5")), 
@@ -6056,7 +6055,6 @@ extension S3 {
     public struct PutBucketWebsiteRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "websiteConfiguration"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "bucket", location: .uri(locationName: "Bucket")), 
             AWSMemberEncoding(label: "contentMD5", location: .header(locationName: "Content-MD5")), 
@@ -6106,7 +6104,6 @@ extension S3 {
     public struct PutObjectAclRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "accessControlPolicy"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "accessControlPolicy", location: .body(locationName: "AccessControlPolicy")), 
             AWSMemberEncoding(label: "acl", location: .header(locationName: "x-amz-acl")), 
@@ -6200,7 +6197,6 @@ extension S3 {
     public struct PutObjectLegalHoldRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "legalHold"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "bucket", location: .uri(locationName: "Bucket")), 
             AWSMemberEncoding(label: "contentMD5", location: .header(locationName: "Content-MD5")), 
@@ -6264,7 +6260,6 @@ extension S3 {
     public struct PutObjectLockConfigurationRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "objectLockConfiguration"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "bucket", location: .uri(locationName: "Bucket")), 
             AWSMemberEncoding(label: "contentMD5", location: .header(locationName: "Content-MD5")), 
@@ -6542,7 +6537,6 @@ extension S3 {
     public struct PutObjectRetentionRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "retention"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "bucket", location: .uri(locationName: "Bucket")), 
             AWSMemberEncoding(label: "bypassGovernanceRetention", location: .header(locationName: "x-amz-bypass-governance-retention")), 
@@ -6612,7 +6606,6 @@ extension S3 {
     public struct PutObjectTaggingRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "tagging"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "bucket", location: .uri(locationName: "Bucket")), 
             AWSMemberEncoding(label: "contentMD5", location: .header(locationName: "Content-MD5")), 
@@ -6657,7 +6650,6 @@ extension S3 {
     public struct PutPublicAccessBlockRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "publicAccessBlockConfiguration"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "bucket", location: .uri(locationName: "Bucket")), 
             AWSMemberEncoding(label: "contentMD5", location: .header(locationName: "Content-MD5")), 
@@ -6785,6 +6777,7 @@ extension S3 {
     }
 
     public struct ReplicationConfiguration: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "rules", location: .body(locationName: "Rule"), encoding: .flatList)
         ]
@@ -6941,6 +6934,7 @@ extension S3 {
     }
 
     public struct RequestPaymentConfiguration: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
 
         /// Specifies who pays for the download and request fees.
         public let payer: Payer
@@ -6992,7 +6986,6 @@ extension S3 {
     public struct RestoreObjectRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "restoreRequest"
-        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "bucket", location: .uri(locationName: "Bucket")), 
             AWSMemberEncoding(label: "key", location: .uri(locationName: "Key")), 
@@ -7033,6 +7026,7 @@ extension S3 {
     }
 
     public struct RestoreRequest: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
 
         /// Lifetime of the active copy in days. Do not use with restores that specify OutputLocation.
         public let days: Int?
@@ -7347,6 +7341,7 @@ extension S3 {
     }
 
     public struct ServerSideEncryptionConfiguration: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "rules", location: .body(locationName: "Rule"), encoding: .flatList)
         ]
@@ -7460,6 +7455,7 @@ extension S3 {
     }
 
     public struct Tagging: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "tagSet", location: .body(locationName: "TagSet"), encoding: .list(member:"Tag"))
         ]
@@ -7836,6 +7832,7 @@ extension S3 {
     }
 
     public struct VersioningConfiguration: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "mFADelete", location: .body(locationName: "MfaDelete"))
         ]
@@ -7857,6 +7854,7 @@ extension S3 {
     }
 
     public struct WebsiteConfiguration: AWSShape {
+        public static let _xmlNamespace: String? = "http://s3.amazonaws.com/doc/2006-03-01/"
         public static var _encoding = [
             AWSMemberEncoding(label: "routingRules", location: .body(locationName: "RoutingRules"), encoding: .list(member:"RoutingRule"))
         ]

--- a/Sources/AWSSDKSwift/Services/S3/S3_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/S3/S3_Shapes.swift
@@ -5927,7 +5927,8 @@ extension S3 {
         public static var _encoding = [
             AWSMemberEncoding(label: "bucket", location: .uri(locationName: "Bucket")), 
             AWSMemberEncoding(label: "confirmRemoveSelfBucketAccess", location: .header(locationName: "x-amz-confirm-remove-self-bucket-access")), 
-            AWSMemberEncoding(label: "contentMD5", location: .header(locationName: "Content-MD5"))
+            AWSMemberEncoding(label: "contentMD5", location: .header(locationName: "Content-MD5")), 
+            AWSMemberEncoding(label: "policy", location: .body(locationName: "Policy"))
         ]
 
         /// The name of the bucket.

--- a/Sources/AWSSDKSwift/Services/S3/S3_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/S3/S3_Shapes.swift
@@ -981,6 +981,7 @@ extension S3 {
         /// The key for the payload
         public static let payloadPath: String? = "copyObjectResult"
         public static var _encoding = [
+            AWSMemberEncoding(label: "copyObjectResult", location: .body(locationName: "CopyObjectResult")), 
             AWSMemberEncoding(label: "copySourceVersionId", location: .header(locationName: "x-amz-copy-source-version-id")), 
             AWSMemberEncoding(label: "expiration", location: .header(locationName: "x-amz-expiration")), 
             AWSMemberEncoding(label: "requestCharged", location: .header(locationName: "x-amz-request-charged")), 
@@ -2328,6 +2329,9 @@ extension S3 {
     public struct GetBucketAnalyticsConfigurationOutput: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "analyticsConfiguration"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "analyticsConfiguration", location: .body(locationName: "AnalyticsConfiguration"))
+        ]
 
         /// The configuration and any analyses for the analytics filter.
         public let analyticsConfiguration: AnalyticsConfiguration?
@@ -2400,6 +2404,9 @@ extension S3 {
     public struct GetBucketEncryptionOutput: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "serverSideEncryptionConfiguration"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "serverSideEncryptionConfiguration", location: .body(locationName: "ServerSideEncryptionConfiguration"))
+        ]
 
         public let serverSideEncryptionConfiguration: ServerSideEncryptionConfiguration?
 
@@ -2432,6 +2439,9 @@ extension S3 {
     public struct GetBucketInventoryConfigurationOutput: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "inventoryConfiguration"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "inventoryConfiguration", location: .body(locationName: "InventoryConfiguration"))
+        ]
 
         /// Specifies the inventory configuration.
         public let inventoryConfiguration: InventoryConfiguration?
@@ -2599,6 +2609,9 @@ extension S3 {
     public struct GetBucketMetricsConfigurationOutput: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "metricsConfiguration"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "metricsConfiguration", location: .body(locationName: "MetricsConfiguration"))
+        ]
 
         /// Specifies the metrics configuration.
         public let metricsConfiguration: MetricsConfiguration?
@@ -2654,6 +2667,9 @@ extension S3 {
     public struct GetBucketPolicyOutput: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "policy"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "policy", location: .body(locationName: "Policy"))
+        ]
 
         /// The bucket policy as a JSON document.
         public let policy: String?
@@ -2687,6 +2703,9 @@ extension S3 {
     public struct GetBucketPolicyStatusOutput: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "policyStatus"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "policyStatus", location: .body(locationName: "PolicyStatus"))
+        ]
 
         /// The policy status for the specified bucket.
         public let policyStatus: PolicyStatus?
@@ -2720,6 +2739,9 @@ extension S3 {
     public struct GetBucketReplicationOutput: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "replicationConfiguration"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "replicationConfiguration", location: .body(locationName: "ReplicationConfiguration"))
+        ]
 
         public let replicationConfiguration: ReplicationConfiguration?
 
@@ -2961,6 +2983,9 @@ extension S3 {
     public struct GetObjectLegalHoldOutput: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "legalHold"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "legalHold", location: .body(locationName: "LegalHold"))
+        ]
 
         /// The current Legal Hold status for the specified object.
         public let legalHold: ObjectLockLegalHold?
@@ -3012,6 +3037,9 @@ extension S3 {
     public struct GetObjectLockConfigurationOutput: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "objectLockConfiguration"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "objectLockConfiguration", location: .body(locationName: "ObjectLockConfiguration"))
+        ]
 
         /// The specified bucket's Object Lock configuration.
         public let objectLockConfiguration: ObjectLockConfiguration?
@@ -3323,6 +3351,9 @@ extension S3 {
     public struct GetObjectRetentionOutput: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "retention"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "retention", location: .body(locationName: "Retention"))
+        ]
 
         /// The container element for an object's retention settings.
         public let retention: ObjectLockRetention?
@@ -3480,6 +3511,9 @@ extension S3 {
     public struct GetPublicAccessBlockOutput: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "publicAccessBlockConfiguration"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "publicAccessBlockConfiguration", location: .body(locationName: "PublicAccessBlockConfiguration"))
+        ]
 
         /// The PublicAccessBlock configuration currently in effect for this Amazon S3 bucket.
         public let publicAccessBlockConfiguration: PublicAccessBlockConfiguration?
@@ -7574,6 +7608,7 @@ extension S3 {
         /// The key for the payload
         public static let payloadPath: String? = "copyPartResult"
         public static var _encoding = [
+            AWSMemberEncoding(label: "copyPartResult", location: .body(locationName: "CopyPartResult")), 
             AWSMemberEncoding(label: "copySourceVersionId", location: .header(locationName: "x-amz-copy-source-version-id")), 
             AWSMemberEncoding(label: "requestCharged", location: .header(locationName: "x-amz-request-charged")), 
             AWSMemberEncoding(label: "serverSideEncryption", location: .header(locationName: "x-amz-server-side-encryption")), 

--- a/Sources/AWSSDKSwift/Services/S3Control/S3Control_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/S3Control/S3Control_Shapes.swift
@@ -1052,6 +1052,7 @@ extension S3Control {
     }
 
     public struct PublicAccessBlockConfiguration: AWSShape {
+        public static let _xmlNamespace: String? = "http://awss3control.amazonaws.com/doc/2018-08-20/"
         public static var _encoding = [
             AWSMemberEncoding(label: "blockPublicAcls", location: .body(locationName: "BlockPublicAcls")), 
             AWSMemberEncoding(label: "blockPublicPolicy", location: .body(locationName: "BlockPublicPolicy")), 
@@ -1119,7 +1120,6 @@ extension S3Control {
     public struct PutPublicAccessBlockRequest: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "publicAccessBlockConfiguration"
-        public static let _xmlNamespace: String? = "http://awss3control.amazonaws.com/doc/2018-08-20/"
         public static var _encoding = [
             AWSMemberEncoding(label: "accountId", location: .header(locationName: "x-amz-account-id")), 
             AWSMemberEncoding(label: "publicAccessBlockConfiguration", location: .body(locationName: "PublicAccessBlockConfiguration"))

--- a/Sources/AWSSDKSwift/Services/S3Control/S3Control_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/S3Control/S3Control_Shapes.swift
@@ -551,6 +551,9 @@ extension S3Control {
     public struct GetPublicAccessBlockOutput: AWSShape {
         /// The key for the payload
         public static let payloadPath: String? = "publicAccessBlockConfiguration"
+        public static var _encoding = [
+            AWSMemberEncoding(label: "publicAccessBlockConfiguration", location: .body(locationName: "PublicAccessBlockConfiguration"))
+        ]
 
         /// The PublicAccessBlock configuration currently in effect for this Amazon Web Services account.
         public let publicAccessBlockConfiguration: PublicAccessBlockConfiguration?


### PR DESCRIPTION
This is required for https://github.com/swift-aws/aws-sdk-swift-core/pull/212 as the XML namespace is now read from the Payload object