### PR TITLE
Use generic AWSPaginateToken with associated type Token

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -228,7 +228,7 @@ let package = Package(
         .library(name: "AWSXRay", targets: ["AWSXRay"])
     ],
     dependencies: [
-        .package(url: "https://github.com/swift-aws/aws-sdk-swift-core.git", .branch("paginate-token-associated-type"))
+        .package(url: "https://github.com/swift-aws/aws-sdk-swift-core.git", .branch("master"))
     ],
     targets: [
         .target(name: "AWSACM", dependencies: ["AWSSDKSwiftCore"], path: "./Sources/AWSSDKSwift/Services/ACM"),

--- a/Package.swift
+++ b/Package.swift
@@ -228,7 +228,7 @@ let package = Package(
         .library(name: "AWSXRay", targets: ["AWSXRay"])
     ],
     dependencies: [
-        .package(url: "https://github.com/swift-aws/aws-sdk-swift-core.git", .branch("master"))
+        .package(url: "https://github.com/swift-aws/aws-sdk-swift-core.git", .branch("paginate-token-associated-type"))
     ],
     targets: [
         .target(name: "AWSACM", dependencies: ["AWSSDKSwiftCore"], path: "./Sources/AWSSDKSwift/Services/ACM"),

--- a/Sources/AWSSDKSwift/Services/ACM/ACM_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/ACM/ACM_Paginator.swift
@@ -13,7 +13,7 @@ extension ACM {
 
 }
 
-extension ACM.ListCertificatesRequest: AWSPaginateStringToken {
+extension ACM.ListCertificatesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ACM.ListCertificatesRequest {
         return .init(
             certificateStatuses: self.certificateStatuses, 

--- a/Sources/AWSSDKSwift/Services/ACMPCA/ACMPCA_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/ACMPCA/ACMPCA_Paginator.swift
@@ -23,7 +23,7 @@ extension ACMPCA {
 
 }
 
-extension ACMPCA.ListCertificateAuthoritiesRequest: AWSPaginateStringToken {
+extension ACMPCA.ListCertificateAuthoritiesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ACMPCA.ListCertificateAuthoritiesRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -33,7 +33,7 @@ extension ACMPCA.ListCertificateAuthoritiesRequest: AWSPaginateStringToken {
     }
 }
 
-extension ACMPCA.ListPermissionsRequest: AWSPaginateStringToken {
+extension ACMPCA.ListPermissionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ACMPCA.ListPermissionsRequest {
         return .init(
             certificateAuthorityArn: self.certificateAuthorityArn, 
@@ -44,7 +44,7 @@ extension ACMPCA.ListPermissionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension ACMPCA.ListTagsRequest: AWSPaginateStringToken {
+extension ACMPCA.ListTagsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ACMPCA.ListTagsRequest {
         return .init(
             certificateAuthorityArn: self.certificateAuthorityArn, 

--- a/Sources/AWSSDKSwift/Services/APIGateway/APIGateway_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/APIGateway/APIGateway_Paginator.swift
@@ -68,7 +68,7 @@ extension APIGateway {
 
 }
 
-extension APIGateway.GetApiKeysRequest: AWSPaginateStringToken {
+extension APIGateway.GetApiKeysRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> APIGateway.GetApiKeysRequest {
         return .init(
             customerId: self.customerId, 
@@ -81,7 +81,7 @@ extension APIGateway.GetApiKeysRequest: AWSPaginateStringToken {
     }
 }
 
-extension APIGateway.GetBasePathMappingsRequest: AWSPaginateStringToken {
+extension APIGateway.GetBasePathMappingsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> APIGateway.GetBasePathMappingsRequest {
         return .init(
             domainName: self.domainName, 
@@ -92,7 +92,7 @@ extension APIGateway.GetBasePathMappingsRequest: AWSPaginateStringToken {
     }
 }
 
-extension APIGateway.GetClientCertificatesRequest: AWSPaginateStringToken {
+extension APIGateway.GetClientCertificatesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> APIGateway.GetClientCertificatesRequest {
         return .init(
             limit: self.limit, 
@@ -102,7 +102,7 @@ extension APIGateway.GetClientCertificatesRequest: AWSPaginateStringToken {
     }
 }
 
-extension APIGateway.GetDeploymentsRequest: AWSPaginateStringToken {
+extension APIGateway.GetDeploymentsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> APIGateway.GetDeploymentsRequest {
         return .init(
             limit: self.limit, 
@@ -113,7 +113,7 @@ extension APIGateway.GetDeploymentsRequest: AWSPaginateStringToken {
     }
 }
 
-extension APIGateway.GetDomainNamesRequest: AWSPaginateStringToken {
+extension APIGateway.GetDomainNamesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> APIGateway.GetDomainNamesRequest {
         return .init(
             limit: self.limit, 
@@ -123,7 +123,7 @@ extension APIGateway.GetDomainNamesRequest: AWSPaginateStringToken {
     }
 }
 
-extension APIGateway.GetModelsRequest: AWSPaginateStringToken {
+extension APIGateway.GetModelsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> APIGateway.GetModelsRequest {
         return .init(
             limit: self.limit, 
@@ -134,7 +134,7 @@ extension APIGateway.GetModelsRequest: AWSPaginateStringToken {
     }
 }
 
-extension APIGateway.GetResourcesRequest: AWSPaginateStringToken {
+extension APIGateway.GetResourcesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> APIGateway.GetResourcesRequest {
         return .init(
             embed: self.embed, 
@@ -146,7 +146,7 @@ extension APIGateway.GetResourcesRequest: AWSPaginateStringToken {
     }
 }
 
-extension APIGateway.GetRestApisRequest: AWSPaginateStringToken {
+extension APIGateway.GetRestApisRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> APIGateway.GetRestApisRequest {
         return .init(
             limit: self.limit, 
@@ -156,7 +156,7 @@ extension APIGateway.GetRestApisRequest: AWSPaginateStringToken {
     }
 }
 
-extension APIGateway.GetUsageRequest: AWSPaginateStringToken {
+extension APIGateway.GetUsageRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> APIGateway.GetUsageRequest {
         return .init(
             endDate: self.endDate, 
@@ -170,7 +170,7 @@ extension APIGateway.GetUsageRequest: AWSPaginateStringToken {
     }
 }
 
-extension APIGateway.GetUsagePlanKeysRequest: AWSPaginateStringToken {
+extension APIGateway.GetUsagePlanKeysRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> APIGateway.GetUsagePlanKeysRequest {
         return .init(
             limit: self.limit, 
@@ -182,7 +182,7 @@ extension APIGateway.GetUsagePlanKeysRequest: AWSPaginateStringToken {
     }
 }
 
-extension APIGateway.GetUsagePlansRequest: AWSPaginateStringToken {
+extension APIGateway.GetUsagePlansRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> APIGateway.GetUsagePlansRequest {
         return .init(
             keyId: self.keyId, 
@@ -193,7 +193,7 @@ extension APIGateway.GetUsagePlansRequest: AWSPaginateStringToken {
     }
 }
 
-extension APIGateway.GetVpcLinksRequest: AWSPaginateStringToken {
+extension APIGateway.GetVpcLinksRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> APIGateway.GetVpcLinksRequest {
         return .init(
             limit: self.limit, 

--- a/Sources/AWSSDKSwift/Services/AccessAnalyzer/AccessAnalyzer_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/AccessAnalyzer/AccessAnalyzer_Paginator.swift
@@ -28,7 +28,7 @@ extension AccessAnalyzer {
 
 }
 
-extension AccessAnalyzer.ListAnalyzedResourcesRequest: AWSPaginateStringToken {
+extension AccessAnalyzer.ListAnalyzedResourcesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AccessAnalyzer.ListAnalyzedResourcesRequest {
         return .init(
             analyzerArn: self.analyzerArn, 
@@ -40,7 +40,7 @@ extension AccessAnalyzer.ListAnalyzedResourcesRequest: AWSPaginateStringToken {
     }
 }
 
-extension AccessAnalyzer.ListAnalyzersRequest: AWSPaginateStringToken {
+extension AccessAnalyzer.ListAnalyzersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AccessAnalyzer.ListAnalyzersRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -51,7 +51,7 @@ extension AccessAnalyzer.ListAnalyzersRequest: AWSPaginateStringToken {
     }
 }
 
-extension AccessAnalyzer.ListArchiveRulesRequest: AWSPaginateStringToken {
+extension AccessAnalyzer.ListArchiveRulesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AccessAnalyzer.ListArchiveRulesRequest {
         return .init(
             analyzerName: self.analyzerName, 
@@ -62,7 +62,7 @@ extension AccessAnalyzer.ListArchiveRulesRequest: AWSPaginateStringToken {
     }
 }
 
-extension AccessAnalyzer.ListFindingsRequest: AWSPaginateStringToken {
+extension AccessAnalyzer.ListFindingsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AccessAnalyzer.ListFindingsRequest {
         return .init(
             analyzerArn: self.analyzerArn, 

--- a/Sources/AWSSDKSwift/Services/AlexaForBusiness/AlexaForBusiness_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/AlexaForBusiness/AlexaForBusiness_Paginator.swift
@@ -98,7 +98,7 @@ extension AlexaForBusiness {
 
 }
 
-extension AlexaForBusiness.ListBusinessReportSchedulesRequest: AWSPaginateStringToken {
+extension AlexaForBusiness.ListBusinessReportSchedulesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AlexaForBusiness.ListBusinessReportSchedulesRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -108,7 +108,7 @@ extension AlexaForBusiness.ListBusinessReportSchedulesRequest: AWSPaginateString
     }
 }
 
-extension AlexaForBusiness.ListConferenceProvidersRequest: AWSPaginateStringToken {
+extension AlexaForBusiness.ListConferenceProvidersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AlexaForBusiness.ListConferenceProvidersRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -118,7 +118,7 @@ extension AlexaForBusiness.ListConferenceProvidersRequest: AWSPaginateStringToke
     }
 }
 
-extension AlexaForBusiness.ListDeviceEventsRequest: AWSPaginateStringToken {
+extension AlexaForBusiness.ListDeviceEventsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AlexaForBusiness.ListDeviceEventsRequest {
         return .init(
             deviceArn: self.deviceArn, 
@@ -130,7 +130,7 @@ extension AlexaForBusiness.ListDeviceEventsRequest: AWSPaginateStringToken {
     }
 }
 
-extension AlexaForBusiness.ListGatewayGroupsRequest: AWSPaginateStringToken {
+extension AlexaForBusiness.ListGatewayGroupsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AlexaForBusiness.ListGatewayGroupsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -140,7 +140,7 @@ extension AlexaForBusiness.ListGatewayGroupsRequest: AWSPaginateStringToken {
     }
 }
 
-extension AlexaForBusiness.ListGatewaysRequest: AWSPaginateStringToken {
+extension AlexaForBusiness.ListGatewaysRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AlexaForBusiness.ListGatewaysRequest {
         return .init(
             gatewayGroupArn: self.gatewayGroupArn, 
@@ -151,7 +151,7 @@ extension AlexaForBusiness.ListGatewaysRequest: AWSPaginateStringToken {
     }
 }
 
-extension AlexaForBusiness.ListSkillsRequest: AWSPaginateStringToken {
+extension AlexaForBusiness.ListSkillsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AlexaForBusiness.ListSkillsRequest {
         return .init(
             enablementType: self.enablementType, 
@@ -164,7 +164,7 @@ extension AlexaForBusiness.ListSkillsRequest: AWSPaginateStringToken {
     }
 }
 
-extension AlexaForBusiness.ListSkillsStoreCategoriesRequest: AWSPaginateStringToken {
+extension AlexaForBusiness.ListSkillsStoreCategoriesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AlexaForBusiness.ListSkillsStoreCategoriesRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -174,7 +174,7 @@ extension AlexaForBusiness.ListSkillsStoreCategoriesRequest: AWSPaginateStringTo
     }
 }
 
-extension AlexaForBusiness.ListSkillsStoreSkillsByCategoryRequest: AWSPaginateStringToken {
+extension AlexaForBusiness.ListSkillsStoreSkillsByCategoryRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AlexaForBusiness.ListSkillsStoreSkillsByCategoryRequest {
         return .init(
             categoryId: self.categoryId, 
@@ -185,7 +185,7 @@ extension AlexaForBusiness.ListSkillsStoreSkillsByCategoryRequest: AWSPaginateSt
     }
 }
 
-extension AlexaForBusiness.ListSmartHomeAppliancesRequest: AWSPaginateStringToken {
+extension AlexaForBusiness.ListSmartHomeAppliancesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AlexaForBusiness.ListSmartHomeAppliancesRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -196,7 +196,7 @@ extension AlexaForBusiness.ListSmartHomeAppliancesRequest: AWSPaginateStringToke
     }
 }
 
-extension AlexaForBusiness.ListTagsRequest: AWSPaginateStringToken {
+extension AlexaForBusiness.ListTagsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AlexaForBusiness.ListTagsRequest {
         return .init(
             arn: self.arn, 
@@ -207,7 +207,7 @@ extension AlexaForBusiness.ListTagsRequest: AWSPaginateStringToken {
     }
 }
 
-extension AlexaForBusiness.SearchAddressBooksRequest: AWSPaginateStringToken {
+extension AlexaForBusiness.SearchAddressBooksRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AlexaForBusiness.SearchAddressBooksRequest {
         return .init(
             filters: self.filters, 
@@ -219,7 +219,7 @@ extension AlexaForBusiness.SearchAddressBooksRequest: AWSPaginateStringToken {
     }
 }
 
-extension AlexaForBusiness.SearchContactsRequest: AWSPaginateStringToken {
+extension AlexaForBusiness.SearchContactsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AlexaForBusiness.SearchContactsRequest {
         return .init(
             filters: self.filters, 
@@ -231,7 +231,7 @@ extension AlexaForBusiness.SearchContactsRequest: AWSPaginateStringToken {
     }
 }
 
-extension AlexaForBusiness.SearchDevicesRequest: AWSPaginateStringToken {
+extension AlexaForBusiness.SearchDevicesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AlexaForBusiness.SearchDevicesRequest {
         return .init(
             filters: self.filters, 
@@ -243,7 +243,7 @@ extension AlexaForBusiness.SearchDevicesRequest: AWSPaginateStringToken {
     }
 }
 
-extension AlexaForBusiness.SearchNetworkProfilesRequest: AWSPaginateStringToken {
+extension AlexaForBusiness.SearchNetworkProfilesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AlexaForBusiness.SearchNetworkProfilesRequest {
         return .init(
             filters: self.filters, 
@@ -255,7 +255,7 @@ extension AlexaForBusiness.SearchNetworkProfilesRequest: AWSPaginateStringToken 
     }
 }
 
-extension AlexaForBusiness.SearchProfilesRequest: AWSPaginateStringToken {
+extension AlexaForBusiness.SearchProfilesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AlexaForBusiness.SearchProfilesRequest {
         return .init(
             filters: self.filters, 
@@ -267,7 +267,7 @@ extension AlexaForBusiness.SearchProfilesRequest: AWSPaginateStringToken {
     }
 }
 
-extension AlexaForBusiness.SearchRoomsRequest: AWSPaginateStringToken {
+extension AlexaForBusiness.SearchRoomsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AlexaForBusiness.SearchRoomsRequest {
         return .init(
             filters: self.filters, 
@@ -279,7 +279,7 @@ extension AlexaForBusiness.SearchRoomsRequest: AWSPaginateStringToken {
     }
 }
 
-extension AlexaForBusiness.SearchSkillGroupsRequest: AWSPaginateStringToken {
+extension AlexaForBusiness.SearchSkillGroupsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AlexaForBusiness.SearchSkillGroupsRequest {
         return .init(
             filters: self.filters, 
@@ -291,7 +291,7 @@ extension AlexaForBusiness.SearchSkillGroupsRequest: AWSPaginateStringToken {
     }
 }
 
-extension AlexaForBusiness.SearchUsersRequest: AWSPaginateStringToken {
+extension AlexaForBusiness.SearchUsersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AlexaForBusiness.SearchUsersRequest {
         return .init(
             filters: self.filters, 

--- a/Sources/AWSSDKSwift/Services/AppConfig/AppConfig_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/AppConfig/AppConfig_Paginator.swift
@@ -33,7 +33,7 @@ extension AppConfig {
 
 }
 
-extension AppConfig.ListApplicationsRequest: AWSPaginateStringToken {
+extension AppConfig.ListApplicationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AppConfig.ListApplicationsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -43,7 +43,7 @@ extension AppConfig.ListApplicationsRequest: AWSPaginateStringToken {
     }
 }
 
-extension AppConfig.ListConfigurationProfilesRequest: AWSPaginateStringToken {
+extension AppConfig.ListConfigurationProfilesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AppConfig.ListConfigurationProfilesRequest {
         return .init(
             applicationId: self.applicationId, 
@@ -54,7 +54,7 @@ extension AppConfig.ListConfigurationProfilesRequest: AWSPaginateStringToken {
     }
 }
 
-extension AppConfig.ListDeploymentStrategiesRequest: AWSPaginateStringToken {
+extension AppConfig.ListDeploymentStrategiesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AppConfig.ListDeploymentStrategiesRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -64,7 +64,7 @@ extension AppConfig.ListDeploymentStrategiesRequest: AWSPaginateStringToken {
     }
 }
 
-extension AppConfig.ListDeploymentsRequest: AWSPaginateStringToken {
+extension AppConfig.ListDeploymentsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AppConfig.ListDeploymentsRequest {
         return .init(
             applicationId: self.applicationId, 
@@ -76,7 +76,7 @@ extension AppConfig.ListDeploymentsRequest: AWSPaginateStringToken {
     }
 }
 
-extension AppConfig.ListEnvironmentsRequest: AWSPaginateStringToken {
+extension AppConfig.ListEnvironmentsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AppConfig.ListEnvironmentsRequest {
         return .init(
             applicationId: self.applicationId, 

--- a/Sources/AWSSDKSwift/Services/AppMesh/AppMesh_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/AppMesh/AppMesh_Paginator.swift
@@ -38,7 +38,7 @@ extension AppMesh {
 
 }
 
-extension AppMesh.ListMeshesInput: AWSPaginateStringToken {
+extension AppMesh.ListMeshesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AppMesh.ListMeshesInput {
         return .init(
             limit: self.limit, 
@@ -48,7 +48,7 @@ extension AppMesh.ListMeshesInput: AWSPaginateStringToken {
     }
 }
 
-extension AppMesh.ListRoutesInput: AWSPaginateStringToken {
+extension AppMesh.ListRoutesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AppMesh.ListRoutesInput {
         return .init(
             limit: self.limit, 
@@ -61,7 +61,7 @@ extension AppMesh.ListRoutesInput: AWSPaginateStringToken {
     }
 }
 
-extension AppMesh.ListTagsForResourceInput: AWSPaginateStringToken {
+extension AppMesh.ListTagsForResourceInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AppMesh.ListTagsForResourceInput {
         return .init(
             limit: self.limit, 
@@ -72,7 +72,7 @@ extension AppMesh.ListTagsForResourceInput: AWSPaginateStringToken {
     }
 }
 
-extension AppMesh.ListVirtualNodesInput: AWSPaginateStringToken {
+extension AppMesh.ListVirtualNodesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AppMesh.ListVirtualNodesInput {
         return .init(
             limit: self.limit, 
@@ -84,7 +84,7 @@ extension AppMesh.ListVirtualNodesInput: AWSPaginateStringToken {
     }
 }
 
-extension AppMesh.ListVirtualRoutersInput: AWSPaginateStringToken {
+extension AppMesh.ListVirtualRoutersInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AppMesh.ListVirtualRoutersInput {
         return .init(
             limit: self.limit, 
@@ -96,7 +96,7 @@ extension AppMesh.ListVirtualRoutersInput: AWSPaginateStringToken {
     }
 }
 
-extension AppMesh.ListVirtualServicesInput: AWSPaginateStringToken {
+extension AppMesh.ListVirtualServicesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AppMesh.ListVirtualServicesInput {
         return .init(
             limit: self.limit, 

--- a/Sources/AWSSDKSwift/Services/AppStream/AppStream_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/AppStream/AppStream_Paginator.swift
@@ -18,7 +18,7 @@ extension AppStream {
 
 }
 
-extension AppStream.DescribeImagePermissionsRequest: AWSPaginateStringToken {
+extension AppStream.DescribeImagePermissionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AppStream.DescribeImagePermissionsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -30,7 +30,7 @@ extension AppStream.DescribeImagePermissionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension AppStream.DescribeImagesRequest: AWSPaginateStringToken {
+extension AppStream.DescribeImagesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AppStream.DescribeImagesRequest {
         return .init(
             arns: self.arns, 

--- a/Sources/AWSSDKSwift/Services/ApplicationAutoScaling/ApplicationAutoScaling_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/ApplicationAutoScaling/ApplicationAutoScaling_Paginator.swift
@@ -28,7 +28,7 @@ extension ApplicationAutoScaling {
 
 }
 
-extension ApplicationAutoScaling.DescribeScalableTargetsRequest: AWSPaginateStringToken {
+extension ApplicationAutoScaling.DescribeScalableTargetsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ApplicationAutoScaling.DescribeScalableTargetsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -41,7 +41,7 @@ extension ApplicationAutoScaling.DescribeScalableTargetsRequest: AWSPaginateStri
     }
 }
 
-extension ApplicationAutoScaling.DescribeScalingActivitiesRequest: AWSPaginateStringToken {
+extension ApplicationAutoScaling.DescribeScalingActivitiesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ApplicationAutoScaling.DescribeScalingActivitiesRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -54,7 +54,7 @@ extension ApplicationAutoScaling.DescribeScalingActivitiesRequest: AWSPaginateSt
     }
 }
 
-extension ApplicationAutoScaling.DescribeScalingPoliciesRequest: AWSPaginateStringToken {
+extension ApplicationAutoScaling.DescribeScalingPoliciesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ApplicationAutoScaling.DescribeScalingPoliciesRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -68,7 +68,7 @@ extension ApplicationAutoScaling.DescribeScalingPoliciesRequest: AWSPaginateStri
     }
 }
 
-extension ApplicationAutoScaling.DescribeScheduledActionsRequest: AWSPaginateStringToken {
+extension ApplicationAutoScaling.DescribeScheduledActionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ApplicationAutoScaling.DescribeScheduledActionsRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/ApplicationDiscoveryService/ApplicationDiscoveryService_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/ApplicationDiscoveryService/ApplicationDiscoveryService_Paginator.swift
@@ -18,7 +18,7 @@ extension ApplicationDiscoveryService {
 
 }
 
-extension ApplicationDiscoveryService.DescribeContinuousExportsRequest: AWSPaginateStringToken {
+extension ApplicationDiscoveryService.DescribeContinuousExportsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ApplicationDiscoveryService.DescribeContinuousExportsRequest {
         return .init(
             exportIds: self.exportIds, 
@@ -29,7 +29,7 @@ extension ApplicationDiscoveryService.DescribeContinuousExportsRequest: AWSPagin
     }
 }
 
-extension ApplicationDiscoveryService.DescribeImportTasksRequest: AWSPaginateStringToken {
+extension ApplicationDiscoveryService.DescribeImportTasksRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ApplicationDiscoveryService.DescribeImportTasksRequest {
         return .init(
             filters: self.filters, 

--- a/Sources/AWSSDKSwift/Services/ApplicationInsights/ApplicationInsights_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/ApplicationInsights/ApplicationInsights_Paginator.swift
@@ -38,7 +38,7 @@ extension ApplicationInsights {
 
 }
 
-extension ApplicationInsights.ListApplicationsRequest: AWSPaginateStringToken {
+extension ApplicationInsights.ListApplicationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ApplicationInsights.ListApplicationsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -48,7 +48,7 @@ extension ApplicationInsights.ListApplicationsRequest: AWSPaginateStringToken {
     }
 }
 
-extension ApplicationInsights.ListComponentsRequest: AWSPaginateStringToken {
+extension ApplicationInsights.ListComponentsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ApplicationInsights.ListComponentsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -59,7 +59,7 @@ extension ApplicationInsights.ListComponentsRequest: AWSPaginateStringToken {
     }
 }
 
-extension ApplicationInsights.ListConfigurationHistoryRequest: AWSPaginateStringToken {
+extension ApplicationInsights.ListConfigurationHistoryRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ApplicationInsights.ListConfigurationHistoryRequest {
         return .init(
             endTime: self.endTime, 
@@ -73,7 +73,7 @@ extension ApplicationInsights.ListConfigurationHistoryRequest: AWSPaginateString
     }
 }
 
-extension ApplicationInsights.ListLogPatternSetsRequest: AWSPaginateStringToken {
+extension ApplicationInsights.ListLogPatternSetsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ApplicationInsights.ListLogPatternSetsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -84,7 +84,7 @@ extension ApplicationInsights.ListLogPatternSetsRequest: AWSPaginateStringToken 
     }
 }
 
-extension ApplicationInsights.ListLogPatternsRequest: AWSPaginateStringToken {
+extension ApplicationInsights.ListLogPatternsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ApplicationInsights.ListLogPatternsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -96,7 +96,7 @@ extension ApplicationInsights.ListLogPatternsRequest: AWSPaginateStringToken {
     }
 }
 
-extension ApplicationInsights.ListProblemsRequest: AWSPaginateStringToken {
+extension ApplicationInsights.ListProblemsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ApplicationInsights.ListProblemsRequest {
         return .init(
             endTime: self.endTime, 

--- a/Sources/AWSSDKSwift/Services/Athena/Athena_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Athena/Athena_Paginator.swift
@@ -28,7 +28,7 @@ extension Athena {
 
 }
 
-extension Athena.GetQueryResultsInput: AWSPaginateStringToken {
+extension Athena.GetQueryResultsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Athena.GetQueryResultsInput {
         return .init(
             maxResults: self.maxResults, 
@@ -39,7 +39,7 @@ extension Athena.GetQueryResultsInput: AWSPaginateStringToken {
     }
 }
 
-extension Athena.ListNamedQueriesInput: AWSPaginateStringToken {
+extension Athena.ListNamedQueriesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Athena.ListNamedQueriesInput {
         return .init(
             maxResults: self.maxResults, 
@@ -50,7 +50,7 @@ extension Athena.ListNamedQueriesInput: AWSPaginateStringToken {
     }
 }
 
-extension Athena.ListQueryExecutionsInput: AWSPaginateStringToken {
+extension Athena.ListQueryExecutionsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Athena.ListQueryExecutionsInput {
         return .init(
             maxResults: self.maxResults, 
@@ -61,7 +61,7 @@ extension Athena.ListQueryExecutionsInput: AWSPaginateStringToken {
     }
 }
 
-extension Athena.ListWorkGroupsInput: AWSPaginateStringToken {
+extension Athena.ListWorkGroupsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Athena.ListWorkGroupsInput {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/AugmentedAIRuntime/AugmentedAIRuntime_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/AugmentedAIRuntime/AugmentedAIRuntime_Paginator.swift
@@ -13,7 +13,7 @@ extension AugmentedAIRuntime {
 
 }
 
-extension AugmentedAIRuntime.ListHumanLoopsRequest: AWSPaginateStringToken {
+extension AugmentedAIRuntime.ListHumanLoopsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AugmentedAIRuntime.ListHumanLoopsRequest {
         return .init(
             creationTimeAfter: self.creationTimeAfter, 

--- a/Sources/AWSSDKSwift/Services/AutoScaling/AutoScaling_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/AutoScaling/AutoScaling_Paginator.swift
@@ -48,7 +48,7 @@ extension AutoScaling {
 
 }
 
-extension AutoScaling.AutoScalingGroupNamesType: AWSPaginateStringToken {
+extension AutoScaling.AutoScalingGroupNamesType: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AutoScaling.AutoScalingGroupNamesType {
         return .init(
             autoScalingGroupNames: self.autoScalingGroupNames, 
@@ -59,7 +59,7 @@ extension AutoScaling.AutoScalingGroupNamesType: AWSPaginateStringToken {
     }
 }
 
-extension AutoScaling.DescribeAutoScalingInstancesType: AWSPaginateStringToken {
+extension AutoScaling.DescribeAutoScalingInstancesType: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AutoScaling.DescribeAutoScalingInstancesType {
         return .init(
             instanceIds: self.instanceIds, 
@@ -70,7 +70,7 @@ extension AutoScaling.DescribeAutoScalingInstancesType: AWSPaginateStringToken {
     }
 }
 
-extension AutoScaling.LaunchConfigurationNamesType: AWSPaginateStringToken {
+extension AutoScaling.LaunchConfigurationNamesType: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AutoScaling.LaunchConfigurationNamesType {
         return .init(
             launchConfigurationNames: self.launchConfigurationNames, 
@@ -81,7 +81,7 @@ extension AutoScaling.LaunchConfigurationNamesType: AWSPaginateStringToken {
     }
 }
 
-extension AutoScaling.DescribeNotificationConfigurationsType: AWSPaginateStringToken {
+extension AutoScaling.DescribeNotificationConfigurationsType: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AutoScaling.DescribeNotificationConfigurationsType {
         return .init(
             autoScalingGroupNames: self.autoScalingGroupNames, 
@@ -92,7 +92,7 @@ extension AutoScaling.DescribeNotificationConfigurationsType: AWSPaginateStringT
     }
 }
 
-extension AutoScaling.DescribePoliciesType: AWSPaginateStringToken {
+extension AutoScaling.DescribePoliciesType: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AutoScaling.DescribePoliciesType {
         return .init(
             autoScalingGroupName: self.autoScalingGroupName, 
@@ -105,7 +105,7 @@ extension AutoScaling.DescribePoliciesType: AWSPaginateStringToken {
     }
 }
 
-extension AutoScaling.DescribeScalingActivitiesType: AWSPaginateStringToken {
+extension AutoScaling.DescribeScalingActivitiesType: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AutoScaling.DescribeScalingActivitiesType {
         return .init(
             activityIds: self.activityIds, 
@@ -117,7 +117,7 @@ extension AutoScaling.DescribeScalingActivitiesType: AWSPaginateStringToken {
     }
 }
 
-extension AutoScaling.DescribeScheduledActionsType: AWSPaginateStringToken {
+extension AutoScaling.DescribeScheduledActionsType: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AutoScaling.DescribeScheduledActionsType {
         return .init(
             autoScalingGroupName: self.autoScalingGroupName, 
@@ -131,7 +131,7 @@ extension AutoScaling.DescribeScheduledActionsType: AWSPaginateStringToken {
     }
 }
 
-extension AutoScaling.DescribeTagsType: AWSPaginateStringToken {
+extension AutoScaling.DescribeTagsType: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> AutoScaling.DescribeTagsType {
         return .init(
             filters: self.filters, 

--- a/Sources/AWSSDKSwift/Services/Backup/Backup_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Backup/Backup_Paginator.swift
@@ -68,7 +68,7 @@ extension Backup {
 
 }
 
-extension Backup.ListBackupJobsInput: AWSPaginateStringToken {
+extension Backup.ListBackupJobsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Backup.ListBackupJobsInput {
         return .init(
             byBackupVaultName: self.byBackupVaultName, 
@@ -84,7 +84,7 @@ extension Backup.ListBackupJobsInput: AWSPaginateStringToken {
     }
 }
 
-extension Backup.ListBackupPlanTemplatesInput: AWSPaginateStringToken {
+extension Backup.ListBackupPlanTemplatesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Backup.ListBackupPlanTemplatesInput {
         return .init(
             maxResults: self.maxResults, 
@@ -94,7 +94,7 @@ extension Backup.ListBackupPlanTemplatesInput: AWSPaginateStringToken {
     }
 }
 
-extension Backup.ListBackupPlanVersionsInput: AWSPaginateStringToken {
+extension Backup.ListBackupPlanVersionsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Backup.ListBackupPlanVersionsInput {
         return .init(
             backupPlanId: self.backupPlanId, 
@@ -105,7 +105,7 @@ extension Backup.ListBackupPlanVersionsInput: AWSPaginateStringToken {
     }
 }
 
-extension Backup.ListBackupPlansInput: AWSPaginateStringToken {
+extension Backup.ListBackupPlansInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Backup.ListBackupPlansInput {
         return .init(
             includeDeleted: self.includeDeleted, 
@@ -116,7 +116,7 @@ extension Backup.ListBackupPlansInput: AWSPaginateStringToken {
     }
 }
 
-extension Backup.ListBackupSelectionsInput: AWSPaginateStringToken {
+extension Backup.ListBackupSelectionsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Backup.ListBackupSelectionsInput {
         return .init(
             backupPlanId: self.backupPlanId, 
@@ -127,7 +127,7 @@ extension Backup.ListBackupSelectionsInput: AWSPaginateStringToken {
     }
 }
 
-extension Backup.ListBackupVaultsInput: AWSPaginateStringToken {
+extension Backup.ListBackupVaultsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Backup.ListBackupVaultsInput {
         return .init(
             maxResults: self.maxResults, 
@@ -137,7 +137,7 @@ extension Backup.ListBackupVaultsInput: AWSPaginateStringToken {
     }
 }
 
-extension Backup.ListCopyJobsInput: AWSPaginateStringToken {
+extension Backup.ListCopyJobsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Backup.ListCopyJobsInput {
         return .init(
             byCreatedAfter: self.byCreatedAfter, 
@@ -153,7 +153,7 @@ extension Backup.ListCopyJobsInput: AWSPaginateStringToken {
     }
 }
 
-extension Backup.ListProtectedResourcesInput: AWSPaginateStringToken {
+extension Backup.ListProtectedResourcesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Backup.ListProtectedResourcesInput {
         return .init(
             maxResults: self.maxResults, 
@@ -163,7 +163,7 @@ extension Backup.ListProtectedResourcesInput: AWSPaginateStringToken {
     }
 }
 
-extension Backup.ListRecoveryPointsByBackupVaultInput: AWSPaginateStringToken {
+extension Backup.ListRecoveryPointsByBackupVaultInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Backup.ListRecoveryPointsByBackupVaultInput {
         return .init(
             backupVaultName: self.backupVaultName, 
@@ -179,7 +179,7 @@ extension Backup.ListRecoveryPointsByBackupVaultInput: AWSPaginateStringToken {
     }
 }
 
-extension Backup.ListRecoveryPointsByResourceInput: AWSPaginateStringToken {
+extension Backup.ListRecoveryPointsByResourceInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Backup.ListRecoveryPointsByResourceInput {
         return .init(
             maxResults: self.maxResults, 
@@ -190,7 +190,7 @@ extension Backup.ListRecoveryPointsByResourceInput: AWSPaginateStringToken {
     }
 }
 
-extension Backup.ListRestoreJobsInput: AWSPaginateStringToken {
+extension Backup.ListRestoreJobsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Backup.ListRestoreJobsInput {
         return .init(
             maxResults: self.maxResults, 
@@ -200,7 +200,7 @@ extension Backup.ListRestoreJobsInput: AWSPaginateStringToken {
     }
 }
 
-extension Backup.ListTagsInput: AWSPaginateStringToken {
+extension Backup.ListTagsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Backup.ListTagsInput {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/Batch/Batch_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Batch/Batch_Paginator.swift
@@ -28,7 +28,7 @@ extension Batch {
 
 }
 
-extension Batch.DescribeComputeEnvironmentsRequest: AWSPaginateStringToken {
+extension Batch.DescribeComputeEnvironmentsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Batch.DescribeComputeEnvironmentsRequest {
         return .init(
             computeEnvironments: self.computeEnvironments, 
@@ -39,7 +39,7 @@ extension Batch.DescribeComputeEnvironmentsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Batch.DescribeJobDefinitionsRequest: AWSPaginateStringToken {
+extension Batch.DescribeJobDefinitionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Batch.DescribeJobDefinitionsRequest {
         return .init(
             jobDefinitionName: self.jobDefinitionName, 
@@ -52,7 +52,7 @@ extension Batch.DescribeJobDefinitionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Batch.DescribeJobQueuesRequest: AWSPaginateStringToken {
+extension Batch.DescribeJobQueuesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Batch.DescribeJobQueuesRequest {
         return .init(
             jobQueues: self.jobQueues, 
@@ -63,7 +63,7 @@ extension Batch.DescribeJobQueuesRequest: AWSPaginateStringToken {
     }
 }
 
-extension Batch.ListJobsRequest: AWSPaginateStringToken {
+extension Batch.ListJobsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Batch.ListJobsRequest {
         return .init(
             arrayJobId: self.arrayJobId, 

--- a/Sources/AWSSDKSwift/Services/Chime/Chime_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Chime/Chime_Paginator.swift
@@ -63,7 +63,7 @@ extension Chime {
 
 }
 
-extension Chime.ListAccountsRequest: AWSPaginateStringToken {
+extension Chime.ListAccountsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Chime.ListAccountsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -75,7 +75,7 @@ extension Chime.ListAccountsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Chime.ListAttendeesRequest: AWSPaginateStringToken {
+extension Chime.ListAttendeesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Chime.ListAttendeesRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -86,7 +86,7 @@ extension Chime.ListAttendeesRequest: AWSPaginateStringToken {
     }
 }
 
-extension Chime.ListBotsRequest: AWSPaginateStringToken {
+extension Chime.ListBotsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Chime.ListBotsRequest {
         return .init(
             accountId: self.accountId, 
@@ -97,7 +97,7 @@ extension Chime.ListBotsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Chime.ListMeetingsRequest: AWSPaginateStringToken {
+extension Chime.ListMeetingsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Chime.ListMeetingsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -107,7 +107,7 @@ extension Chime.ListMeetingsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Chime.ListPhoneNumberOrdersRequest: AWSPaginateStringToken {
+extension Chime.ListPhoneNumberOrdersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Chime.ListPhoneNumberOrdersRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -117,7 +117,7 @@ extension Chime.ListPhoneNumberOrdersRequest: AWSPaginateStringToken {
     }
 }
 
-extension Chime.ListPhoneNumbersRequest: AWSPaginateStringToken {
+extension Chime.ListPhoneNumbersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Chime.ListPhoneNumbersRequest {
         return .init(
             filterName: self.filterName, 
@@ -131,7 +131,7 @@ extension Chime.ListPhoneNumbersRequest: AWSPaginateStringToken {
     }
 }
 
-extension Chime.ListRoomMembershipsRequest: AWSPaginateStringToken {
+extension Chime.ListRoomMembershipsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Chime.ListRoomMembershipsRequest {
         return .init(
             accountId: self.accountId, 
@@ -143,7 +143,7 @@ extension Chime.ListRoomMembershipsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Chime.ListRoomsRequest: AWSPaginateStringToken {
+extension Chime.ListRoomsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Chime.ListRoomsRequest {
         return .init(
             accountId: self.accountId, 
@@ -155,7 +155,7 @@ extension Chime.ListRoomsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Chime.ListUsersRequest: AWSPaginateStringToken {
+extension Chime.ListUsersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Chime.ListUsersRequest {
         return .init(
             accountId: self.accountId, 
@@ -168,7 +168,7 @@ extension Chime.ListUsersRequest: AWSPaginateStringToken {
     }
 }
 
-extension Chime.ListVoiceConnectorGroupsRequest: AWSPaginateStringToken {
+extension Chime.ListVoiceConnectorGroupsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Chime.ListVoiceConnectorGroupsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -178,7 +178,7 @@ extension Chime.ListVoiceConnectorGroupsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Chime.ListVoiceConnectorsRequest: AWSPaginateStringToken {
+extension Chime.ListVoiceConnectorsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Chime.ListVoiceConnectorsRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/Cloud9/Cloud9_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Cloud9/Cloud9_Paginator.swift
@@ -18,7 +18,7 @@ extension Cloud9 {
 
 }
 
-extension Cloud9.DescribeEnvironmentMembershipsRequest: AWSPaginateStringToken {
+extension Cloud9.DescribeEnvironmentMembershipsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Cloud9.DescribeEnvironmentMembershipsRequest {
         return .init(
             environmentId: self.environmentId, 
@@ -31,7 +31,7 @@ extension Cloud9.DescribeEnvironmentMembershipsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Cloud9.ListEnvironmentsRequest: AWSPaginateStringToken {
+extension Cloud9.ListEnvironmentsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Cloud9.ListEnvironmentsRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/CloudDirectory/CloudDirectory_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/CloudDirectory/CloudDirectory_Paginator.swift
@@ -103,7 +103,7 @@ extension CloudDirectory {
 
 }
 
-extension CloudDirectory.ListAppliedSchemaArnsRequest: AWSPaginateStringToken {
+extension CloudDirectory.ListAppliedSchemaArnsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudDirectory.ListAppliedSchemaArnsRequest {
         return .init(
             directoryArn: self.directoryArn, 
@@ -115,7 +115,7 @@ extension CloudDirectory.ListAppliedSchemaArnsRequest: AWSPaginateStringToken {
     }
 }
 
-extension CloudDirectory.ListAttachedIndicesRequest: AWSPaginateStringToken {
+extension CloudDirectory.ListAttachedIndicesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudDirectory.ListAttachedIndicesRequest {
         return .init(
             consistencyLevel: self.consistencyLevel, 
@@ -128,7 +128,7 @@ extension CloudDirectory.ListAttachedIndicesRequest: AWSPaginateStringToken {
     }
 }
 
-extension CloudDirectory.ListDevelopmentSchemaArnsRequest: AWSPaginateStringToken {
+extension CloudDirectory.ListDevelopmentSchemaArnsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudDirectory.ListDevelopmentSchemaArnsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -138,7 +138,7 @@ extension CloudDirectory.ListDevelopmentSchemaArnsRequest: AWSPaginateStringToke
     }
 }
 
-extension CloudDirectory.ListDirectoriesRequest: AWSPaginateStringToken {
+extension CloudDirectory.ListDirectoriesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudDirectory.ListDirectoriesRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -149,7 +149,7 @@ extension CloudDirectory.ListDirectoriesRequest: AWSPaginateStringToken {
     }
 }
 
-extension CloudDirectory.ListFacetAttributesRequest: AWSPaginateStringToken {
+extension CloudDirectory.ListFacetAttributesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudDirectory.ListFacetAttributesRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -161,7 +161,7 @@ extension CloudDirectory.ListFacetAttributesRequest: AWSPaginateStringToken {
     }
 }
 
-extension CloudDirectory.ListFacetNamesRequest: AWSPaginateStringToken {
+extension CloudDirectory.ListFacetNamesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudDirectory.ListFacetNamesRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -172,7 +172,7 @@ extension CloudDirectory.ListFacetNamesRequest: AWSPaginateStringToken {
     }
 }
 
-extension CloudDirectory.ListIndexRequest: AWSPaginateStringToken {
+extension CloudDirectory.ListIndexRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudDirectory.ListIndexRequest {
         return .init(
             consistencyLevel: self.consistencyLevel, 
@@ -186,7 +186,7 @@ extension CloudDirectory.ListIndexRequest: AWSPaginateStringToken {
     }
 }
 
-extension CloudDirectory.ListManagedSchemaArnsRequest: AWSPaginateStringToken {
+extension CloudDirectory.ListManagedSchemaArnsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudDirectory.ListManagedSchemaArnsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -197,7 +197,7 @@ extension CloudDirectory.ListManagedSchemaArnsRequest: AWSPaginateStringToken {
     }
 }
 
-extension CloudDirectory.ListObjectAttributesRequest: AWSPaginateStringToken {
+extension CloudDirectory.ListObjectAttributesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudDirectory.ListObjectAttributesRequest {
         return .init(
             consistencyLevel: self.consistencyLevel, 
@@ -211,7 +211,7 @@ extension CloudDirectory.ListObjectAttributesRequest: AWSPaginateStringToken {
     }
 }
 
-extension CloudDirectory.ListObjectChildrenRequest: AWSPaginateStringToken {
+extension CloudDirectory.ListObjectChildrenRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudDirectory.ListObjectChildrenRequest {
         return .init(
             consistencyLevel: self.consistencyLevel, 
@@ -224,7 +224,7 @@ extension CloudDirectory.ListObjectChildrenRequest: AWSPaginateStringToken {
     }
 }
 
-extension CloudDirectory.ListObjectParentPathsRequest: AWSPaginateStringToken {
+extension CloudDirectory.ListObjectParentPathsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudDirectory.ListObjectParentPathsRequest {
         return .init(
             directoryArn: self.directoryArn, 
@@ -236,7 +236,7 @@ extension CloudDirectory.ListObjectParentPathsRequest: AWSPaginateStringToken {
     }
 }
 
-extension CloudDirectory.ListObjectParentsRequest: AWSPaginateStringToken {
+extension CloudDirectory.ListObjectParentsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudDirectory.ListObjectParentsRequest {
         return .init(
             consistencyLevel: self.consistencyLevel, 
@@ -250,7 +250,7 @@ extension CloudDirectory.ListObjectParentsRequest: AWSPaginateStringToken {
     }
 }
 
-extension CloudDirectory.ListObjectPoliciesRequest: AWSPaginateStringToken {
+extension CloudDirectory.ListObjectPoliciesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudDirectory.ListObjectPoliciesRequest {
         return .init(
             consistencyLevel: self.consistencyLevel, 
@@ -263,7 +263,7 @@ extension CloudDirectory.ListObjectPoliciesRequest: AWSPaginateStringToken {
     }
 }
 
-extension CloudDirectory.ListPolicyAttachmentsRequest: AWSPaginateStringToken {
+extension CloudDirectory.ListPolicyAttachmentsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudDirectory.ListPolicyAttachmentsRequest {
         return .init(
             consistencyLevel: self.consistencyLevel, 
@@ -276,7 +276,7 @@ extension CloudDirectory.ListPolicyAttachmentsRequest: AWSPaginateStringToken {
     }
 }
 
-extension CloudDirectory.ListPublishedSchemaArnsRequest: AWSPaginateStringToken {
+extension CloudDirectory.ListPublishedSchemaArnsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudDirectory.ListPublishedSchemaArnsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -287,7 +287,7 @@ extension CloudDirectory.ListPublishedSchemaArnsRequest: AWSPaginateStringToken 
     }
 }
 
-extension CloudDirectory.ListTagsForResourceRequest: AWSPaginateStringToken {
+extension CloudDirectory.ListTagsForResourceRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudDirectory.ListTagsForResourceRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -298,7 +298,7 @@ extension CloudDirectory.ListTagsForResourceRequest: AWSPaginateStringToken {
     }
 }
 
-extension CloudDirectory.ListTypedLinkFacetAttributesRequest: AWSPaginateStringToken {
+extension CloudDirectory.ListTypedLinkFacetAttributesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudDirectory.ListTypedLinkFacetAttributesRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -310,7 +310,7 @@ extension CloudDirectory.ListTypedLinkFacetAttributesRequest: AWSPaginateStringT
     }
 }
 
-extension CloudDirectory.ListTypedLinkFacetNamesRequest: AWSPaginateStringToken {
+extension CloudDirectory.ListTypedLinkFacetNamesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudDirectory.ListTypedLinkFacetNamesRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -321,7 +321,7 @@ extension CloudDirectory.ListTypedLinkFacetNamesRequest: AWSPaginateStringToken 
     }
 }
 
-extension CloudDirectory.LookupPolicyRequest: AWSPaginateStringToken {
+extension CloudDirectory.LookupPolicyRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudDirectory.LookupPolicyRequest {
         return .init(
             directoryArn: self.directoryArn, 

--- a/Sources/AWSSDKSwift/Services/CloudFormation/CloudFormation_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/CloudFormation/CloudFormation_Paginator.swift
@@ -58,7 +58,7 @@ extension CloudFormation {
 
 }
 
-extension CloudFormation.DescribeStackEventsInput: AWSPaginateStringToken {
+extension CloudFormation.DescribeStackEventsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudFormation.DescribeStackEventsInput {
         return .init(
             nextToken: token, 
@@ -68,7 +68,7 @@ extension CloudFormation.DescribeStackEventsInput: AWSPaginateStringToken {
     }
 }
 
-extension CloudFormation.DescribeStackResourceDriftsInput: AWSPaginateStringToken {
+extension CloudFormation.DescribeStackResourceDriftsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudFormation.DescribeStackResourceDriftsInput {
         return .init(
             maxResults: self.maxResults, 
@@ -80,7 +80,7 @@ extension CloudFormation.DescribeStackResourceDriftsInput: AWSPaginateStringToke
     }
 }
 
-extension CloudFormation.DescribeStacksInput: AWSPaginateStringToken {
+extension CloudFormation.DescribeStacksInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudFormation.DescribeStacksInput {
         return .init(
             nextToken: token, 
@@ -90,7 +90,7 @@ extension CloudFormation.DescribeStacksInput: AWSPaginateStringToken {
     }
 }
 
-extension CloudFormation.ListExportsInput: AWSPaginateStringToken {
+extension CloudFormation.ListExportsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudFormation.ListExportsInput {
         return .init(
             nextToken: token
@@ -99,7 +99,7 @@ extension CloudFormation.ListExportsInput: AWSPaginateStringToken {
     }
 }
 
-extension CloudFormation.ListImportsInput: AWSPaginateStringToken {
+extension CloudFormation.ListImportsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudFormation.ListImportsInput {
         return .init(
             exportName: self.exportName, 
@@ -109,7 +109,7 @@ extension CloudFormation.ListImportsInput: AWSPaginateStringToken {
     }
 }
 
-extension CloudFormation.ListStackResourcesInput: AWSPaginateStringToken {
+extension CloudFormation.ListStackResourcesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudFormation.ListStackResourcesInput {
         return .init(
             nextToken: token, 
@@ -119,7 +119,7 @@ extension CloudFormation.ListStackResourcesInput: AWSPaginateStringToken {
     }
 }
 
-extension CloudFormation.ListStacksInput: AWSPaginateStringToken {
+extension CloudFormation.ListStacksInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudFormation.ListStacksInput {
         return .init(
             nextToken: token, 
@@ -129,7 +129,7 @@ extension CloudFormation.ListStacksInput: AWSPaginateStringToken {
     }
 }
 
-extension CloudFormation.ListTypeRegistrationsInput: AWSPaginateStringToken {
+extension CloudFormation.ListTypeRegistrationsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudFormation.ListTypeRegistrationsInput {
         return .init(
             maxResults: self.maxResults, 
@@ -143,7 +143,7 @@ extension CloudFormation.ListTypeRegistrationsInput: AWSPaginateStringToken {
     }
 }
 
-extension CloudFormation.ListTypeVersionsInput: AWSPaginateStringToken {
+extension CloudFormation.ListTypeVersionsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudFormation.ListTypeVersionsInput {
         return .init(
             arn: self.arn, 
@@ -157,7 +157,7 @@ extension CloudFormation.ListTypeVersionsInput: AWSPaginateStringToken {
     }
 }
 
-extension CloudFormation.ListTypesInput: AWSPaginateStringToken {
+extension CloudFormation.ListTypesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudFormation.ListTypesInput {
         return .init(
             deprecatedStatus: self.deprecatedStatus, 

--- a/Sources/AWSSDKSwift/Services/CloudFront/CloudFront_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/CloudFront/CloudFront_Paginator.swift
@@ -28,7 +28,7 @@ extension CloudFront {
 
 }
 
-extension CloudFront.ListCloudFrontOriginAccessIdentitiesRequest: AWSPaginateStringToken {
+extension CloudFront.ListCloudFrontOriginAccessIdentitiesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudFront.ListCloudFrontOriginAccessIdentitiesRequest {
         return .init(
             marker: token, 
@@ -38,7 +38,7 @@ extension CloudFront.ListCloudFrontOriginAccessIdentitiesRequest: AWSPaginateStr
     }
 }
 
-extension CloudFront.ListDistributionsRequest: AWSPaginateStringToken {
+extension CloudFront.ListDistributionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudFront.ListDistributionsRequest {
         return .init(
             marker: token, 
@@ -48,7 +48,7 @@ extension CloudFront.ListDistributionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension CloudFront.ListInvalidationsRequest: AWSPaginateStringToken {
+extension CloudFront.ListInvalidationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudFront.ListInvalidationsRequest {
         return .init(
             distributionId: self.distributionId, 
@@ -59,7 +59,7 @@ extension CloudFront.ListInvalidationsRequest: AWSPaginateStringToken {
     }
 }
 
-extension CloudFront.ListStreamingDistributionsRequest: AWSPaginateStringToken {
+extension CloudFront.ListStreamingDistributionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudFront.ListStreamingDistributionsRequest {
         return .init(
             marker: token, 

--- a/Sources/AWSSDKSwift/Services/CloudHSMV2/CloudHSMV2_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/CloudHSMV2/CloudHSMV2_Paginator.swift
@@ -23,7 +23,7 @@ extension CloudHSMV2 {
 
 }
 
-extension CloudHSMV2.DescribeBackupsRequest: AWSPaginateStringToken {
+extension CloudHSMV2.DescribeBackupsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudHSMV2.DescribeBackupsRequest {
         return .init(
             filters: self.filters, 
@@ -35,7 +35,7 @@ extension CloudHSMV2.DescribeBackupsRequest: AWSPaginateStringToken {
     }
 }
 
-extension CloudHSMV2.DescribeClustersRequest: AWSPaginateStringToken {
+extension CloudHSMV2.DescribeClustersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudHSMV2.DescribeClustersRequest {
         return .init(
             filters: self.filters, 
@@ -46,7 +46,7 @@ extension CloudHSMV2.DescribeClustersRequest: AWSPaginateStringToken {
     }
 }
 
-extension CloudHSMV2.ListTagsRequest: AWSPaginateStringToken {
+extension CloudHSMV2.ListTagsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudHSMV2.ListTagsRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/CloudTrail/CloudTrail_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/CloudTrail/CloudTrail_Paginator.swift
@@ -28,7 +28,7 @@ extension CloudTrail {
 
 }
 
-extension CloudTrail.ListPublicKeysRequest: AWSPaginateStringToken {
+extension CloudTrail.ListPublicKeysRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudTrail.ListPublicKeysRequest {
         return .init(
             endTime: self.endTime, 
@@ -39,7 +39,7 @@ extension CloudTrail.ListPublicKeysRequest: AWSPaginateStringToken {
     }
 }
 
-extension CloudTrail.ListTagsRequest: AWSPaginateStringToken {
+extension CloudTrail.ListTagsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudTrail.ListTagsRequest {
         return .init(
             nextToken: token, 
@@ -49,7 +49,7 @@ extension CloudTrail.ListTagsRequest: AWSPaginateStringToken {
     }
 }
 
-extension CloudTrail.ListTrailsRequest: AWSPaginateStringToken {
+extension CloudTrail.ListTrailsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudTrail.ListTrailsRequest {
         return .init(
             nextToken: token
@@ -58,7 +58,7 @@ extension CloudTrail.ListTrailsRequest: AWSPaginateStringToken {
     }
 }
 
-extension CloudTrail.LookupEventsRequest: AWSPaginateStringToken {
+extension CloudTrail.LookupEventsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudTrail.LookupEventsRequest {
         return .init(
             endTime: self.endTime, 

--- a/Sources/AWSSDKSwift/Services/CloudWatch/CloudWatch_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/CloudWatch/CloudWatch_Paginator.swift
@@ -38,7 +38,7 @@ extension CloudWatch {
 
 }
 
-extension CloudWatch.DescribeAlarmHistoryInput: AWSPaginateStringToken {
+extension CloudWatch.DescribeAlarmHistoryInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudWatch.DescribeAlarmHistoryInput {
         return .init(
             alarmName: self.alarmName, 
@@ -54,7 +54,7 @@ extension CloudWatch.DescribeAlarmHistoryInput: AWSPaginateStringToken {
     }
 }
 
-extension CloudWatch.DescribeAlarmsInput: AWSPaginateStringToken {
+extension CloudWatch.DescribeAlarmsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudWatch.DescribeAlarmsInput {
         return .init(
             actionPrefix: self.actionPrefix, 
@@ -71,7 +71,7 @@ extension CloudWatch.DescribeAlarmsInput: AWSPaginateStringToken {
     }
 }
 
-extension CloudWatch.DescribeInsightRulesInput: AWSPaginateStringToken {
+extension CloudWatch.DescribeInsightRulesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudWatch.DescribeInsightRulesInput {
         return .init(
             maxResults: self.maxResults, 
@@ -81,7 +81,7 @@ extension CloudWatch.DescribeInsightRulesInput: AWSPaginateStringToken {
     }
 }
 
-extension CloudWatch.GetMetricDataInput: AWSPaginateStringToken {
+extension CloudWatch.GetMetricDataInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudWatch.GetMetricDataInput {
         return .init(
             endTime: self.endTime, 
@@ -95,7 +95,7 @@ extension CloudWatch.GetMetricDataInput: AWSPaginateStringToken {
     }
 }
 
-extension CloudWatch.ListDashboardsInput: AWSPaginateStringToken {
+extension CloudWatch.ListDashboardsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudWatch.ListDashboardsInput {
         return .init(
             dashboardNamePrefix: self.dashboardNamePrefix, 
@@ -105,7 +105,7 @@ extension CloudWatch.ListDashboardsInput: AWSPaginateStringToken {
     }
 }
 
-extension CloudWatch.ListMetricsInput: AWSPaginateStringToken {
+extension CloudWatch.ListMetricsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudWatch.ListMetricsInput {
         return .init(
             dimensions: self.dimensions, 

--- a/Sources/AWSSDKSwift/Services/CloudWatchLogs/CloudWatchLogs_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/CloudWatchLogs/CloudWatchLogs_Paginator.swift
@@ -43,7 +43,7 @@ extension CloudWatchLogs {
 
 }
 
-extension CloudWatchLogs.DescribeDestinationsRequest: AWSPaginateStringToken {
+extension CloudWatchLogs.DescribeDestinationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudWatchLogs.DescribeDestinationsRequest {
         return .init(
             destinationNamePrefix: self.destinationNamePrefix, 
@@ -54,7 +54,7 @@ extension CloudWatchLogs.DescribeDestinationsRequest: AWSPaginateStringToken {
     }
 }
 
-extension CloudWatchLogs.DescribeLogGroupsRequest: AWSPaginateStringToken {
+extension CloudWatchLogs.DescribeLogGroupsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudWatchLogs.DescribeLogGroupsRequest {
         return .init(
             limit: self.limit, 
@@ -65,7 +65,7 @@ extension CloudWatchLogs.DescribeLogGroupsRequest: AWSPaginateStringToken {
     }
 }
 
-extension CloudWatchLogs.DescribeLogStreamsRequest: AWSPaginateStringToken {
+extension CloudWatchLogs.DescribeLogStreamsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudWatchLogs.DescribeLogStreamsRequest {
         return .init(
             descending: self.descending, 
@@ -79,7 +79,7 @@ extension CloudWatchLogs.DescribeLogStreamsRequest: AWSPaginateStringToken {
     }
 }
 
-extension CloudWatchLogs.DescribeMetricFiltersRequest: AWSPaginateStringToken {
+extension CloudWatchLogs.DescribeMetricFiltersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudWatchLogs.DescribeMetricFiltersRequest {
         return .init(
             filterNamePrefix: self.filterNamePrefix, 
@@ -93,7 +93,7 @@ extension CloudWatchLogs.DescribeMetricFiltersRequest: AWSPaginateStringToken {
     }
 }
 
-extension CloudWatchLogs.DescribeSubscriptionFiltersRequest: AWSPaginateStringToken {
+extension CloudWatchLogs.DescribeSubscriptionFiltersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudWatchLogs.DescribeSubscriptionFiltersRequest {
         return .init(
             filterNamePrefix: self.filterNamePrefix, 
@@ -105,7 +105,7 @@ extension CloudWatchLogs.DescribeSubscriptionFiltersRequest: AWSPaginateStringTo
     }
 }
 
-extension CloudWatchLogs.FilterLogEventsRequest: AWSPaginateStringToken {
+extension CloudWatchLogs.FilterLogEventsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudWatchLogs.FilterLogEventsRequest {
         return .init(
             endTime: self.endTime, 
@@ -121,7 +121,7 @@ extension CloudWatchLogs.FilterLogEventsRequest: AWSPaginateStringToken {
     }
 }
 
-extension CloudWatchLogs.GetLogEventsRequest: AWSPaginateStringToken {
+extension CloudWatchLogs.GetLogEventsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CloudWatchLogs.GetLogEventsRequest {
         return .init(
             endTime: self.endTime, 

--- a/Sources/AWSSDKSwift/Services/CodeCommit/CodeCommit_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/CodeCommit/CodeCommit_Paginator.swift
@@ -68,7 +68,7 @@ extension CodeCommit {
 
 }
 
-extension CodeCommit.DescribeMergeConflictsInput: AWSPaginateStringToken {
+extension CodeCommit.DescribeMergeConflictsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CodeCommit.DescribeMergeConflictsInput {
         return .init(
             conflictDetailLevel: self.conflictDetailLevel, 
@@ -85,7 +85,7 @@ extension CodeCommit.DescribeMergeConflictsInput: AWSPaginateStringToken {
     }
 }
 
-extension CodeCommit.DescribePullRequestEventsInput: AWSPaginateStringToken {
+extension CodeCommit.DescribePullRequestEventsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CodeCommit.DescribePullRequestEventsInput {
         return .init(
             actorArn: self.actorArn, 
@@ -98,7 +98,7 @@ extension CodeCommit.DescribePullRequestEventsInput: AWSPaginateStringToken {
     }
 }
 
-extension CodeCommit.GetCommentsForComparedCommitInput: AWSPaginateStringToken {
+extension CodeCommit.GetCommentsForComparedCommitInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CodeCommit.GetCommentsForComparedCommitInput {
         return .init(
             afterCommitId: self.afterCommitId, 
@@ -111,7 +111,7 @@ extension CodeCommit.GetCommentsForComparedCommitInput: AWSPaginateStringToken {
     }
 }
 
-extension CodeCommit.GetCommentsForPullRequestInput: AWSPaginateStringToken {
+extension CodeCommit.GetCommentsForPullRequestInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CodeCommit.GetCommentsForPullRequestInput {
         return .init(
             afterCommitId: self.afterCommitId, 
@@ -125,7 +125,7 @@ extension CodeCommit.GetCommentsForPullRequestInput: AWSPaginateStringToken {
     }
 }
 
-extension CodeCommit.GetDifferencesInput: AWSPaginateStringToken {
+extension CodeCommit.GetDifferencesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CodeCommit.GetDifferencesInput {
         return .init(
             afterCommitSpecifier: self.afterCommitSpecifier, 
@@ -140,7 +140,7 @@ extension CodeCommit.GetDifferencesInput: AWSPaginateStringToken {
     }
 }
 
-extension CodeCommit.GetMergeConflictsInput: AWSPaginateStringToken {
+extension CodeCommit.GetMergeConflictsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CodeCommit.GetMergeConflictsInput {
         return .init(
             conflictDetailLevel: self.conflictDetailLevel, 
@@ -156,7 +156,7 @@ extension CodeCommit.GetMergeConflictsInput: AWSPaginateStringToken {
     }
 }
 
-extension CodeCommit.ListApprovalRuleTemplatesInput: AWSPaginateStringToken {
+extension CodeCommit.ListApprovalRuleTemplatesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CodeCommit.ListApprovalRuleTemplatesInput {
         return .init(
             maxResults: self.maxResults, 
@@ -166,7 +166,7 @@ extension CodeCommit.ListApprovalRuleTemplatesInput: AWSPaginateStringToken {
     }
 }
 
-extension CodeCommit.ListAssociatedApprovalRuleTemplatesForRepositoryInput: AWSPaginateStringToken {
+extension CodeCommit.ListAssociatedApprovalRuleTemplatesForRepositoryInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CodeCommit.ListAssociatedApprovalRuleTemplatesForRepositoryInput {
         return .init(
             maxResults: self.maxResults, 
@@ -177,7 +177,7 @@ extension CodeCommit.ListAssociatedApprovalRuleTemplatesForRepositoryInput: AWSP
     }
 }
 
-extension CodeCommit.ListBranchesInput: AWSPaginateStringToken {
+extension CodeCommit.ListBranchesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CodeCommit.ListBranchesInput {
         return .init(
             nextToken: token, 
@@ -187,7 +187,7 @@ extension CodeCommit.ListBranchesInput: AWSPaginateStringToken {
     }
 }
 
-extension CodeCommit.ListPullRequestsInput: AWSPaginateStringToken {
+extension CodeCommit.ListPullRequestsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CodeCommit.ListPullRequestsInput {
         return .init(
             authorArn: self.authorArn, 
@@ -200,7 +200,7 @@ extension CodeCommit.ListPullRequestsInput: AWSPaginateStringToken {
     }
 }
 
-extension CodeCommit.ListRepositoriesInput: AWSPaginateStringToken {
+extension CodeCommit.ListRepositoriesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CodeCommit.ListRepositoriesInput {
         return .init(
             nextToken: token, 
@@ -211,7 +211,7 @@ extension CodeCommit.ListRepositoriesInput: AWSPaginateStringToken {
     }
 }
 
-extension CodeCommit.ListRepositoriesForApprovalRuleTemplateInput: AWSPaginateStringToken {
+extension CodeCommit.ListRepositoriesForApprovalRuleTemplateInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CodeCommit.ListRepositoriesForApprovalRuleTemplateInput {
         return .init(
             approvalRuleTemplateName: self.approvalRuleTemplateName, 

--- a/Sources/AWSSDKSwift/Services/CodeDeploy/CodeDeploy_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/CodeDeploy/CodeDeploy_Paginator.swift
@@ -39,7 +39,7 @@ extension CodeDeploy {
 
 }
 
-extension CodeDeploy.ListApplicationRevisionsInput: AWSPaginateStringToken {
+extension CodeDeploy.ListApplicationRevisionsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CodeDeploy.ListApplicationRevisionsInput {
         return .init(
             applicationName: self.applicationName, 
@@ -54,7 +54,7 @@ extension CodeDeploy.ListApplicationRevisionsInput: AWSPaginateStringToken {
     }
 }
 
-extension CodeDeploy.ListApplicationsInput: AWSPaginateStringToken {
+extension CodeDeploy.ListApplicationsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CodeDeploy.ListApplicationsInput {
         return .init(
             nextToken: token
@@ -63,7 +63,7 @@ extension CodeDeploy.ListApplicationsInput: AWSPaginateStringToken {
     }
 }
 
-extension CodeDeploy.ListDeploymentConfigsInput: AWSPaginateStringToken {
+extension CodeDeploy.ListDeploymentConfigsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CodeDeploy.ListDeploymentConfigsInput {
         return .init(
             nextToken: token
@@ -72,7 +72,7 @@ extension CodeDeploy.ListDeploymentConfigsInput: AWSPaginateStringToken {
     }
 }
 
-extension CodeDeploy.ListDeploymentGroupsInput: AWSPaginateStringToken {
+extension CodeDeploy.ListDeploymentGroupsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CodeDeploy.ListDeploymentGroupsInput {
         return .init(
             applicationName: self.applicationName, 
@@ -82,7 +82,7 @@ extension CodeDeploy.ListDeploymentGroupsInput: AWSPaginateStringToken {
     }
 }
 
-extension CodeDeploy.ListDeploymentInstancesInput: AWSPaginateStringToken {
+extension CodeDeploy.ListDeploymentInstancesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CodeDeploy.ListDeploymentInstancesInput {
         return .init(
             deploymentId: self.deploymentId, 
@@ -94,7 +94,7 @@ extension CodeDeploy.ListDeploymentInstancesInput: AWSPaginateStringToken {
     }
 }
 
-extension CodeDeploy.ListDeploymentsInput: AWSPaginateStringToken {
+extension CodeDeploy.ListDeploymentsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CodeDeploy.ListDeploymentsInput {
         return .init(
             applicationName: self.applicationName, 

--- a/Sources/AWSSDKSwift/Services/CodeGuruProfiler/CodeGuruProfiler_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/CodeGuruProfiler/CodeGuruProfiler_Paginator.swift
@@ -18,7 +18,7 @@ extension CodeGuruProfiler {
 
 }
 
-extension CodeGuruProfiler.ListProfileTimesRequest: AWSPaginateStringToken {
+extension CodeGuruProfiler.ListProfileTimesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CodeGuruProfiler.ListProfileTimesRequest {
         return .init(
             endTime: self.endTime, 
@@ -33,7 +33,7 @@ extension CodeGuruProfiler.ListProfileTimesRequest: AWSPaginateStringToken {
     }
 }
 
-extension CodeGuruProfiler.ListProfilingGroupsRequest: AWSPaginateStringToken {
+extension CodeGuruProfiler.ListProfilingGroupsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CodeGuruProfiler.ListProfilingGroupsRequest {
         return .init(
             includeDescription: self.includeDescription, 

--- a/Sources/AWSSDKSwift/Services/CodeGuruReviewer/CodeGuruReviewer_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/CodeGuruReviewer/CodeGuruReviewer_Paginator.swift
@@ -13,7 +13,7 @@ extension CodeGuruReviewer {
 
 }
 
-extension CodeGuruReviewer.ListRepositoryAssociationsRequest: AWSPaginateStringToken {
+extension CodeGuruReviewer.ListRepositoryAssociationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CodeGuruReviewer.ListRepositoryAssociationsRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/CodePipeline/CodePipeline_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/CodePipeline/CodePipeline_Paginator.swift
@@ -38,7 +38,7 @@ extension CodePipeline {
 
 }
 
-extension CodePipeline.ListActionExecutionsInput: AWSPaginateStringToken {
+extension CodePipeline.ListActionExecutionsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CodePipeline.ListActionExecutionsInput {
         return .init(
             filter: self.filter, 
@@ -50,7 +50,7 @@ extension CodePipeline.ListActionExecutionsInput: AWSPaginateStringToken {
     }
 }
 
-extension CodePipeline.ListActionTypesInput: AWSPaginateStringToken {
+extension CodePipeline.ListActionTypesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CodePipeline.ListActionTypesInput {
         return .init(
             actionOwnerFilter: self.actionOwnerFilter, 
@@ -60,7 +60,7 @@ extension CodePipeline.ListActionTypesInput: AWSPaginateStringToken {
     }
 }
 
-extension CodePipeline.ListPipelineExecutionsInput: AWSPaginateStringToken {
+extension CodePipeline.ListPipelineExecutionsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CodePipeline.ListPipelineExecutionsInput {
         return .init(
             maxResults: self.maxResults, 
@@ -71,7 +71,7 @@ extension CodePipeline.ListPipelineExecutionsInput: AWSPaginateStringToken {
     }
 }
 
-extension CodePipeline.ListPipelinesInput: AWSPaginateStringToken {
+extension CodePipeline.ListPipelinesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CodePipeline.ListPipelinesInput {
         return .init(
             nextToken: token
@@ -80,7 +80,7 @@ extension CodePipeline.ListPipelinesInput: AWSPaginateStringToken {
     }
 }
 
-extension CodePipeline.ListTagsForResourceInput: AWSPaginateStringToken {
+extension CodePipeline.ListTagsForResourceInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CodePipeline.ListTagsForResourceInput {
         return .init(
             maxResults: self.maxResults, 
@@ -91,7 +91,7 @@ extension CodePipeline.ListTagsForResourceInput: AWSPaginateStringToken {
     }
 }
 
-extension CodePipeline.ListWebhooksInput: AWSPaginateStringToken {
+extension CodePipeline.ListWebhooksInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CodePipeline.ListWebhooksInput {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/CodeStarNotifications/CodeStarNotifications_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/CodeStarNotifications/CodeStarNotifications_Paginator.swift
@@ -23,7 +23,7 @@ extension CodeStarNotifications {
 
 }
 
-extension CodeStarNotifications.ListEventTypesRequest: AWSPaginateStringToken {
+extension CodeStarNotifications.ListEventTypesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CodeStarNotifications.ListEventTypesRequest {
         return .init(
             filters: self.filters, 
@@ -34,7 +34,7 @@ extension CodeStarNotifications.ListEventTypesRequest: AWSPaginateStringToken {
     }
 }
 
-extension CodeStarNotifications.ListNotificationRulesRequest: AWSPaginateStringToken {
+extension CodeStarNotifications.ListNotificationRulesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CodeStarNotifications.ListNotificationRulesRequest {
         return .init(
             filters: self.filters, 
@@ -45,7 +45,7 @@ extension CodeStarNotifications.ListNotificationRulesRequest: AWSPaginateStringT
     }
 }
 
-extension CodeStarNotifications.ListTargetsRequest: AWSPaginateStringToken {
+extension CodeStarNotifications.ListTargetsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CodeStarNotifications.ListTargetsRequest {
         return .init(
             filters: self.filters, 

--- a/Sources/AWSSDKSwift/Services/CodeStarconnections/CodeStarconnections_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/CodeStarconnections/CodeStarconnections_Paginator.swift
@@ -13,7 +13,7 @@ extension CodeStarconnections {
 
 }
 
-extension CodeStarconnections.ListConnectionsInput: AWSPaginateStringToken {
+extension CodeStarconnections.ListConnectionsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CodeStarconnections.ListConnectionsInput {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/CognitoIdentityProvider/CognitoIdentityProvider_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/CognitoIdentityProvider/CognitoIdentityProvider_Paginator.swift
@@ -53,7 +53,7 @@ extension CognitoIdentityProvider {
 
 }
 
-extension CognitoIdentityProvider.AdminListGroupsForUserRequest: AWSPaginateStringToken {
+extension CognitoIdentityProvider.AdminListGroupsForUserRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CognitoIdentityProvider.AdminListGroupsForUserRequest {
         return .init(
             limit: self.limit, 
@@ -65,7 +65,7 @@ extension CognitoIdentityProvider.AdminListGroupsForUserRequest: AWSPaginateStri
     }
 }
 
-extension CognitoIdentityProvider.AdminListUserAuthEventsRequest: AWSPaginateStringToken {
+extension CognitoIdentityProvider.AdminListUserAuthEventsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CognitoIdentityProvider.AdminListUserAuthEventsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -77,7 +77,7 @@ extension CognitoIdentityProvider.AdminListUserAuthEventsRequest: AWSPaginateStr
     }
 }
 
-extension CognitoIdentityProvider.ListGroupsRequest: AWSPaginateStringToken {
+extension CognitoIdentityProvider.ListGroupsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CognitoIdentityProvider.ListGroupsRequest {
         return .init(
             limit: self.limit, 
@@ -88,7 +88,7 @@ extension CognitoIdentityProvider.ListGroupsRequest: AWSPaginateStringToken {
     }
 }
 
-extension CognitoIdentityProvider.ListIdentityProvidersRequest: AWSPaginateStringToken {
+extension CognitoIdentityProvider.ListIdentityProvidersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CognitoIdentityProvider.ListIdentityProvidersRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -99,7 +99,7 @@ extension CognitoIdentityProvider.ListIdentityProvidersRequest: AWSPaginateStrin
     }
 }
 
-extension CognitoIdentityProvider.ListResourceServersRequest: AWSPaginateStringToken {
+extension CognitoIdentityProvider.ListResourceServersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CognitoIdentityProvider.ListResourceServersRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -110,7 +110,7 @@ extension CognitoIdentityProvider.ListResourceServersRequest: AWSPaginateStringT
     }
 }
 
-extension CognitoIdentityProvider.ListUserPoolClientsRequest: AWSPaginateStringToken {
+extension CognitoIdentityProvider.ListUserPoolClientsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CognitoIdentityProvider.ListUserPoolClientsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -121,7 +121,7 @@ extension CognitoIdentityProvider.ListUserPoolClientsRequest: AWSPaginateStringT
     }
 }
 
-extension CognitoIdentityProvider.ListUserPoolsRequest: AWSPaginateStringToken {
+extension CognitoIdentityProvider.ListUserPoolsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CognitoIdentityProvider.ListUserPoolsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -131,7 +131,7 @@ extension CognitoIdentityProvider.ListUserPoolsRequest: AWSPaginateStringToken {
     }
 }
 
-extension CognitoIdentityProvider.ListUsersRequest: AWSPaginateStringToken {
+extension CognitoIdentityProvider.ListUsersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CognitoIdentityProvider.ListUsersRequest {
         return .init(
             attributesToGet: self.attributesToGet, 
@@ -144,7 +144,7 @@ extension CognitoIdentityProvider.ListUsersRequest: AWSPaginateStringToken {
     }
 }
 
-extension CognitoIdentityProvider.ListUsersInGroupRequest: AWSPaginateStringToken {
+extension CognitoIdentityProvider.ListUsersInGroupRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CognitoIdentityProvider.ListUsersInGroupRequest {
         return .init(
             groupName: self.groupName, 

--- a/Sources/AWSSDKSwift/Services/Comprehend/Comprehend_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Comprehend/Comprehend_Paginator.swift
@@ -48,7 +48,7 @@ extension Comprehend {
 
 }
 
-extension Comprehend.ListDocumentClassificationJobsRequest: AWSPaginateStringToken {
+extension Comprehend.ListDocumentClassificationJobsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Comprehend.ListDocumentClassificationJobsRequest {
         return .init(
             filter: self.filter, 
@@ -59,7 +59,7 @@ extension Comprehend.ListDocumentClassificationJobsRequest: AWSPaginateStringTok
     }
 }
 
-extension Comprehend.ListDocumentClassifiersRequest: AWSPaginateStringToken {
+extension Comprehend.ListDocumentClassifiersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Comprehend.ListDocumentClassifiersRequest {
         return .init(
             filter: self.filter, 
@@ -70,7 +70,7 @@ extension Comprehend.ListDocumentClassifiersRequest: AWSPaginateStringToken {
     }
 }
 
-extension Comprehend.ListDominantLanguageDetectionJobsRequest: AWSPaginateStringToken {
+extension Comprehend.ListDominantLanguageDetectionJobsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Comprehend.ListDominantLanguageDetectionJobsRequest {
         return .init(
             filter: self.filter, 
@@ -81,7 +81,7 @@ extension Comprehend.ListDominantLanguageDetectionJobsRequest: AWSPaginateString
     }
 }
 
-extension Comprehend.ListEntitiesDetectionJobsRequest: AWSPaginateStringToken {
+extension Comprehend.ListEntitiesDetectionJobsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Comprehend.ListEntitiesDetectionJobsRequest {
         return .init(
             filter: self.filter, 
@@ -92,7 +92,7 @@ extension Comprehend.ListEntitiesDetectionJobsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Comprehend.ListEntityRecognizersRequest: AWSPaginateStringToken {
+extension Comprehend.ListEntityRecognizersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Comprehend.ListEntityRecognizersRequest {
         return .init(
             filter: self.filter, 
@@ -103,7 +103,7 @@ extension Comprehend.ListEntityRecognizersRequest: AWSPaginateStringToken {
     }
 }
 
-extension Comprehend.ListKeyPhrasesDetectionJobsRequest: AWSPaginateStringToken {
+extension Comprehend.ListKeyPhrasesDetectionJobsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Comprehend.ListKeyPhrasesDetectionJobsRequest {
         return .init(
             filter: self.filter, 
@@ -114,7 +114,7 @@ extension Comprehend.ListKeyPhrasesDetectionJobsRequest: AWSPaginateStringToken 
     }
 }
 
-extension Comprehend.ListSentimentDetectionJobsRequest: AWSPaginateStringToken {
+extension Comprehend.ListSentimentDetectionJobsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Comprehend.ListSentimentDetectionJobsRequest {
         return .init(
             filter: self.filter, 
@@ -125,7 +125,7 @@ extension Comprehend.ListSentimentDetectionJobsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Comprehend.ListTopicsDetectionJobsRequest: AWSPaginateStringToken {
+extension Comprehend.ListTopicsDetectionJobsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Comprehend.ListTopicsDetectionJobsRequest {
         return .init(
             filter: self.filter, 

--- a/Sources/AWSSDKSwift/Services/ConfigService/ConfigService_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/ConfigService/ConfigService_Paginator.swift
@@ -28,7 +28,7 @@ extension ConfigService {
 
 }
 
-extension ConfigService.DescribeRemediationExceptionsRequest: AWSPaginateStringToken {
+extension ConfigService.DescribeRemediationExceptionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ConfigService.DescribeRemediationExceptionsRequest {
         return .init(
             configRuleName: self.configRuleName, 
@@ -40,7 +40,7 @@ extension ConfigService.DescribeRemediationExceptionsRequest: AWSPaginateStringT
     }
 }
 
-extension ConfigService.DescribeRemediationExecutionStatusRequest: AWSPaginateStringToken {
+extension ConfigService.DescribeRemediationExecutionStatusRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ConfigService.DescribeRemediationExecutionStatusRequest {
         return .init(
             configRuleName: self.configRuleName, 
@@ -52,7 +52,7 @@ extension ConfigService.DescribeRemediationExecutionStatusRequest: AWSPaginateSt
     }
 }
 
-extension ConfigService.GetResourceConfigHistoryRequest: AWSPaginateStringToken {
+extension ConfigService.GetResourceConfigHistoryRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ConfigService.GetResourceConfigHistoryRequest {
         return .init(
             chronologicalOrder: self.chronologicalOrder, 
@@ -67,7 +67,7 @@ extension ConfigService.GetResourceConfigHistoryRequest: AWSPaginateStringToken 
     }
 }
 
-extension ConfigService.SelectAggregateResourceConfigRequest: AWSPaginateStringToken {
+extension ConfigService.SelectAggregateResourceConfigRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ConfigService.SelectAggregateResourceConfigRequest {
         return .init(
             configurationAggregatorName: self.configurationAggregatorName, 

--- a/Sources/AWSSDKSwift/Services/Connect/Connect_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Connect/Connect_Paginator.swift
@@ -58,7 +58,7 @@ extension Connect {
 
 }
 
-extension Connect.GetCurrentMetricDataRequest: AWSPaginateStringToken {
+extension Connect.GetCurrentMetricDataRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Connect.GetCurrentMetricDataRequest {
         return .init(
             currentMetrics: self.currentMetrics, 
@@ -72,7 +72,7 @@ extension Connect.GetCurrentMetricDataRequest: AWSPaginateStringToken {
     }
 }
 
-extension Connect.GetMetricDataRequest: AWSPaginateStringToken {
+extension Connect.GetMetricDataRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Connect.GetMetricDataRequest {
         return .init(
             endTime: self.endTime, 
@@ -88,7 +88,7 @@ extension Connect.GetMetricDataRequest: AWSPaginateStringToken {
     }
 }
 
-extension Connect.ListContactFlowsRequest: AWSPaginateStringToken {
+extension Connect.ListContactFlowsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Connect.ListContactFlowsRequest {
         return .init(
             contactFlowTypes: self.contactFlowTypes, 
@@ -100,7 +100,7 @@ extension Connect.ListContactFlowsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Connect.ListHoursOfOperationsRequest: AWSPaginateStringToken {
+extension Connect.ListHoursOfOperationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Connect.ListHoursOfOperationsRequest {
         return .init(
             instanceId: self.instanceId, 
@@ -111,7 +111,7 @@ extension Connect.ListHoursOfOperationsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Connect.ListPhoneNumbersRequest: AWSPaginateStringToken {
+extension Connect.ListPhoneNumbersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Connect.ListPhoneNumbersRequest {
         return .init(
             instanceId: self.instanceId, 
@@ -124,7 +124,7 @@ extension Connect.ListPhoneNumbersRequest: AWSPaginateStringToken {
     }
 }
 
-extension Connect.ListQueuesRequest: AWSPaginateStringToken {
+extension Connect.ListQueuesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Connect.ListQueuesRequest {
         return .init(
             instanceId: self.instanceId, 
@@ -136,7 +136,7 @@ extension Connect.ListQueuesRequest: AWSPaginateStringToken {
     }
 }
 
-extension Connect.ListRoutingProfilesRequest: AWSPaginateStringToken {
+extension Connect.ListRoutingProfilesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Connect.ListRoutingProfilesRequest {
         return .init(
             instanceId: self.instanceId, 
@@ -147,7 +147,7 @@ extension Connect.ListRoutingProfilesRequest: AWSPaginateStringToken {
     }
 }
 
-extension Connect.ListSecurityProfilesRequest: AWSPaginateStringToken {
+extension Connect.ListSecurityProfilesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Connect.ListSecurityProfilesRequest {
         return .init(
             instanceId: self.instanceId, 
@@ -158,7 +158,7 @@ extension Connect.ListSecurityProfilesRequest: AWSPaginateStringToken {
     }
 }
 
-extension Connect.ListUserHierarchyGroupsRequest: AWSPaginateStringToken {
+extension Connect.ListUserHierarchyGroupsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Connect.ListUserHierarchyGroupsRequest {
         return .init(
             instanceId: self.instanceId, 
@@ -169,7 +169,7 @@ extension Connect.ListUserHierarchyGroupsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Connect.ListUsersRequest: AWSPaginateStringToken {
+extension Connect.ListUsersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Connect.ListUsersRequest {
         return .init(
             instanceId: self.instanceId, 

--- a/Sources/AWSSDKSwift/Services/ConnectParticipant/ConnectParticipant_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/ConnectParticipant/ConnectParticipant_Paginator.swift
@@ -13,7 +13,7 @@ extension ConnectParticipant {
 
 }
 
-extension ConnectParticipant.GetTranscriptRequest: AWSPaginateStringToken {
+extension ConnectParticipant.GetTranscriptRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ConnectParticipant.GetTranscriptRequest {
         return .init(
             connectionToken: self.connectionToken, 

--- a/Sources/AWSSDKSwift/Services/CostExplorer/CostExplorer_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/CostExplorer/CostExplorer_Paginator.swift
@@ -18,7 +18,7 @@ extension CostExplorer {
 
 }
 
-extension CostExplorer.GetSavingsPlansCoverageRequest: AWSPaginateStringToken {
+extension CostExplorer.GetSavingsPlansCoverageRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CostExplorer.GetSavingsPlansCoverageRequest {
         return .init(
             filter: self.filter, 
@@ -33,7 +33,7 @@ extension CostExplorer.GetSavingsPlansCoverageRequest: AWSPaginateStringToken {
     }
 }
 
-extension CostExplorer.GetSavingsPlansUtilizationDetailsRequest: AWSPaginateStringToken {
+extension CostExplorer.GetSavingsPlansUtilizationDetailsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CostExplorer.GetSavingsPlansUtilizationDetailsRequest {
         return .init(
             filter: self.filter, 

--- a/Sources/AWSSDKSwift/Services/CostandUsageReportService/CostandUsageReportService_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/CostandUsageReportService/CostandUsageReportService_Paginator.swift
@@ -13,7 +13,7 @@ extension CostandUsageReportService {
 
 }
 
-extension CostandUsageReportService.DescribeReportDefinitionsRequest: AWSPaginateStringToken {
+extension CostandUsageReportService.DescribeReportDefinitionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> CostandUsageReportService.DescribeReportDefinitionsRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/DataExchange/DataExchange_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/DataExchange/DataExchange_Paginator.swift
@@ -28,7 +28,7 @@ extension DataExchange {
 
 }
 
-extension DataExchange.ListDataSetRevisionsRequest: AWSPaginateStringToken {
+extension DataExchange.ListDataSetRevisionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DataExchange.ListDataSetRevisionsRequest {
         return .init(
             dataSetId: self.dataSetId, 
@@ -39,7 +39,7 @@ extension DataExchange.ListDataSetRevisionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension DataExchange.ListDataSetsRequest: AWSPaginateStringToken {
+extension DataExchange.ListDataSetsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DataExchange.ListDataSetsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -50,7 +50,7 @@ extension DataExchange.ListDataSetsRequest: AWSPaginateStringToken {
     }
 }
 
-extension DataExchange.ListJobsRequest: AWSPaginateStringToken {
+extension DataExchange.ListJobsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DataExchange.ListJobsRequest {
         return .init(
             dataSetId: self.dataSetId, 
@@ -62,7 +62,7 @@ extension DataExchange.ListJobsRequest: AWSPaginateStringToken {
     }
 }
 
-extension DataExchange.ListRevisionAssetsRequest: AWSPaginateStringToken {
+extension DataExchange.ListRevisionAssetsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DataExchange.ListRevisionAssetsRequest {
         return .init(
             dataSetId: self.dataSetId, 

--- a/Sources/AWSSDKSwift/Services/DataPipeline/DataPipeline_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/DataPipeline/DataPipeline_Paginator.swift
@@ -23,7 +23,7 @@ extension DataPipeline {
 
 }
 
-extension DataPipeline.DescribeObjectsInput: AWSPaginateStringToken {
+extension DataPipeline.DescribeObjectsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DataPipeline.DescribeObjectsInput {
         return .init(
             evaluateExpressions: self.evaluateExpressions, 
@@ -35,7 +35,7 @@ extension DataPipeline.DescribeObjectsInput: AWSPaginateStringToken {
     }
 }
 
-extension DataPipeline.ListPipelinesInput: AWSPaginateStringToken {
+extension DataPipeline.ListPipelinesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DataPipeline.ListPipelinesInput {
         return .init(
             marker: token
@@ -44,7 +44,7 @@ extension DataPipeline.ListPipelinesInput: AWSPaginateStringToken {
     }
 }
 
-extension DataPipeline.QueryObjectsInput: AWSPaginateStringToken {
+extension DataPipeline.QueryObjectsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DataPipeline.QueryObjectsInput {
         return .init(
             limit: self.limit, 

--- a/Sources/AWSSDKSwift/Services/DataSync/DataSync_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/DataSync/DataSync_Paginator.swift
@@ -33,7 +33,7 @@ extension DataSync {
 
 }
 
-extension DataSync.ListAgentsRequest: AWSPaginateStringToken {
+extension DataSync.ListAgentsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DataSync.ListAgentsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -43,7 +43,7 @@ extension DataSync.ListAgentsRequest: AWSPaginateStringToken {
     }
 }
 
-extension DataSync.ListLocationsRequest: AWSPaginateStringToken {
+extension DataSync.ListLocationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DataSync.ListLocationsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -53,7 +53,7 @@ extension DataSync.ListLocationsRequest: AWSPaginateStringToken {
     }
 }
 
-extension DataSync.ListTagsForResourceRequest: AWSPaginateStringToken {
+extension DataSync.ListTagsForResourceRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DataSync.ListTagsForResourceRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -64,7 +64,7 @@ extension DataSync.ListTagsForResourceRequest: AWSPaginateStringToken {
     }
 }
 
-extension DataSync.ListTaskExecutionsRequest: AWSPaginateStringToken {
+extension DataSync.ListTaskExecutionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DataSync.ListTaskExecutionsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -75,7 +75,7 @@ extension DataSync.ListTaskExecutionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension DataSync.ListTasksRequest: AWSPaginateStringToken {
+extension DataSync.ListTasksRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DataSync.ListTasksRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/DatabaseMigrationService/DatabaseMigrationService_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/DatabaseMigrationService/DatabaseMigrationService_Paginator.swift
@@ -83,7 +83,7 @@ extension DatabaseMigrationService {
 
 }
 
-extension DatabaseMigrationService.DescribeCertificatesMessage: AWSPaginateStringToken {
+extension DatabaseMigrationService.DescribeCertificatesMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DatabaseMigrationService.DescribeCertificatesMessage {
         return .init(
             filters: self.filters, 
@@ -94,7 +94,7 @@ extension DatabaseMigrationService.DescribeCertificatesMessage: AWSPaginateStrin
     }
 }
 
-extension DatabaseMigrationService.DescribeConnectionsMessage: AWSPaginateStringToken {
+extension DatabaseMigrationService.DescribeConnectionsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DatabaseMigrationService.DescribeConnectionsMessage {
         return .init(
             filters: self.filters, 
@@ -105,7 +105,7 @@ extension DatabaseMigrationService.DescribeConnectionsMessage: AWSPaginateString
     }
 }
 
-extension DatabaseMigrationService.DescribeEndpointTypesMessage: AWSPaginateStringToken {
+extension DatabaseMigrationService.DescribeEndpointTypesMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DatabaseMigrationService.DescribeEndpointTypesMessage {
         return .init(
             filters: self.filters, 
@@ -116,7 +116,7 @@ extension DatabaseMigrationService.DescribeEndpointTypesMessage: AWSPaginateStri
     }
 }
 
-extension DatabaseMigrationService.DescribeEndpointsMessage: AWSPaginateStringToken {
+extension DatabaseMigrationService.DescribeEndpointsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DatabaseMigrationService.DescribeEndpointsMessage {
         return .init(
             filters: self.filters, 
@@ -127,7 +127,7 @@ extension DatabaseMigrationService.DescribeEndpointsMessage: AWSPaginateStringTo
     }
 }
 
-extension DatabaseMigrationService.DescribeEventSubscriptionsMessage: AWSPaginateStringToken {
+extension DatabaseMigrationService.DescribeEventSubscriptionsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DatabaseMigrationService.DescribeEventSubscriptionsMessage {
         return .init(
             filters: self.filters, 
@@ -139,7 +139,7 @@ extension DatabaseMigrationService.DescribeEventSubscriptionsMessage: AWSPaginat
     }
 }
 
-extension DatabaseMigrationService.DescribeEventsMessage: AWSPaginateStringToken {
+extension DatabaseMigrationService.DescribeEventsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DatabaseMigrationService.DescribeEventsMessage {
         return .init(
             duration: self.duration, 
@@ -156,7 +156,7 @@ extension DatabaseMigrationService.DescribeEventsMessage: AWSPaginateStringToken
     }
 }
 
-extension DatabaseMigrationService.DescribeOrderableReplicationInstancesMessage: AWSPaginateStringToken {
+extension DatabaseMigrationService.DescribeOrderableReplicationInstancesMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DatabaseMigrationService.DescribeOrderableReplicationInstancesMessage {
         return .init(
             marker: token, 
@@ -166,7 +166,7 @@ extension DatabaseMigrationService.DescribeOrderableReplicationInstancesMessage:
     }
 }
 
-extension DatabaseMigrationService.DescribePendingMaintenanceActionsMessage: AWSPaginateStringToken {
+extension DatabaseMigrationService.DescribePendingMaintenanceActionsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DatabaseMigrationService.DescribePendingMaintenanceActionsMessage {
         return .init(
             filters: self.filters, 
@@ -178,7 +178,7 @@ extension DatabaseMigrationService.DescribePendingMaintenanceActionsMessage: AWS
     }
 }
 
-extension DatabaseMigrationService.DescribeReplicationInstanceTaskLogsMessage: AWSPaginateStringToken {
+extension DatabaseMigrationService.DescribeReplicationInstanceTaskLogsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DatabaseMigrationService.DescribeReplicationInstanceTaskLogsMessage {
         return .init(
             marker: token, 
@@ -189,7 +189,7 @@ extension DatabaseMigrationService.DescribeReplicationInstanceTaskLogsMessage: A
     }
 }
 
-extension DatabaseMigrationService.DescribeReplicationInstancesMessage: AWSPaginateStringToken {
+extension DatabaseMigrationService.DescribeReplicationInstancesMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DatabaseMigrationService.DescribeReplicationInstancesMessage {
         return .init(
             filters: self.filters, 
@@ -200,7 +200,7 @@ extension DatabaseMigrationService.DescribeReplicationInstancesMessage: AWSPagin
     }
 }
 
-extension DatabaseMigrationService.DescribeReplicationSubnetGroupsMessage: AWSPaginateStringToken {
+extension DatabaseMigrationService.DescribeReplicationSubnetGroupsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DatabaseMigrationService.DescribeReplicationSubnetGroupsMessage {
         return .init(
             filters: self.filters, 
@@ -211,7 +211,7 @@ extension DatabaseMigrationService.DescribeReplicationSubnetGroupsMessage: AWSPa
     }
 }
 
-extension DatabaseMigrationService.DescribeReplicationTaskAssessmentResultsMessage: AWSPaginateStringToken {
+extension DatabaseMigrationService.DescribeReplicationTaskAssessmentResultsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DatabaseMigrationService.DescribeReplicationTaskAssessmentResultsMessage {
         return .init(
             marker: token, 
@@ -222,7 +222,7 @@ extension DatabaseMigrationService.DescribeReplicationTaskAssessmentResultsMessa
     }
 }
 
-extension DatabaseMigrationService.DescribeReplicationTasksMessage: AWSPaginateStringToken {
+extension DatabaseMigrationService.DescribeReplicationTasksMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DatabaseMigrationService.DescribeReplicationTasksMessage {
         return .init(
             filters: self.filters, 
@@ -234,7 +234,7 @@ extension DatabaseMigrationService.DescribeReplicationTasksMessage: AWSPaginateS
     }
 }
 
-extension DatabaseMigrationService.DescribeSchemasMessage: AWSPaginateStringToken {
+extension DatabaseMigrationService.DescribeSchemasMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DatabaseMigrationService.DescribeSchemasMessage {
         return .init(
             endpointArn: self.endpointArn, 
@@ -245,7 +245,7 @@ extension DatabaseMigrationService.DescribeSchemasMessage: AWSPaginateStringToke
     }
 }
 
-extension DatabaseMigrationService.DescribeTableStatisticsMessage: AWSPaginateStringToken {
+extension DatabaseMigrationService.DescribeTableStatisticsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DatabaseMigrationService.DescribeTableStatisticsMessage {
         return .init(
             filters: self.filters, 

--- a/Sources/AWSSDKSwift/Services/Detective/Detective_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Detective/Detective_Paginator.swift
@@ -23,7 +23,7 @@ extension Detective {
 
 }
 
-extension Detective.ListGraphsRequest: AWSPaginateStringToken {
+extension Detective.ListGraphsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Detective.ListGraphsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -33,7 +33,7 @@ extension Detective.ListGraphsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Detective.ListInvitationsRequest: AWSPaginateStringToken {
+extension Detective.ListInvitationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Detective.ListInvitationsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -43,7 +43,7 @@ extension Detective.ListInvitationsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Detective.ListMembersRequest: AWSPaginateStringToken {
+extension Detective.ListMembersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Detective.ListMembersRequest {
         return .init(
             graphArn: self.graphArn, 

--- a/Sources/AWSSDKSwift/Services/DeviceFarm/DeviceFarm_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/DeviceFarm/DeviceFarm_Paginator.swift
@@ -98,7 +98,7 @@ extension DeviceFarm {
 
 }
 
-extension DeviceFarm.GetOfferingStatusRequest: AWSPaginateStringToken {
+extension DeviceFarm.GetOfferingStatusRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DeviceFarm.GetOfferingStatusRequest {
         return .init(
             nextToken: token
@@ -107,7 +107,7 @@ extension DeviceFarm.GetOfferingStatusRequest: AWSPaginateStringToken {
     }
 }
 
-extension DeviceFarm.ListArtifactsRequest: AWSPaginateStringToken {
+extension DeviceFarm.ListArtifactsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DeviceFarm.ListArtifactsRequest {
         return .init(
             arn: self.arn, 
@@ -118,7 +118,7 @@ extension DeviceFarm.ListArtifactsRequest: AWSPaginateStringToken {
     }
 }
 
-extension DeviceFarm.ListDevicePoolsRequest: AWSPaginateStringToken {
+extension DeviceFarm.ListDevicePoolsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DeviceFarm.ListDevicePoolsRequest {
         return .init(
             arn: self.arn, 
@@ -129,7 +129,7 @@ extension DeviceFarm.ListDevicePoolsRequest: AWSPaginateStringToken {
     }
 }
 
-extension DeviceFarm.ListDevicesRequest: AWSPaginateStringToken {
+extension DeviceFarm.ListDevicesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DeviceFarm.ListDevicesRequest {
         return .init(
             arn: self.arn, 
@@ -140,7 +140,7 @@ extension DeviceFarm.ListDevicesRequest: AWSPaginateStringToken {
     }
 }
 
-extension DeviceFarm.ListJobsRequest: AWSPaginateStringToken {
+extension DeviceFarm.ListJobsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DeviceFarm.ListJobsRequest {
         return .init(
             arn: self.arn, 
@@ -150,7 +150,7 @@ extension DeviceFarm.ListJobsRequest: AWSPaginateStringToken {
     }
 }
 
-extension DeviceFarm.ListOfferingTransactionsRequest: AWSPaginateStringToken {
+extension DeviceFarm.ListOfferingTransactionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DeviceFarm.ListOfferingTransactionsRequest {
         return .init(
             nextToken: token
@@ -159,7 +159,7 @@ extension DeviceFarm.ListOfferingTransactionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension DeviceFarm.ListOfferingsRequest: AWSPaginateStringToken {
+extension DeviceFarm.ListOfferingsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DeviceFarm.ListOfferingsRequest {
         return .init(
             nextToken: token
@@ -168,7 +168,7 @@ extension DeviceFarm.ListOfferingsRequest: AWSPaginateStringToken {
     }
 }
 
-extension DeviceFarm.ListProjectsRequest: AWSPaginateStringToken {
+extension DeviceFarm.ListProjectsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DeviceFarm.ListProjectsRequest {
         return .init(
             arn: self.arn, 
@@ -178,7 +178,7 @@ extension DeviceFarm.ListProjectsRequest: AWSPaginateStringToken {
     }
 }
 
-extension DeviceFarm.ListRunsRequest: AWSPaginateStringToken {
+extension DeviceFarm.ListRunsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DeviceFarm.ListRunsRequest {
         return .init(
             arn: self.arn, 
@@ -188,7 +188,7 @@ extension DeviceFarm.ListRunsRequest: AWSPaginateStringToken {
     }
 }
 
-extension DeviceFarm.ListSamplesRequest: AWSPaginateStringToken {
+extension DeviceFarm.ListSamplesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DeviceFarm.ListSamplesRequest {
         return .init(
             arn: self.arn, 
@@ -198,7 +198,7 @@ extension DeviceFarm.ListSamplesRequest: AWSPaginateStringToken {
     }
 }
 
-extension DeviceFarm.ListSuitesRequest: AWSPaginateStringToken {
+extension DeviceFarm.ListSuitesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DeviceFarm.ListSuitesRequest {
         return .init(
             arn: self.arn, 
@@ -208,7 +208,7 @@ extension DeviceFarm.ListSuitesRequest: AWSPaginateStringToken {
     }
 }
 
-extension DeviceFarm.ListTestGridProjectsRequest: AWSPaginateStringToken {
+extension DeviceFarm.ListTestGridProjectsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DeviceFarm.ListTestGridProjectsRequest {
         return .init(
             maxResult: self.maxResult, 
@@ -218,7 +218,7 @@ extension DeviceFarm.ListTestGridProjectsRequest: AWSPaginateStringToken {
     }
 }
 
-extension DeviceFarm.ListTestGridSessionActionsRequest: AWSPaginateStringToken {
+extension DeviceFarm.ListTestGridSessionActionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DeviceFarm.ListTestGridSessionActionsRequest {
         return .init(
             maxResult: self.maxResult, 
@@ -229,7 +229,7 @@ extension DeviceFarm.ListTestGridSessionActionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension DeviceFarm.ListTestGridSessionArtifactsRequest: AWSPaginateStringToken {
+extension DeviceFarm.ListTestGridSessionArtifactsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DeviceFarm.ListTestGridSessionArtifactsRequest {
         return .init(
             maxResult: self.maxResult, 
@@ -241,7 +241,7 @@ extension DeviceFarm.ListTestGridSessionArtifactsRequest: AWSPaginateStringToken
     }
 }
 
-extension DeviceFarm.ListTestGridSessionsRequest: AWSPaginateStringToken {
+extension DeviceFarm.ListTestGridSessionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DeviceFarm.ListTestGridSessionsRequest {
         return .init(
             creationTimeAfter: self.creationTimeAfter, 
@@ -257,7 +257,7 @@ extension DeviceFarm.ListTestGridSessionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension DeviceFarm.ListTestsRequest: AWSPaginateStringToken {
+extension DeviceFarm.ListTestsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DeviceFarm.ListTestsRequest {
         return .init(
             arn: self.arn, 
@@ -267,7 +267,7 @@ extension DeviceFarm.ListTestsRequest: AWSPaginateStringToken {
     }
 }
 
-extension DeviceFarm.ListUniqueProblemsRequest: AWSPaginateStringToken {
+extension DeviceFarm.ListUniqueProblemsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DeviceFarm.ListUniqueProblemsRequest {
         return .init(
             arn: self.arn, 
@@ -277,7 +277,7 @@ extension DeviceFarm.ListUniqueProblemsRequest: AWSPaginateStringToken {
     }
 }
 
-extension DeviceFarm.ListUploadsRequest: AWSPaginateStringToken {
+extension DeviceFarm.ListUploadsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DeviceFarm.ListUploadsRequest {
         return .init(
             arn: self.arn, 

--- a/Sources/AWSSDKSwift/Services/DirectoryService/DirectoryService_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/DirectoryService/DirectoryService_Paginator.swift
@@ -13,7 +13,7 @@ extension DirectoryService {
 
 }
 
-extension DirectoryService.DescribeDomainControllersRequest: AWSPaginateStringToken {
+extension DirectoryService.DescribeDomainControllersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DirectoryService.DescribeDomainControllersRequest {
         return .init(
             directoryId: self.directoryId, 

--- a/Sources/AWSSDKSwift/Services/DocDB/DocDB_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/DocDB/DocDB_Paginator.swift
@@ -38,7 +38,7 @@ extension DocDB {
 
 }
 
-extension DocDB.DescribeDBClustersMessage: AWSPaginateStringToken {
+extension DocDB.DescribeDBClustersMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DocDB.DescribeDBClustersMessage {
         return .init(
             dBClusterIdentifier: self.dBClusterIdentifier, 
@@ -50,7 +50,7 @@ extension DocDB.DescribeDBClustersMessage: AWSPaginateStringToken {
     }
 }
 
-extension DocDB.DescribeDBEngineVersionsMessage: AWSPaginateStringToken {
+extension DocDB.DescribeDBEngineVersionsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DocDB.DescribeDBEngineVersionsMessage {
         return .init(
             dBParameterGroupFamily: self.dBParameterGroupFamily, 
@@ -67,7 +67,7 @@ extension DocDB.DescribeDBEngineVersionsMessage: AWSPaginateStringToken {
     }
 }
 
-extension DocDB.DescribeDBInstancesMessage: AWSPaginateStringToken {
+extension DocDB.DescribeDBInstancesMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DocDB.DescribeDBInstancesMessage {
         return .init(
             dBInstanceIdentifier: self.dBInstanceIdentifier, 
@@ -79,7 +79,7 @@ extension DocDB.DescribeDBInstancesMessage: AWSPaginateStringToken {
     }
 }
 
-extension DocDB.DescribeDBSubnetGroupsMessage: AWSPaginateStringToken {
+extension DocDB.DescribeDBSubnetGroupsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DocDB.DescribeDBSubnetGroupsMessage {
         return .init(
             dBSubnetGroupName: self.dBSubnetGroupName, 
@@ -91,7 +91,7 @@ extension DocDB.DescribeDBSubnetGroupsMessage: AWSPaginateStringToken {
     }
 }
 
-extension DocDB.DescribeEventsMessage: AWSPaginateStringToken {
+extension DocDB.DescribeEventsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DocDB.DescribeEventsMessage {
         return .init(
             duration: self.duration, 
@@ -108,7 +108,7 @@ extension DocDB.DescribeEventsMessage: AWSPaginateStringToken {
     }
 }
 
-extension DocDB.DescribeOrderableDBInstanceOptionsMessage: AWSPaginateStringToken {
+extension DocDB.DescribeOrderableDBInstanceOptionsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DocDB.DescribeOrderableDBInstanceOptionsMessage {
         return .init(
             dBInstanceClass: self.dBInstanceClass, 

--- a/Sources/AWSSDKSwift/Services/DynamoDB/DynamoDB_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/DynamoDB/DynamoDB_Paginator.swift
@@ -6,6 +6,11 @@ import NIO
 
 extension DynamoDB {
 
+    ///  The BatchGetItem operation returns the attributes of one or more items from one or more tables. You identify requested items by primary key. A single operation can retrieve up to 16 MB of data, which can contain as many as 100 items. BatchGetItem returns a partial result if the response size limit is exceeded, the table's provisioned throughput is exceeded, or an internal processing failure occurs. If a partial result is returned, the operation returns a value for UnprocessedKeys. You can use this value to retry the operation starting with the next item to get.  If you request more than 100 items, BatchGetItem returns a ValidationException with the message "Too many items requested for the BatchGetItem call."  For example, if you ask to retrieve 100 items, but each individual item is 300 KB in size, the system returns 52 items (so as not to exceed the 16 MB limit). It also returns an appropriate UnprocessedKeys value so you can get the next page of results. If desired, your application can include its own logic to assemble the pages of results into one dataset. If none of the items can be processed due to insufficient provisioned throughput on all of the tables in the request, then BatchGetItem returns a ProvisionedThroughputExceededException. If at least one of the items is successfully processed, then BatchGetItem completes successfully, while returning the keys of the unread items in UnprocessedKeys.  If DynamoDB returns any unprocessed items, you should retry the batch operation on those items. However, we strongly recommend that you use an exponential backoff algorithm. If you retry the batch operation immediately, the underlying read or write requests can still fail due to throttling on the individual tables. If you delay the batch operation using exponential backoff, the individual requests in the batch are much more likely to succeed. For more information, see Batch Operations and Error Handling in the Amazon DynamoDB Developer Guide.  By default, BatchGetItem performs eventually consistent reads on every table in the request. If you want strongly consistent reads instead, you can set ConsistentRead to true for any or all tables. In order to minimize response latency, BatchGetItem retrieves items in parallel. When designing your application, keep in mind that DynamoDB does not return items in any particular order. To help parse the response by item, include the primary key values for the items in your request in the ProjectionExpression parameter. If a requested item does not exist, it is not returned in the result. Requests for nonexistent items consume the minimum read capacity units according to the type of read. For more information, see Working with Tables in the Amazon DynamoDB Developer Guide.
+    public func batchGetItemPaginator(_ input: BatchGetItemInput, onPage: @escaping (BatchGetItemOutput, EventLoop)->EventLoopFuture<Bool>) -> EventLoopFuture<Void> {
+        return client.paginate(input: input, command: batchGetItem, tokenKey: \BatchGetItemOutput.unprocessedKeys, onPage: onPage)
+    }
+
     ///  Returns a list of ContributorInsightsSummary for a table and all its global secondary indexes.
     public func listContributorInsightsPaginator(_ input: ListContributorInsightsInput, onPage: @escaping (ListContributorInsightsOutput, EventLoop)->EventLoopFuture<Bool>) -> EventLoopFuture<Void> {
         return client.paginate(input: input, command: listContributorInsights, tokenKey: \ListContributorInsightsOutput.nextToken, onPage: onPage)
@@ -16,9 +21,29 @@ extension DynamoDB {
         return client.paginate(input: input, command: listTables, tokenKey: \ListTablesOutput.lastEvaluatedTableName, onPage: onPage)
     }
 
+    ///  The Query operation finds items based on primary key values. You can query any table or secondary index that has a composite primary key (a partition key and a sort key).  Use the KeyConditionExpression parameter to provide a specific value for the partition key. The Query operation will return all of the items from the table or index with that partition key value. You can optionally narrow the scope of the Query operation by specifying a sort key value and a comparison operator in KeyConditionExpression. To further refine the Query results, you can optionally provide a FilterExpression. A FilterExpression determines which items within the results should be returned to you. All of the other results are discarded.   A Query operation always returns a result set. If no matching items are found, the result set will be empty. Queries that do not return results consume the minimum number of read capacity units for that type of read operation.    DynamoDB calculates the number of read capacity units consumed based on item size, not on the amount of data that is returned to an application. The number of capacity units consumed will be the same whether you request all of the attributes (the default behavior) or just some of them (using a projection expression). The number will also be the same whether or not you use a FilterExpression.    Query results are always sorted by the sort key value. If the data type of the sort key is Number, the results are returned in numeric order; otherwise, the results are returned in order of UTF-8 bytes. By default, the sort order is ascending. To reverse the order, set the ScanIndexForward parameter to false.   A single Query operation will read up to the maximum number of items set (if using the Limit parameter) or a maximum of 1 MB of data and then apply any filtering to the results using FilterExpression. If LastEvaluatedKey is present in the response, you will need to paginate the result set. For more information, see Paginating the Results in the Amazon DynamoDB Developer Guide.   FilterExpression is applied after a Query finishes, but before the results are returned. A FilterExpression cannot contain partition key or sort key attributes. You need to specify those attributes in the KeyConditionExpression.    A Query operation can return an empty result set and a LastEvaluatedKey if all the items read for the page of results are filtered out.   You can query a table, a local secondary index, or a global secondary index. For a query on a table or on a local secondary index, you can set the ConsistentRead parameter to true and obtain a strongly consistent result. Global secondary indexes support eventually consistent reads only, so do not specify ConsistentRead when querying a global secondary index.
+    public func queryPaginator(_ input: QueryInput, onPage: @escaping (QueryOutput, EventLoop)->EventLoopFuture<Bool>) -> EventLoopFuture<Void> {
+        return client.paginate(input: input, command: query, tokenKey: \QueryOutput.lastEvaluatedKey, onPage: onPage)
+    }
+
+    ///  The Scan operation returns one or more items and item attributes by accessing every item in a table or a secondary index. To have DynamoDB return fewer items, you can provide a FilterExpression operation. If the total number of scanned items exceeds the maximum dataset size limit of 1 MB, the scan stops and results are returned to the user as a LastEvaluatedKey value to continue the scan in a subsequent operation. The results also include the number of items exceeding the limit. A scan can result in no table data meeting the filter criteria.  A single Scan operation reads up to the maximum number of items set (if using the Limit parameter) or a maximum of 1 MB of data and then apply any filtering to the results using FilterExpression. If LastEvaluatedKey is present in the response, you need to paginate the result set. For more information, see Paginating the Results in the Amazon DynamoDB Developer Guide.   Scan operations proceed sequentially; however, for faster performance on a large table or secondary index, applications can request a parallel Scan operation by providing the Segment and TotalSegments parameters. For more information, see Parallel Scan in the Amazon DynamoDB Developer Guide.  Scan uses eventually consistent reads when accessing the data in a table; therefore, the result set might not include the changes to data in the table immediately before the operation began. If you need a consistent copy of the data, as of the time that the Scan begins, you can set the ConsistentRead parameter to true.
+    public func scanPaginator(_ input: ScanInput, onPage: @escaping (ScanOutput, EventLoop)->EventLoopFuture<Bool>) -> EventLoopFuture<Void> {
+        return client.paginate(input: input, command: scan, tokenKey: \ScanOutput.lastEvaluatedKey, onPage: onPage)
+    }
+
 }
 
-extension DynamoDB.ListContributorInsightsInput: AWSPaginateStringToken {
+extension DynamoDB.BatchGetItemInput: AWSPaginateToken {
+    public func usingPaginationToken(_ token: [String: DynamoDB.KeysAndAttributes]) -> DynamoDB.BatchGetItemInput {
+        return .init(
+            requestItems: token, 
+            returnConsumedCapacity: self.returnConsumedCapacity
+        )
+
+    }
+}
+
+extension DynamoDB.ListContributorInsightsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DynamoDB.ListContributorInsightsInput {
         return .init(
             maxResults: self.maxResults, 
@@ -29,11 +54,60 @@ extension DynamoDB.ListContributorInsightsInput: AWSPaginateStringToken {
     }
 }
 
-extension DynamoDB.ListTablesInput: AWSPaginateStringToken {
+extension DynamoDB.ListTablesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> DynamoDB.ListTablesInput {
         return .init(
             exclusiveStartTableName: token, 
             limit: self.limit
+        )
+
+    }
+}
+
+extension DynamoDB.QueryInput: AWSPaginateToken {
+    public func usingPaginationToken(_ token: [String: DynamoDB.AttributeValue]) -> DynamoDB.QueryInput {
+        return .init(
+            attributesToGet: self.attributesToGet, 
+            conditionalOperator: self.conditionalOperator, 
+            consistentRead: self.consistentRead, 
+            exclusiveStartKey: token, 
+            expressionAttributeNames: self.expressionAttributeNames, 
+            expressionAttributeValues: self.expressionAttributeValues, 
+            filterExpression: self.filterExpression, 
+            indexName: self.indexName, 
+            keyConditionExpression: self.keyConditionExpression, 
+            keyConditions: self.keyConditions, 
+            limit: self.limit, 
+            projectionExpression: self.projectionExpression, 
+            queryFilter: self.queryFilter, 
+            returnConsumedCapacity: self.returnConsumedCapacity, 
+            scanIndexForward: self.scanIndexForward, 
+            select: self.select, 
+            tableName: self.tableName
+        )
+
+    }
+}
+
+extension DynamoDB.ScanInput: AWSPaginateToken {
+    public func usingPaginationToken(_ token: [String: DynamoDB.AttributeValue]) -> DynamoDB.ScanInput {
+        return .init(
+            attributesToGet: self.attributesToGet, 
+            conditionalOperator: self.conditionalOperator, 
+            consistentRead: self.consistentRead, 
+            exclusiveStartKey: token, 
+            expressionAttributeNames: self.expressionAttributeNames, 
+            expressionAttributeValues: self.expressionAttributeValues, 
+            filterExpression: self.filterExpression, 
+            indexName: self.indexName, 
+            limit: self.limit, 
+            projectionExpression: self.projectionExpression, 
+            returnConsumedCapacity: self.returnConsumedCapacity, 
+            scanFilter: self.scanFilter, 
+            segment: self.segment, 
+            select: self.select, 
+            tableName: self.tableName, 
+            totalSegments: self.totalSegments
         )
 
     }

--- a/Sources/AWSSDKSwift/Services/EBS/EBS_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/EBS/EBS_Paginator.swift
@@ -18,7 +18,7 @@ extension EBS {
 
 }
 
-extension EBS.ListChangedBlocksRequest: AWSPaginateStringToken {
+extension EBS.ListChangedBlocksRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EBS.ListChangedBlocksRequest {
         return .init(
             firstSnapshotId: self.firstSnapshotId, 
@@ -31,7 +31,7 @@ extension EBS.ListChangedBlocksRequest: AWSPaginateStringToken {
     }
 }
 
-extension EBS.ListSnapshotBlocksRequest: AWSPaginateStringToken {
+extension EBS.ListSnapshotBlocksRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EBS.ListSnapshotBlocksRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/EC2/EC2_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/EC2/EC2_Paginator.swift
@@ -433,7 +433,7 @@ extension EC2 {
 
 }
 
-extension EC2.DescribeByoipCidrsRequest: AWSPaginateStringToken {
+extension EC2.DescribeByoipCidrsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeByoipCidrsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -444,7 +444,7 @@ extension EC2.DescribeByoipCidrsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeCapacityReservationsRequest: AWSPaginateStringToken {
+extension EC2.DescribeCapacityReservationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeCapacityReservationsRequest {
         return .init(
             capacityReservationIds: self.capacityReservationIds, 
@@ -457,7 +457,7 @@ extension EC2.DescribeCapacityReservationsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeClassicLinkInstancesRequest: AWSPaginateStringToken {
+extension EC2.DescribeClassicLinkInstancesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeClassicLinkInstancesRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -470,7 +470,7 @@ extension EC2.DescribeClassicLinkInstancesRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeClientVpnAuthorizationRulesRequest: AWSPaginateStringToken {
+extension EC2.DescribeClientVpnAuthorizationRulesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeClientVpnAuthorizationRulesRequest {
         return .init(
             clientVpnEndpointId: self.clientVpnEndpointId, 
@@ -483,7 +483,7 @@ extension EC2.DescribeClientVpnAuthorizationRulesRequest: AWSPaginateStringToken
     }
 }
 
-extension EC2.DescribeClientVpnConnectionsRequest: AWSPaginateStringToken {
+extension EC2.DescribeClientVpnConnectionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeClientVpnConnectionsRequest {
         return .init(
             clientVpnEndpointId: self.clientVpnEndpointId, 
@@ -496,7 +496,7 @@ extension EC2.DescribeClientVpnConnectionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeClientVpnEndpointsRequest: AWSPaginateStringToken {
+extension EC2.DescribeClientVpnEndpointsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeClientVpnEndpointsRequest {
         return .init(
             clientVpnEndpointIds: self.clientVpnEndpointIds, 
@@ -509,7 +509,7 @@ extension EC2.DescribeClientVpnEndpointsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeClientVpnRoutesRequest: AWSPaginateStringToken {
+extension EC2.DescribeClientVpnRoutesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeClientVpnRoutesRequest {
         return .init(
             clientVpnEndpointId: self.clientVpnEndpointId, 
@@ -522,7 +522,7 @@ extension EC2.DescribeClientVpnRoutesRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeClientVpnTargetNetworksRequest: AWSPaginateStringToken {
+extension EC2.DescribeClientVpnTargetNetworksRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeClientVpnTargetNetworksRequest {
         return .init(
             associationIds: self.associationIds, 
@@ -536,7 +536,7 @@ extension EC2.DescribeClientVpnTargetNetworksRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeCoipPoolsRequest: AWSPaginateStringToken {
+extension EC2.DescribeCoipPoolsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeCoipPoolsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -549,7 +549,7 @@ extension EC2.DescribeCoipPoolsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeDhcpOptionsRequest: AWSPaginateStringToken {
+extension EC2.DescribeDhcpOptionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeDhcpOptionsRequest {
         return .init(
             dhcpOptionsIds: self.dhcpOptionsIds, 
@@ -562,7 +562,7 @@ extension EC2.DescribeDhcpOptionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeEgressOnlyInternetGatewaysRequest: AWSPaginateStringToken {
+extension EC2.DescribeEgressOnlyInternetGatewaysRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeEgressOnlyInternetGatewaysRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -575,7 +575,7 @@ extension EC2.DescribeEgressOnlyInternetGatewaysRequest: AWSPaginateStringToken 
     }
 }
 
-extension EC2.DescribeExportImageTasksRequest: AWSPaginateStringToken {
+extension EC2.DescribeExportImageTasksRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeExportImageTasksRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -588,7 +588,7 @@ extension EC2.DescribeExportImageTasksRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeFastSnapshotRestoresRequest: AWSPaginateStringToken {
+extension EC2.DescribeFastSnapshotRestoresRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeFastSnapshotRestoresRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -600,7 +600,7 @@ extension EC2.DescribeFastSnapshotRestoresRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeFleetsRequest: AWSPaginateStringToken {
+extension EC2.DescribeFleetsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeFleetsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -613,7 +613,7 @@ extension EC2.DescribeFleetsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeFlowLogsRequest: AWSPaginateStringToken {
+extension EC2.DescribeFlowLogsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeFlowLogsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -626,7 +626,7 @@ extension EC2.DescribeFlowLogsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeFpgaImagesRequest: AWSPaginateStringToken {
+extension EC2.DescribeFpgaImagesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeFpgaImagesRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -640,7 +640,7 @@ extension EC2.DescribeFpgaImagesRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeHostReservationOfferingsRequest: AWSPaginateStringToken {
+extension EC2.DescribeHostReservationOfferingsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeHostReservationOfferingsRequest {
         return .init(
             filter: self.filter, 
@@ -654,7 +654,7 @@ extension EC2.DescribeHostReservationOfferingsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeHostReservationsRequest: AWSPaginateStringToken {
+extension EC2.DescribeHostReservationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeHostReservationsRequest {
         return .init(
             filter: self.filter, 
@@ -666,7 +666,7 @@ extension EC2.DescribeHostReservationsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeHostsRequest: AWSPaginateStringToken {
+extension EC2.DescribeHostsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeHostsRequest {
         return .init(
             filter: self.filter, 
@@ -678,7 +678,7 @@ extension EC2.DescribeHostsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeIamInstanceProfileAssociationsRequest: AWSPaginateStringToken {
+extension EC2.DescribeIamInstanceProfileAssociationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeIamInstanceProfileAssociationsRequest {
         return .init(
             associationIds: self.associationIds, 
@@ -690,7 +690,7 @@ extension EC2.DescribeIamInstanceProfileAssociationsRequest: AWSPaginateStringTo
     }
 }
 
-extension EC2.DescribeImportImageTasksRequest: AWSPaginateStringToken {
+extension EC2.DescribeImportImageTasksRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeImportImageTasksRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -703,7 +703,7 @@ extension EC2.DescribeImportImageTasksRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeImportSnapshotTasksRequest: AWSPaginateStringToken {
+extension EC2.DescribeImportSnapshotTasksRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeImportSnapshotTasksRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -716,7 +716,7 @@ extension EC2.DescribeImportSnapshotTasksRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeInstanceCreditSpecificationsRequest: AWSPaginateStringToken {
+extension EC2.DescribeInstanceCreditSpecificationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeInstanceCreditSpecificationsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -729,7 +729,7 @@ extension EC2.DescribeInstanceCreditSpecificationsRequest: AWSPaginateStringToke
     }
 }
 
-extension EC2.DescribeInstanceStatusRequest: AWSPaginateStringToken {
+extension EC2.DescribeInstanceStatusRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeInstanceStatusRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -743,7 +743,7 @@ extension EC2.DescribeInstanceStatusRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeInstanceTypeOfferingsRequest: AWSPaginateStringToken {
+extension EC2.DescribeInstanceTypeOfferingsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeInstanceTypeOfferingsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -756,7 +756,7 @@ extension EC2.DescribeInstanceTypeOfferingsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeInstanceTypesRequest: AWSPaginateStringToken {
+extension EC2.DescribeInstanceTypesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeInstanceTypesRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -769,7 +769,7 @@ extension EC2.DescribeInstanceTypesRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeInstancesRequest: AWSPaginateStringToken {
+extension EC2.DescribeInstancesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeInstancesRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -782,7 +782,7 @@ extension EC2.DescribeInstancesRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeInternetGatewaysRequest: AWSPaginateStringToken {
+extension EC2.DescribeInternetGatewaysRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeInternetGatewaysRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -795,7 +795,7 @@ extension EC2.DescribeInternetGatewaysRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeIpv6PoolsRequest: AWSPaginateStringToken {
+extension EC2.DescribeIpv6PoolsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeIpv6PoolsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -808,7 +808,7 @@ extension EC2.DescribeIpv6PoolsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeLaunchTemplateVersionsRequest: AWSPaginateStringToken {
+extension EC2.DescribeLaunchTemplateVersionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeLaunchTemplateVersionsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -825,7 +825,7 @@ extension EC2.DescribeLaunchTemplateVersionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeLaunchTemplatesRequest: AWSPaginateStringToken {
+extension EC2.DescribeLaunchTemplatesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeLaunchTemplatesRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -839,7 +839,7 @@ extension EC2.DescribeLaunchTemplatesRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsRequest: AWSPaginateStringToken {
+extension EC2.DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -852,7 +852,7 @@ extension EC2.DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsReq
     }
 }
 
-extension EC2.DescribeLocalGatewayRouteTableVpcAssociationsRequest: AWSPaginateStringToken {
+extension EC2.DescribeLocalGatewayRouteTableVpcAssociationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeLocalGatewayRouteTableVpcAssociationsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -865,7 +865,7 @@ extension EC2.DescribeLocalGatewayRouteTableVpcAssociationsRequest: AWSPaginateS
     }
 }
 
-extension EC2.DescribeLocalGatewayRouteTablesRequest: AWSPaginateStringToken {
+extension EC2.DescribeLocalGatewayRouteTablesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeLocalGatewayRouteTablesRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -878,7 +878,7 @@ extension EC2.DescribeLocalGatewayRouteTablesRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeLocalGatewayVirtualInterfaceGroupsRequest: AWSPaginateStringToken {
+extension EC2.DescribeLocalGatewayVirtualInterfaceGroupsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeLocalGatewayVirtualInterfaceGroupsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -891,7 +891,7 @@ extension EC2.DescribeLocalGatewayVirtualInterfaceGroupsRequest: AWSPaginateStri
     }
 }
 
-extension EC2.DescribeLocalGatewayVirtualInterfacesRequest: AWSPaginateStringToken {
+extension EC2.DescribeLocalGatewayVirtualInterfacesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeLocalGatewayVirtualInterfacesRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -904,7 +904,7 @@ extension EC2.DescribeLocalGatewayVirtualInterfacesRequest: AWSPaginateStringTok
     }
 }
 
-extension EC2.DescribeLocalGatewaysRequest: AWSPaginateStringToken {
+extension EC2.DescribeLocalGatewaysRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeLocalGatewaysRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -917,7 +917,7 @@ extension EC2.DescribeLocalGatewaysRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeMovingAddressesRequest: AWSPaginateStringToken {
+extension EC2.DescribeMovingAddressesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeMovingAddressesRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -930,7 +930,7 @@ extension EC2.DescribeMovingAddressesRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeNatGatewaysRequest: AWSPaginateStringToken {
+extension EC2.DescribeNatGatewaysRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeNatGatewaysRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -943,7 +943,7 @@ extension EC2.DescribeNatGatewaysRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeNetworkAclsRequest: AWSPaginateStringToken {
+extension EC2.DescribeNetworkAclsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeNetworkAclsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -956,7 +956,7 @@ extension EC2.DescribeNetworkAclsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeNetworkInterfacePermissionsRequest: AWSPaginateStringToken {
+extension EC2.DescribeNetworkInterfacePermissionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeNetworkInterfacePermissionsRequest {
         return .init(
             filters: self.filters, 
@@ -968,7 +968,7 @@ extension EC2.DescribeNetworkInterfacePermissionsRequest: AWSPaginateStringToken
     }
 }
 
-extension EC2.DescribeNetworkInterfacesRequest: AWSPaginateStringToken {
+extension EC2.DescribeNetworkInterfacesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeNetworkInterfacesRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -981,7 +981,7 @@ extension EC2.DescribeNetworkInterfacesRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribePrefixListsRequest: AWSPaginateStringToken {
+extension EC2.DescribePrefixListsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribePrefixListsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -994,7 +994,7 @@ extension EC2.DescribePrefixListsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribePrincipalIdFormatRequest: AWSPaginateStringToken {
+extension EC2.DescribePrincipalIdFormatRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribePrincipalIdFormatRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1006,7 +1006,7 @@ extension EC2.DescribePrincipalIdFormatRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribePublicIpv4PoolsRequest: AWSPaginateStringToken {
+extension EC2.DescribePublicIpv4PoolsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribePublicIpv4PoolsRequest {
         return .init(
             filters: self.filters, 
@@ -1018,7 +1018,7 @@ extension EC2.DescribePublicIpv4PoolsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeReservedInstancesModificationsRequest: AWSPaginateStringToken {
+extension EC2.DescribeReservedInstancesModificationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeReservedInstancesModificationsRequest {
         return .init(
             filters: self.filters, 
@@ -1029,7 +1029,7 @@ extension EC2.DescribeReservedInstancesModificationsRequest: AWSPaginateStringTo
     }
 }
 
-extension EC2.DescribeReservedInstancesOfferingsRequest: AWSPaginateStringToken {
+extension EC2.DescribeReservedInstancesOfferingsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeReservedInstancesOfferingsRequest {
         return .init(
             availabilityZone: self.availabilityZone, 
@@ -1052,7 +1052,7 @@ extension EC2.DescribeReservedInstancesOfferingsRequest: AWSPaginateStringToken 
     }
 }
 
-extension EC2.DescribeRouteTablesRequest: AWSPaginateStringToken {
+extension EC2.DescribeRouteTablesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeRouteTablesRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1065,7 +1065,7 @@ extension EC2.DescribeRouteTablesRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeScheduledInstanceAvailabilityRequest: AWSPaginateStringToken {
+extension EC2.DescribeScheduledInstanceAvailabilityRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeScheduledInstanceAvailabilityRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1081,7 +1081,7 @@ extension EC2.DescribeScheduledInstanceAvailabilityRequest: AWSPaginateStringTok
     }
 }
 
-extension EC2.DescribeScheduledInstancesRequest: AWSPaginateStringToken {
+extension EC2.DescribeScheduledInstancesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeScheduledInstancesRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1095,7 +1095,7 @@ extension EC2.DescribeScheduledInstancesRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeSecurityGroupsRequest: AWSPaginateStringToken {
+extension EC2.DescribeSecurityGroupsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeSecurityGroupsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1109,7 +1109,7 @@ extension EC2.DescribeSecurityGroupsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeSnapshotsRequest: AWSPaginateStringToken {
+extension EC2.DescribeSnapshotsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeSnapshotsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1124,7 +1124,7 @@ extension EC2.DescribeSnapshotsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeSpotFleetRequestsRequest: AWSPaginateStringToken {
+extension EC2.DescribeSpotFleetRequestsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeSpotFleetRequestsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1136,7 +1136,7 @@ extension EC2.DescribeSpotFleetRequestsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeSpotInstanceRequestsRequest: AWSPaginateStringToken {
+extension EC2.DescribeSpotInstanceRequestsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeSpotInstanceRequestsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1149,7 +1149,7 @@ extension EC2.DescribeSpotInstanceRequestsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeSpotPriceHistoryRequest: AWSPaginateStringToken {
+extension EC2.DescribeSpotPriceHistoryRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeSpotPriceHistoryRequest {
         return .init(
             availabilityZone: self.availabilityZone, 
@@ -1166,7 +1166,7 @@ extension EC2.DescribeSpotPriceHistoryRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeStaleSecurityGroupsRequest: AWSPaginateStringToken {
+extension EC2.DescribeStaleSecurityGroupsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeStaleSecurityGroupsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1178,7 +1178,7 @@ extension EC2.DescribeStaleSecurityGroupsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeSubnetsRequest: AWSPaginateStringToken {
+extension EC2.DescribeSubnetsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeSubnetsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1191,7 +1191,7 @@ extension EC2.DescribeSubnetsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeTagsRequest: AWSPaginateStringToken {
+extension EC2.DescribeTagsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeTagsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1203,7 +1203,7 @@ extension EC2.DescribeTagsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeTrafficMirrorFiltersRequest: AWSPaginateStringToken {
+extension EC2.DescribeTrafficMirrorFiltersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeTrafficMirrorFiltersRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1216,7 +1216,7 @@ extension EC2.DescribeTrafficMirrorFiltersRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeTrafficMirrorSessionsRequest: AWSPaginateStringToken {
+extension EC2.DescribeTrafficMirrorSessionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeTrafficMirrorSessionsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1229,7 +1229,7 @@ extension EC2.DescribeTrafficMirrorSessionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeTrafficMirrorTargetsRequest: AWSPaginateStringToken {
+extension EC2.DescribeTrafficMirrorTargetsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeTrafficMirrorTargetsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1242,7 +1242,7 @@ extension EC2.DescribeTrafficMirrorTargetsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeTransitGatewayAttachmentsRequest: AWSPaginateStringToken {
+extension EC2.DescribeTransitGatewayAttachmentsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeTransitGatewayAttachmentsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1255,7 +1255,7 @@ extension EC2.DescribeTransitGatewayAttachmentsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeTransitGatewayMulticastDomainsRequest: AWSPaginateStringToken {
+extension EC2.DescribeTransitGatewayMulticastDomainsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeTransitGatewayMulticastDomainsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1268,7 +1268,7 @@ extension EC2.DescribeTransitGatewayMulticastDomainsRequest: AWSPaginateStringTo
     }
 }
 
-extension EC2.DescribeTransitGatewayPeeringAttachmentsRequest: AWSPaginateStringToken {
+extension EC2.DescribeTransitGatewayPeeringAttachmentsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeTransitGatewayPeeringAttachmentsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1281,7 +1281,7 @@ extension EC2.DescribeTransitGatewayPeeringAttachmentsRequest: AWSPaginateString
     }
 }
 
-extension EC2.DescribeTransitGatewayRouteTablesRequest: AWSPaginateStringToken {
+extension EC2.DescribeTransitGatewayRouteTablesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeTransitGatewayRouteTablesRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1294,7 +1294,7 @@ extension EC2.DescribeTransitGatewayRouteTablesRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeTransitGatewayVpcAttachmentsRequest: AWSPaginateStringToken {
+extension EC2.DescribeTransitGatewayVpcAttachmentsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeTransitGatewayVpcAttachmentsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1307,7 +1307,7 @@ extension EC2.DescribeTransitGatewayVpcAttachmentsRequest: AWSPaginateStringToke
     }
 }
 
-extension EC2.DescribeTransitGatewaysRequest: AWSPaginateStringToken {
+extension EC2.DescribeTransitGatewaysRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeTransitGatewaysRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1320,7 +1320,7 @@ extension EC2.DescribeTransitGatewaysRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeVolumeStatusRequest: AWSPaginateStringToken {
+extension EC2.DescribeVolumeStatusRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeVolumeStatusRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1333,7 +1333,7 @@ extension EC2.DescribeVolumeStatusRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeVolumesRequest: AWSPaginateStringToken {
+extension EC2.DescribeVolumesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeVolumesRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1346,7 +1346,7 @@ extension EC2.DescribeVolumesRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeVolumesModificationsRequest: AWSPaginateStringToken {
+extension EC2.DescribeVolumesModificationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeVolumesModificationsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1359,7 +1359,7 @@ extension EC2.DescribeVolumesModificationsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeVpcClassicLinkDnsSupportRequest: AWSPaginateStringToken {
+extension EC2.DescribeVpcClassicLinkDnsSupportRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeVpcClassicLinkDnsSupportRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -1370,7 +1370,7 @@ extension EC2.DescribeVpcClassicLinkDnsSupportRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeVpcEndpointConnectionNotificationsRequest: AWSPaginateStringToken {
+extension EC2.DescribeVpcEndpointConnectionNotificationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeVpcEndpointConnectionNotificationsRequest {
         return .init(
             connectionNotificationId: self.connectionNotificationId, 
@@ -1383,7 +1383,7 @@ extension EC2.DescribeVpcEndpointConnectionNotificationsRequest: AWSPaginateStri
     }
 }
 
-extension EC2.DescribeVpcEndpointConnectionsRequest: AWSPaginateStringToken {
+extension EC2.DescribeVpcEndpointConnectionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeVpcEndpointConnectionsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1395,7 +1395,7 @@ extension EC2.DescribeVpcEndpointConnectionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeVpcEndpointServiceConfigurationsRequest: AWSPaginateStringToken {
+extension EC2.DescribeVpcEndpointServiceConfigurationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeVpcEndpointServiceConfigurationsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1408,7 +1408,7 @@ extension EC2.DescribeVpcEndpointServiceConfigurationsRequest: AWSPaginateString
     }
 }
 
-extension EC2.DescribeVpcEndpointServicePermissionsRequest: AWSPaginateStringToken {
+extension EC2.DescribeVpcEndpointServicePermissionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeVpcEndpointServicePermissionsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1421,7 +1421,7 @@ extension EC2.DescribeVpcEndpointServicePermissionsRequest: AWSPaginateStringTok
     }
 }
 
-extension EC2.DescribeVpcEndpointsRequest: AWSPaginateStringToken {
+extension EC2.DescribeVpcEndpointsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeVpcEndpointsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1434,7 +1434,7 @@ extension EC2.DescribeVpcEndpointsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeVpcPeeringConnectionsRequest: AWSPaginateStringToken {
+extension EC2.DescribeVpcPeeringConnectionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeVpcPeeringConnectionsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1447,7 +1447,7 @@ extension EC2.DescribeVpcPeeringConnectionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.DescribeVpcsRequest: AWSPaginateStringToken {
+extension EC2.DescribeVpcsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.DescribeVpcsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1460,7 +1460,7 @@ extension EC2.DescribeVpcsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.GetAssociatedIpv6PoolCidrsRequest: AWSPaginateStringToken {
+extension EC2.GetAssociatedIpv6PoolCidrsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.GetAssociatedIpv6PoolCidrsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1472,7 +1472,7 @@ extension EC2.GetAssociatedIpv6PoolCidrsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.GetTransitGatewayAttachmentPropagationsRequest: AWSPaginateStringToken {
+extension EC2.GetTransitGatewayAttachmentPropagationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.GetTransitGatewayAttachmentPropagationsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1485,7 +1485,7 @@ extension EC2.GetTransitGatewayAttachmentPropagationsRequest: AWSPaginateStringT
     }
 }
 
-extension EC2.GetTransitGatewayMulticastDomainAssociationsRequest: AWSPaginateStringToken {
+extension EC2.GetTransitGatewayMulticastDomainAssociationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.GetTransitGatewayMulticastDomainAssociationsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1498,7 +1498,7 @@ extension EC2.GetTransitGatewayMulticastDomainAssociationsRequest: AWSPaginateSt
     }
 }
 
-extension EC2.GetTransitGatewayRouteTableAssociationsRequest: AWSPaginateStringToken {
+extension EC2.GetTransitGatewayRouteTableAssociationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.GetTransitGatewayRouteTableAssociationsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1511,7 +1511,7 @@ extension EC2.GetTransitGatewayRouteTableAssociationsRequest: AWSPaginateStringT
     }
 }
 
-extension EC2.GetTransitGatewayRouteTablePropagationsRequest: AWSPaginateStringToken {
+extension EC2.GetTransitGatewayRouteTablePropagationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.GetTransitGatewayRouteTablePropagationsRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1524,7 +1524,7 @@ extension EC2.GetTransitGatewayRouteTablePropagationsRequest: AWSPaginateStringT
     }
 }
 
-extension EC2.SearchLocalGatewayRoutesRequest: AWSPaginateStringToken {
+extension EC2.SearchLocalGatewayRoutesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.SearchLocalGatewayRoutesRequest {
         return .init(
             dryRun: self.dryRun, 
@@ -1537,7 +1537,7 @@ extension EC2.SearchLocalGatewayRoutesRequest: AWSPaginateStringToken {
     }
 }
 
-extension EC2.SearchTransitGatewayMulticastGroupsRequest: AWSPaginateStringToken {
+extension EC2.SearchTransitGatewayMulticastGroupsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EC2.SearchTransitGatewayMulticastGroupsRequest {
         return .init(
             dryRun: self.dryRun, 

--- a/Sources/AWSSDKSwift/Services/ECR/ECR_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/ECR/ECR_Paginator.swift
@@ -33,7 +33,7 @@ extension ECR {
 
 }
 
-extension ECR.DescribeImageScanFindingsRequest: AWSPaginateStringToken {
+extension ECR.DescribeImageScanFindingsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ECR.DescribeImageScanFindingsRequest {
         return .init(
             imageId: self.imageId, 
@@ -46,7 +46,7 @@ extension ECR.DescribeImageScanFindingsRequest: AWSPaginateStringToken {
     }
 }
 
-extension ECR.DescribeImagesRequest: AWSPaginateStringToken {
+extension ECR.DescribeImagesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ECR.DescribeImagesRequest {
         return .init(
             filter: self.filter, 
@@ -60,7 +60,7 @@ extension ECR.DescribeImagesRequest: AWSPaginateStringToken {
     }
 }
 
-extension ECR.DescribeRepositoriesRequest: AWSPaginateStringToken {
+extension ECR.DescribeRepositoriesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ECR.DescribeRepositoriesRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -72,7 +72,7 @@ extension ECR.DescribeRepositoriesRequest: AWSPaginateStringToken {
     }
 }
 
-extension ECR.GetLifecyclePolicyPreviewRequest: AWSPaginateStringToken {
+extension ECR.GetLifecyclePolicyPreviewRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ECR.GetLifecyclePolicyPreviewRequest {
         return .init(
             filter: self.filter, 
@@ -86,7 +86,7 @@ extension ECR.GetLifecyclePolicyPreviewRequest: AWSPaginateStringToken {
     }
 }
 
-extension ECR.ListImagesRequest: AWSPaginateStringToken {
+extension ECR.ListImagesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ECR.ListImagesRequest {
         return .init(
             filter: self.filter, 

--- a/Sources/AWSSDKSwift/Services/ECS/ECS_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/ECS/ECS_Paginator.swift
@@ -48,7 +48,7 @@ extension ECS {
 
 }
 
-extension ECS.ListAccountSettingsRequest: AWSPaginateStringToken {
+extension ECS.ListAccountSettingsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ECS.ListAccountSettingsRequest {
         return .init(
             effectiveSettings: self.effectiveSettings, 
@@ -62,7 +62,7 @@ extension ECS.ListAccountSettingsRequest: AWSPaginateStringToken {
     }
 }
 
-extension ECS.ListAttributesRequest: AWSPaginateStringToken {
+extension ECS.ListAttributesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ECS.ListAttributesRequest {
         return .init(
             attributeName: self.attributeName, 
@@ -76,7 +76,7 @@ extension ECS.ListAttributesRequest: AWSPaginateStringToken {
     }
 }
 
-extension ECS.ListClustersRequest: AWSPaginateStringToken {
+extension ECS.ListClustersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ECS.ListClustersRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -86,7 +86,7 @@ extension ECS.ListClustersRequest: AWSPaginateStringToken {
     }
 }
 
-extension ECS.ListContainerInstancesRequest: AWSPaginateStringToken {
+extension ECS.ListContainerInstancesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ECS.ListContainerInstancesRequest {
         return .init(
             cluster: self.cluster, 
@@ -99,7 +99,7 @@ extension ECS.ListContainerInstancesRequest: AWSPaginateStringToken {
     }
 }
 
-extension ECS.ListServicesRequest: AWSPaginateStringToken {
+extension ECS.ListServicesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ECS.ListServicesRequest {
         return .init(
             cluster: self.cluster, 
@@ -112,7 +112,7 @@ extension ECS.ListServicesRequest: AWSPaginateStringToken {
     }
 }
 
-extension ECS.ListTaskDefinitionFamiliesRequest: AWSPaginateStringToken {
+extension ECS.ListTaskDefinitionFamiliesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ECS.ListTaskDefinitionFamiliesRequest {
         return .init(
             familyPrefix: self.familyPrefix, 
@@ -124,7 +124,7 @@ extension ECS.ListTaskDefinitionFamiliesRequest: AWSPaginateStringToken {
     }
 }
 
-extension ECS.ListTaskDefinitionsRequest: AWSPaginateStringToken {
+extension ECS.ListTaskDefinitionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ECS.ListTaskDefinitionsRequest {
         return .init(
             familyPrefix: self.familyPrefix, 
@@ -137,7 +137,7 @@ extension ECS.ListTaskDefinitionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension ECS.ListTasksRequest: AWSPaginateStringToken {
+extension ECS.ListTasksRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ECS.ListTasksRequest {
         return .init(
             cluster: self.cluster, 

--- a/Sources/AWSSDKSwift/Services/EFS/EFS_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/EFS/EFS_Paginator.swift
@@ -29,7 +29,7 @@ extension EFS {
 
 }
 
-extension EFS.DescribeAccessPointsRequest: AWSPaginateStringToken {
+extension EFS.DescribeAccessPointsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EFS.DescribeAccessPointsRequest {
         return .init(
             accessPointId: self.accessPointId, 
@@ -41,7 +41,7 @@ extension EFS.DescribeAccessPointsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EFS.DescribeFileSystemsRequest: AWSPaginateStringToken {
+extension EFS.DescribeFileSystemsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EFS.DescribeFileSystemsRequest {
         return .init(
             creationToken: self.creationToken, 
@@ -53,7 +53,7 @@ extension EFS.DescribeFileSystemsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EFS.DescribeTagsRequest: AWSPaginateStringToken {
+extension EFS.DescribeTagsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EFS.DescribeTagsRequest {
         return .init(
             fileSystemId: self.fileSystemId, 
@@ -64,7 +64,7 @@ extension EFS.DescribeTagsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EFS.ListTagsForResourceRequest: AWSPaginateStringToken {
+extension EFS.ListTagsForResourceRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EFS.ListTagsForResourceRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/EKS/EKS_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/EKS/EKS_Paginator.swift
@@ -28,7 +28,7 @@ extension EKS {
 
 }
 
-extension EKS.ListClustersRequest: AWSPaginateStringToken {
+extension EKS.ListClustersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EKS.ListClustersRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -38,7 +38,7 @@ extension EKS.ListClustersRequest: AWSPaginateStringToken {
     }
 }
 
-extension EKS.ListFargateProfilesRequest: AWSPaginateStringToken {
+extension EKS.ListFargateProfilesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EKS.ListFargateProfilesRequest {
         return .init(
             clusterName: self.clusterName, 
@@ -49,7 +49,7 @@ extension EKS.ListFargateProfilesRequest: AWSPaginateStringToken {
     }
 }
 
-extension EKS.ListNodegroupsRequest: AWSPaginateStringToken {
+extension EKS.ListNodegroupsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EKS.ListNodegroupsRequest {
         return .init(
             clusterName: self.clusterName, 
@@ -60,7 +60,7 @@ extension EKS.ListNodegroupsRequest: AWSPaginateStringToken {
     }
 }
 
-extension EKS.ListUpdatesRequest: AWSPaginateStringToken {
+extension EKS.ListUpdatesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EKS.ListUpdatesRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/ELB/ELB_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/ELB/ELB_Paginator.swift
@@ -13,7 +13,7 @@ extension ELB {
 
 }
 
-extension ELB.DescribeAccessPointsInput: AWSPaginateStringToken {
+extension ELB.DescribeAccessPointsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ELB.DescribeAccessPointsInput {
         return .init(
             loadBalancerNames: self.loadBalancerNames, 

--- a/Sources/AWSSDKSwift/Services/ELBV2/ELBV2_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/ELBV2/ELBV2_Paginator.swift
@@ -23,7 +23,7 @@ extension ELBV2 {
 
 }
 
-extension ELBV2.DescribeListenersInput: AWSPaginateStringToken {
+extension ELBV2.DescribeListenersInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ELBV2.DescribeListenersInput {
         return .init(
             listenerArns: self.listenerArns, 
@@ -35,7 +35,7 @@ extension ELBV2.DescribeListenersInput: AWSPaginateStringToken {
     }
 }
 
-extension ELBV2.DescribeLoadBalancersInput: AWSPaginateStringToken {
+extension ELBV2.DescribeLoadBalancersInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ELBV2.DescribeLoadBalancersInput {
         return .init(
             loadBalancerArns: self.loadBalancerArns, 
@@ -47,7 +47,7 @@ extension ELBV2.DescribeLoadBalancersInput: AWSPaginateStringToken {
     }
 }
 
-extension ELBV2.DescribeTargetGroupsInput: AWSPaginateStringToken {
+extension ELBV2.DescribeTargetGroupsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ELBV2.DescribeTargetGroupsInput {
         return .init(
             loadBalancerArn: self.loadBalancerArn, 

--- a/Sources/AWSSDKSwift/Services/EMR/EMR_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/EMR/EMR_Paginator.swift
@@ -43,7 +43,7 @@ extension EMR {
 
 }
 
-extension EMR.ListBootstrapActionsInput: AWSPaginateStringToken {
+extension EMR.ListBootstrapActionsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EMR.ListBootstrapActionsInput {
         return .init(
             clusterId: self.clusterId, 
@@ -53,7 +53,7 @@ extension EMR.ListBootstrapActionsInput: AWSPaginateStringToken {
     }
 }
 
-extension EMR.ListClustersInput: AWSPaginateStringToken {
+extension EMR.ListClustersInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EMR.ListClustersInput {
         return .init(
             clusterStates: self.clusterStates, 
@@ -65,7 +65,7 @@ extension EMR.ListClustersInput: AWSPaginateStringToken {
     }
 }
 
-extension EMR.ListInstanceFleetsInput: AWSPaginateStringToken {
+extension EMR.ListInstanceFleetsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EMR.ListInstanceFleetsInput {
         return .init(
             clusterId: self.clusterId, 
@@ -75,7 +75,7 @@ extension EMR.ListInstanceFleetsInput: AWSPaginateStringToken {
     }
 }
 
-extension EMR.ListInstanceGroupsInput: AWSPaginateStringToken {
+extension EMR.ListInstanceGroupsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EMR.ListInstanceGroupsInput {
         return .init(
             clusterId: self.clusterId, 
@@ -85,7 +85,7 @@ extension EMR.ListInstanceGroupsInput: AWSPaginateStringToken {
     }
 }
 
-extension EMR.ListInstancesInput: AWSPaginateStringToken {
+extension EMR.ListInstancesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EMR.ListInstancesInput {
         return .init(
             clusterId: self.clusterId, 
@@ -100,7 +100,7 @@ extension EMR.ListInstancesInput: AWSPaginateStringToken {
     }
 }
 
-extension EMR.ListSecurityConfigurationsInput: AWSPaginateStringToken {
+extension EMR.ListSecurityConfigurationsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EMR.ListSecurityConfigurationsInput {
         return .init(
             marker: token
@@ -109,7 +109,7 @@ extension EMR.ListSecurityConfigurationsInput: AWSPaginateStringToken {
     }
 }
 
-extension EMR.ListStepsInput: AWSPaginateStringToken {
+extension EMR.ListStepsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> EMR.ListStepsInput {
         return .init(
             clusterId: self.clusterId, 

--- a/Sources/AWSSDKSwift/Services/ElastiCache/ElastiCache_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/ElastiCache/ElastiCache_Paginator.swift
@@ -83,7 +83,7 @@ extension ElastiCache {
 
 }
 
-extension ElastiCache.DescribeCacheClustersMessage: AWSPaginateStringToken {
+extension ElastiCache.DescribeCacheClustersMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ElastiCache.DescribeCacheClustersMessage {
         return .init(
             cacheClusterId: self.cacheClusterId, 
@@ -96,7 +96,7 @@ extension ElastiCache.DescribeCacheClustersMessage: AWSPaginateStringToken {
     }
 }
 
-extension ElastiCache.DescribeCacheEngineVersionsMessage: AWSPaginateStringToken {
+extension ElastiCache.DescribeCacheEngineVersionsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ElastiCache.DescribeCacheEngineVersionsMessage {
         return .init(
             cacheParameterGroupFamily: self.cacheParameterGroupFamily, 
@@ -110,7 +110,7 @@ extension ElastiCache.DescribeCacheEngineVersionsMessage: AWSPaginateStringToken
     }
 }
 
-extension ElastiCache.DescribeCacheParameterGroupsMessage: AWSPaginateStringToken {
+extension ElastiCache.DescribeCacheParameterGroupsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ElastiCache.DescribeCacheParameterGroupsMessage {
         return .init(
             cacheParameterGroupName: self.cacheParameterGroupName, 
@@ -121,7 +121,7 @@ extension ElastiCache.DescribeCacheParameterGroupsMessage: AWSPaginateStringToke
     }
 }
 
-extension ElastiCache.DescribeCacheParametersMessage: AWSPaginateStringToken {
+extension ElastiCache.DescribeCacheParametersMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ElastiCache.DescribeCacheParametersMessage {
         return .init(
             cacheParameterGroupName: self.cacheParameterGroupName, 
@@ -133,7 +133,7 @@ extension ElastiCache.DescribeCacheParametersMessage: AWSPaginateStringToken {
     }
 }
 
-extension ElastiCache.DescribeCacheSecurityGroupsMessage: AWSPaginateStringToken {
+extension ElastiCache.DescribeCacheSecurityGroupsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ElastiCache.DescribeCacheSecurityGroupsMessage {
         return .init(
             cacheSecurityGroupName: self.cacheSecurityGroupName, 
@@ -144,7 +144,7 @@ extension ElastiCache.DescribeCacheSecurityGroupsMessage: AWSPaginateStringToken
     }
 }
 
-extension ElastiCache.DescribeCacheSubnetGroupsMessage: AWSPaginateStringToken {
+extension ElastiCache.DescribeCacheSubnetGroupsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ElastiCache.DescribeCacheSubnetGroupsMessage {
         return .init(
             cacheSubnetGroupName: self.cacheSubnetGroupName, 
@@ -155,7 +155,7 @@ extension ElastiCache.DescribeCacheSubnetGroupsMessage: AWSPaginateStringToken {
     }
 }
 
-extension ElastiCache.DescribeEngineDefaultParametersMessage: AWSPaginateStringToken {
+extension ElastiCache.DescribeEngineDefaultParametersMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ElastiCache.DescribeEngineDefaultParametersMessage {
         return .init(
             cacheParameterGroupFamily: self.cacheParameterGroupFamily, 
@@ -166,7 +166,7 @@ extension ElastiCache.DescribeEngineDefaultParametersMessage: AWSPaginateStringT
     }
 }
 
-extension ElastiCache.DescribeEventsMessage: AWSPaginateStringToken {
+extension ElastiCache.DescribeEventsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ElastiCache.DescribeEventsMessage {
         return .init(
             duration: self.duration, 
@@ -181,7 +181,7 @@ extension ElastiCache.DescribeEventsMessage: AWSPaginateStringToken {
     }
 }
 
-extension ElastiCache.DescribeGlobalReplicationGroupsMessage: AWSPaginateStringToken {
+extension ElastiCache.DescribeGlobalReplicationGroupsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ElastiCache.DescribeGlobalReplicationGroupsMessage {
         return .init(
             globalReplicationGroupId: self.globalReplicationGroupId, 
@@ -193,7 +193,7 @@ extension ElastiCache.DescribeGlobalReplicationGroupsMessage: AWSPaginateStringT
     }
 }
 
-extension ElastiCache.DescribeReplicationGroupsMessage: AWSPaginateStringToken {
+extension ElastiCache.DescribeReplicationGroupsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ElastiCache.DescribeReplicationGroupsMessage {
         return .init(
             marker: token, 
@@ -204,7 +204,7 @@ extension ElastiCache.DescribeReplicationGroupsMessage: AWSPaginateStringToken {
     }
 }
 
-extension ElastiCache.DescribeReservedCacheNodesMessage: AWSPaginateStringToken {
+extension ElastiCache.DescribeReservedCacheNodesMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ElastiCache.DescribeReservedCacheNodesMessage {
         return .init(
             cacheNodeType: self.cacheNodeType, 
@@ -220,7 +220,7 @@ extension ElastiCache.DescribeReservedCacheNodesMessage: AWSPaginateStringToken 
     }
 }
 
-extension ElastiCache.DescribeReservedCacheNodesOfferingsMessage: AWSPaginateStringToken {
+extension ElastiCache.DescribeReservedCacheNodesOfferingsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ElastiCache.DescribeReservedCacheNodesOfferingsMessage {
         return .init(
             cacheNodeType: self.cacheNodeType, 
@@ -235,7 +235,7 @@ extension ElastiCache.DescribeReservedCacheNodesOfferingsMessage: AWSPaginateStr
     }
 }
 
-extension ElastiCache.DescribeServiceUpdatesMessage: AWSPaginateStringToken {
+extension ElastiCache.DescribeServiceUpdatesMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ElastiCache.DescribeServiceUpdatesMessage {
         return .init(
             marker: token, 
@@ -247,7 +247,7 @@ extension ElastiCache.DescribeServiceUpdatesMessage: AWSPaginateStringToken {
     }
 }
 
-extension ElastiCache.DescribeSnapshotsMessage: AWSPaginateStringToken {
+extension ElastiCache.DescribeSnapshotsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ElastiCache.DescribeSnapshotsMessage {
         return .init(
             cacheClusterId: self.cacheClusterId, 
@@ -262,7 +262,7 @@ extension ElastiCache.DescribeSnapshotsMessage: AWSPaginateStringToken {
     }
 }
 
-extension ElastiCache.DescribeUpdateActionsMessage: AWSPaginateStringToken {
+extension ElastiCache.DescribeUpdateActionsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ElastiCache.DescribeUpdateActionsMessage {
         return .init(
             cacheClusterIds: self.cacheClusterIds, 

--- a/Sources/AWSSDKSwift/Services/ElasticBeanstalk/ElasticBeanstalk_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/ElasticBeanstalk/ElasticBeanstalk_Paginator.swift
@@ -13,7 +13,7 @@ extension ElasticBeanstalk {
 
 }
 
-extension ElasticBeanstalk.DescribeEventsMessage: AWSPaginateStringToken {
+extension ElasticBeanstalk.DescribeEventsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ElasticBeanstalk.DescribeEventsMessage {
         return .init(
             applicationName: self.applicationName, 

--- a/Sources/AWSSDKSwift/Services/ElasticTranscoder/ElasticTranscoder_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/ElasticTranscoder/ElasticTranscoder_Paginator.swift
@@ -28,7 +28,7 @@ extension ElasticTranscoder {
 
 }
 
-extension ElasticTranscoder.ListJobsByPipelineRequest: AWSPaginateStringToken {
+extension ElasticTranscoder.ListJobsByPipelineRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ElasticTranscoder.ListJobsByPipelineRequest {
         return .init(
             ascending: self.ascending, 
@@ -39,7 +39,7 @@ extension ElasticTranscoder.ListJobsByPipelineRequest: AWSPaginateStringToken {
     }
 }
 
-extension ElasticTranscoder.ListJobsByStatusRequest: AWSPaginateStringToken {
+extension ElasticTranscoder.ListJobsByStatusRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ElasticTranscoder.ListJobsByStatusRequest {
         return .init(
             ascending: self.ascending, 
@@ -50,7 +50,7 @@ extension ElasticTranscoder.ListJobsByStatusRequest: AWSPaginateStringToken {
     }
 }
 
-extension ElasticTranscoder.ListPipelinesRequest: AWSPaginateStringToken {
+extension ElasticTranscoder.ListPipelinesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ElasticTranscoder.ListPipelinesRequest {
         return .init(
             ascending: self.ascending, 
@@ -60,7 +60,7 @@ extension ElasticTranscoder.ListPipelinesRequest: AWSPaginateStringToken {
     }
 }
 
-extension ElasticTranscoder.ListPresetsRequest: AWSPaginateStringToken {
+extension ElasticTranscoder.ListPresetsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ElasticTranscoder.ListPresetsRequest {
         return .init(
             ascending: self.ascending, 

--- a/Sources/AWSSDKSwift/Services/ElasticsearchService/ElasticsearchService_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/ElasticsearchService/ElasticsearchService_Paginator.swift
@@ -48,7 +48,7 @@ extension ElasticsearchService {
 
 }
 
-extension ElasticsearchService.DescribePackagesRequest: AWSPaginateStringToken {
+extension ElasticsearchService.DescribePackagesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ElasticsearchService.DescribePackagesRequest {
         return .init(
             filters: self.filters, 
@@ -59,7 +59,7 @@ extension ElasticsearchService.DescribePackagesRequest: AWSPaginateStringToken {
     }
 }
 
-extension ElasticsearchService.DescribeReservedElasticsearchInstanceOfferingsRequest: AWSPaginateStringToken {
+extension ElasticsearchService.DescribeReservedElasticsearchInstanceOfferingsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ElasticsearchService.DescribeReservedElasticsearchInstanceOfferingsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -70,7 +70,7 @@ extension ElasticsearchService.DescribeReservedElasticsearchInstanceOfferingsReq
     }
 }
 
-extension ElasticsearchService.DescribeReservedElasticsearchInstancesRequest: AWSPaginateStringToken {
+extension ElasticsearchService.DescribeReservedElasticsearchInstancesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ElasticsearchService.DescribeReservedElasticsearchInstancesRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -81,7 +81,7 @@ extension ElasticsearchService.DescribeReservedElasticsearchInstancesRequest: AW
     }
 }
 
-extension ElasticsearchService.GetUpgradeHistoryRequest: AWSPaginateStringToken {
+extension ElasticsearchService.GetUpgradeHistoryRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ElasticsearchService.GetUpgradeHistoryRequest {
         return .init(
             domainName: self.domainName, 
@@ -92,7 +92,7 @@ extension ElasticsearchService.GetUpgradeHistoryRequest: AWSPaginateStringToken 
     }
 }
 
-extension ElasticsearchService.ListDomainsForPackageRequest: AWSPaginateStringToken {
+extension ElasticsearchService.ListDomainsForPackageRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ElasticsearchService.ListDomainsForPackageRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -103,7 +103,7 @@ extension ElasticsearchService.ListDomainsForPackageRequest: AWSPaginateStringTo
     }
 }
 
-extension ElasticsearchService.ListElasticsearchInstanceTypesRequest: AWSPaginateStringToken {
+extension ElasticsearchService.ListElasticsearchInstanceTypesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ElasticsearchService.ListElasticsearchInstanceTypesRequest {
         return .init(
             domainName: self.domainName, 
@@ -115,7 +115,7 @@ extension ElasticsearchService.ListElasticsearchInstanceTypesRequest: AWSPaginat
     }
 }
 
-extension ElasticsearchService.ListElasticsearchVersionsRequest: AWSPaginateStringToken {
+extension ElasticsearchService.ListElasticsearchVersionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ElasticsearchService.ListElasticsearchVersionsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -125,7 +125,7 @@ extension ElasticsearchService.ListElasticsearchVersionsRequest: AWSPaginateStri
     }
 }
 
-extension ElasticsearchService.ListPackagesForDomainRequest: AWSPaginateStringToken {
+extension ElasticsearchService.ListPackagesForDomainRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ElasticsearchService.ListPackagesForDomainRequest {
         return .init(
             domainName: self.domainName, 

--- a/Sources/AWSSDKSwift/Services/FMS/FMS_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/FMS/FMS_Paginator.swift
@@ -23,7 +23,7 @@ extension FMS {
 
 }
 
-extension FMS.ListComplianceStatusRequest: AWSPaginateStringToken {
+extension FMS.ListComplianceStatusRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> FMS.ListComplianceStatusRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -34,7 +34,7 @@ extension FMS.ListComplianceStatusRequest: AWSPaginateStringToken {
     }
 }
 
-extension FMS.ListMemberAccountsRequest: AWSPaginateStringToken {
+extension FMS.ListMemberAccountsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> FMS.ListMemberAccountsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -44,7 +44,7 @@ extension FMS.ListMemberAccountsRequest: AWSPaginateStringToken {
     }
 }
 
-extension FMS.ListPoliciesRequest: AWSPaginateStringToken {
+extension FMS.ListPoliciesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> FMS.ListPoliciesRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/FSx/FSx_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/FSx/FSx_Paginator.swift
@@ -23,7 +23,7 @@ extension FSx {
 
 }
 
-extension FSx.DescribeBackupsRequest: AWSPaginateStringToken {
+extension FSx.DescribeBackupsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> FSx.DescribeBackupsRequest {
         return .init(
             backupIds: self.backupIds, 
@@ -35,7 +35,7 @@ extension FSx.DescribeBackupsRequest: AWSPaginateStringToken {
     }
 }
 
-extension FSx.DescribeDataRepositoryTasksRequest: AWSPaginateStringToken {
+extension FSx.DescribeDataRepositoryTasksRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> FSx.DescribeDataRepositoryTasksRequest {
         return .init(
             filters: self.filters, 
@@ -47,7 +47,7 @@ extension FSx.DescribeDataRepositoryTasksRequest: AWSPaginateStringToken {
     }
 }
 
-extension FSx.DescribeFileSystemsRequest: AWSPaginateStringToken {
+extension FSx.DescribeFileSystemsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> FSx.DescribeFileSystemsRequest {
         return .init(
             fileSystemIds: self.fileSystemIds, 

--- a/Sources/AWSSDKSwift/Services/ForecastService/ForecastService_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/ForecastService/ForecastService_Paginator.swift
@@ -38,7 +38,7 @@ extension ForecastService {
 
 }
 
-extension ForecastService.ListDatasetGroupsRequest: AWSPaginateStringToken {
+extension ForecastService.ListDatasetGroupsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ForecastService.ListDatasetGroupsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -48,7 +48,7 @@ extension ForecastService.ListDatasetGroupsRequest: AWSPaginateStringToken {
     }
 }
 
-extension ForecastService.ListDatasetImportJobsRequest: AWSPaginateStringToken {
+extension ForecastService.ListDatasetImportJobsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ForecastService.ListDatasetImportJobsRequest {
         return .init(
             filters: self.filters, 
@@ -59,7 +59,7 @@ extension ForecastService.ListDatasetImportJobsRequest: AWSPaginateStringToken {
     }
 }
 
-extension ForecastService.ListDatasetsRequest: AWSPaginateStringToken {
+extension ForecastService.ListDatasetsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ForecastService.ListDatasetsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -69,7 +69,7 @@ extension ForecastService.ListDatasetsRequest: AWSPaginateStringToken {
     }
 }
 
-extension ForecastService.ListForecastExportJobsRequest: AWSPaginateStringToken {
+extension ForecastService.ListForecastExportJobsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ForecastService.ListForecastExportJobsRequest {
         return .init(
             filters: self.filters, 
@@ -80,7 +80,7 @@ extension ForecastService.ListForecastExportJobsRequest: AWSPaginateStringToken 
     }
 }
 
-extension ForecastService.ListForecastsRequest: AWSPaginateStringToken {
+extension ForecastService.ListForecastsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ForecastService.ListForecastsRequest {
         return .init(
             filters: self.filters, 
@@ -91,7 +91,7 @@ extension ForecastService.ListForecastsRequest: AWSPaginateStringToken {
     }
 }
 
-extension ForecastService.ListPredictorsRequest: AWSPaginateStringToken {
+extension ForecastService.ListPredictorsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ForecastService.ListPredictorsRequest {
         return .init(
             filters: self.filters, 

--- a/Sources/AWSSDKSwift/Services/FraudDetector/FraudDetector_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/FraudDetector/FraudDetector_Paginator.swift
@@ -43,7 +43,7 @@ extension FraudDetector {
 
 }
 
-extension FraudDetector.DescribeModelVersionsRequest: AWSPaginateStringToken {
+extension FraudDetector.DescribeModelVersionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> FraudDetector.DescribeModelVersionsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -56,7 +56,7 @@ extension FraudDetector.DescribeModelVersionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension FraudDetector.GetDetectorsRequest: AWSPaginateStringToken {
+extension FraudDetector.GetDetectorsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> FraudDetector.GetDetectorsRequest {
         return .init(
             detectorId: self.detectorId, 
@@ -67,7 +67,7 @@ extension FraudDetector.GetDetectorsRequest: AWSPaginateStringToken {
     }
 }
 
-extension FraudDetector.GetExternalModelsRequest: AWSPaginateStringToken {
+extension FraudDetector.GetExternalModelsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> FraudDetector.GetExternalModelsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -78,7 +78,7 @@ extension FraudDetector.GetExternalModelsRequest: AWSPaginateStringToken {
     }
 }
 
-extension FraudDetector.GetModelsRequest: AWSPaginateStringToken {
+extension FraudDetector.GetModelsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> FraudDetector.GetModelsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -90,7 +90,7 @@ extension FraudDetector.GetModelsRequest: AWSPaginateStringToken {
     }
 }
 
-extension FraudDetector.GetOutcomesRequest: AWSPaginateStringToken {
+extension FraudDetector.GetOutcomesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> FraudDetector.GetOutcomesRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -101,7 +101,7 @@ extension FraudDetector.GetOutcomesRequest: AWSPaginateStringToken {
     }
 }
 
-extension FraudDetector.GetRulesRequest: AWSPaginateStringToken {
+extension FraudDetector.GetRulesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> FraudDetector.GetRulesRequest {
         return .init(
             detectorId: self.detectorId, 
@@ -114,7 +114,7 @@ extension FraudDetector.GetRulesRequest: AWSPaginateStringToken {
     }
 }
 
-extension FraudDetector.GetVariablesRequest: AWSPaginateStringToken {
+extension FraudDetector.GetVariablesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> FraudDetector.GetVariablesRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/Glacier/Glacier_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Glacier/Glacier_Paginator.swift
@@ -28,7 +28,7 @@ extension Glacier {
 
 }
 
-extension Glacier.ListJobsInput: AWSPaginateStringToken {
+extension Glacier.ListJobsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Glacier.ListJobsInput {
         return .init(
             accountId: self.accountId, 
@@ -42,7 +42,7 @@ extension Glacier.ListJobsInput: AWSPaginateStringToken {
     }
 }
 
-extension Glacier.ListMultipartUploadsInput: AWSPaginateStringToken {
+extension Glacier.ListMultipartUploadsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Glacier.ListMultipartUploadsInput {
         return .init(
             accountId: self.accountId, 
@@ -54,7 +54,7 @@ extension Glacier.ListMultipartUploadsInput: AWSPaginateStringToken {
     }
 }
 
-extension Glacier.ListPartsInput: AWSPaginateStringToken {
+extension Glacier.ListPartsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Glacier.ListPartsInput {
         return .init(
             accountId: self.accountId, 
@@ -67,7 +67,7 @@ extension Glacier.ListPartsInput: AWSPaginateStringToken {
     }
 }
 
-extension Glacier.ListVaultsInput: AWSPaginateStringToken {
+extension Glacier.ListVaultsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Glacier.ListVaultsInput {
         return .init(
             accountId: self.accountId, 

--- a/Sources/AWSSDKSwift/Services/Glue/Glue_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Glue/Glue_Paginator.swift
@@ -128,7 +128,7 @@ extension Glue {
 
 }
 
-extension Glue.GetClassifiersRequest: AWSPaginateStringToken {
+extension Glue.GetClassifiersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Glue.GetClassifiersRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -138,7 +138,7 @@ extension Glue.GetClassifiersRequest: AWSPaginateStringToken {
     }
 }
 
-extension Glue.GetConnectionsRequest: AWSPaginateStringToken {
+extension Glue.GetConnectionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Glue.GetConnectionsRequest {
         return .init(
             catalogId: self.catalogId, 
@@ -151,7 +151,7 @@ extension Glue.GetConnectionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Glue.GetCrawlerMetricsRequest: AWSPaginateStringToken {
+extension Glue.GetCrawlerMetricsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Glue.GetCrawlerMetricsRequest {
         return .init(
             crawlerNameList: self.crawlerNameList, 
@@ -162,7 +162,7 @@ extension Glue.GetCrawlerMetricsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Glue.GetCrawlersRequest: AWSPaginateStringToken {
+extension Glue.GetCrawlersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Glue.GetCrawlersRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -172,7 +172,7 @@ extension Glue.GetCrawlersRequest: AWSPaginateStringToken {
     }
 }
 
-extension Glue.GetDatabasesRequest: AWSPaginateStringToken {
+extension Glue.GetDatabasesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Glue.GetDatabasesRequest {
         return .init(
             catalogId: self.catalogId, 
@@ -183,7 +183,7 @@ extension Glue.GetDatabasesRequest: AWSPaginateStringToken {
     }
 }
 
-extension Glue.GetDevEndpointsRequest: AWSPaginateStringToken {
+extension Glue.GetDevEndpointsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Glue.GetDevEndpointsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -193,7 +193,7 @@ extension Glue.GetDevEndpointsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Glue.GetJobRunsRequest: AWSPaginateStringToken {
+extension Glue.GetJobRunsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Glue.GetJobRunsRequest {
         return .init(
             jobName: self.jobName, 
@@ -204,7 +204,7 @@ extension Glue.GetJobRunsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Glue.GetJobsRequest: AWSPaginateStringToken {
+extension Glue.GetJobsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Glue.GetJobsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -214,7 +214,7 @@ extension Glue.GetJobsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Glue.GetMLTaskRunsRequest: AWSPaginateStringToken {
+extension Glue.GetMLTaskRunsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Glue.GetMLTaskRunsRequest {
         return .init(
             filter: self.filter, 
@@ -227,7 +227,7 @@ extension Glue.GetMLTaskRunsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Glue.GetMLTransformsRequest: AWSPaginateStringToken {
+extension Glue.GetMLTransformsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Glue.GetMLTransformsRequest {
         return .init(
             filter: self.filter, 
@@ -239,7 +239,7 @@ extension Glue.GetMLTransformsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Glue.GetPartitionsRequest: AWSPaginateStringToken {
+extension Glue.GetPartitionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Glue.GetPartitionsRequest {
         return .init(
             catalogId: self.catalogId, 
@@ -254,7 +254,7 @@ extension Glue.GetPartitionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Glue.GetSecurityConfigurationsRequest: AWSPaginateStringToken {
+extension Glue.GetSecurityConfigurationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Glue.GetSecurityConfigurationsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -264,7 +264,7 @@ extension Glue.GetSecurityConfigurationsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Glue.GetTableVersionsRequest: AWSPaginateStringToken {
+extension Glue.GetTableVersionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Glue.GetTableVersionsRequest {
         return .init(
             catalogId: self.catalogId, 
@@ -277,7 +277,7 @@ extension Glue.GetTableVersionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Glue.GetTablesRequest: AWSPaginateStringToken {
+extension Glue.GetTablesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Glue.GetTablesRequest {
         return .init(
             catalogId: self.catalogId, 
@@ -290,7 +290,7 @@ extension Glue.GetTablesRequest: AWSPaginateStringToken {
     }
 }
 
-extension Glue.GetTriggersRequest: AWSPaginateStringToken {
+extension Glue.GetTriggersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Glue.GetTriggersRequest {
         return .init(
             dependentJobName: self.dependentJobName, 
@@ -301,7 +301,7 @@ extension Glue.GetTriggersRequest: AWSPaginateStringToken {
     }
 }
 
-extension Glue.GetUserDefinedFunctionsRequest: AWSPaginateStringToken {
+extension Glue.GetUserDefinedFunctionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Glue.GetUserDefinedFunctionsRequest {
         return .init(
             catalogId: self.catalogId, 
@@ -314,7 +314,7 @@ extension Glue.GetUserDefinedFunctionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Glue.GetWorkflowRunsRequest: AWSPaginateStringToken {
+extension Glue.GetWorkflowRunsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Glue.GetWorkflowRunsRequest {
         return .init(
             includeGraph: self.includeGraph, 
@@ -326,7 +326,7 @@ extension Glue.GetWorkflowRunsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Glue.ListCrawlersRequest: AWSPaginateStringToken {
+extension Glue.ListCrawlersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Glue.ListCrawlersRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -337,7 +337,7 @@ extension Glue.ListCrawlersRequest: AWSPaginateStringToken {
     }
 }
 
-extension Glue.ListDevEndpointsRequest: AWSPaginateStringToken {
+extension Glue.ListDevEndpointsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Glue.ListDevEndpointsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -348,7 +348,7 @@ extension Glue.ListDevEndpointsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Glue.ListJobsRequest: AWSPaginateStringToken {
+extension Glue.ListJobsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Glue.ListJobsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -359,7 +359,7 @@ extension Glue.ListJobsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Glue.ListMLTransformsRequest: AWSPaginateStringToken {
+extension Glue.ListMLTransformsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Glue.ListMLTransformsRequest {
         return .init(
             filter: self.filter, 
@@ -372,7 +372,7 @@ extension Glue.ListMLTransformsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Glue.ListTriggersRequest: AWSPaginateStringToken {
+extension Glue.ListTriggersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Glue.ListTriggersRequest {
         return .init(
             dependentJobName: self.dependentJobName, 
@@ -384,7 +384,7 @@ extension Glue.ListTriggersRequest: AWSPaginateStringToken {
     }
 }
 
-extension Glue.ListWorkflowsRequest: AWSPaginateStringToken {
+extension Glue.ListWorkflowsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Glue.ListWorkflowsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -394,7 +394,7 @@ extension Glue.ListWorkflowsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Glue.SearchTablesRequest: AWSPaginateStringToken {
+extension Glue.SearchTablesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Glue.SearchTablesRequest {
         return .init(
             catalogId: self.catalogId, 

--- a/Sources/AWSSDKSwift/Services/GroundStation/GroundStation_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/GroundStation/GroundStation_Paginator.swift
@@ -38,7 +38,7 @@ extension GroundStation {
 
 }
 
-extension GroundStation.ListConfigsRequest: AWSPaginateStringToken {
+extension GroundStation.ListConfigsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> GroundStation.ListConfigsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -48,7 +48,7 @@ extension GroundStation.ListConfigsRequest: AWSPaginateStringToken {
     }
 }
 
-extension GroundStation.ListContactsRequest: AWSPaginateStringToken {
+extension GroundStation.ListContactsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> GroundStation.ListContactsRequest {
         return .init(
             endTime: self.endTime, 
@@ -64,7 +64,7 @@ extension GroundStation.ListContactsRequest: AWSPaginateStringToken {
     }
 }
 
-extension GroundStation.ListDataflowEndpointGroupsRequest: AWSPaginateStringToken {
+extension GroundStation.ListDataflowEndpointGroupsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> GroundStation.ListDataflowEndpointGroupsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -74,7 +74,7 @@ extension GroundStation.ListDataflowEndpointGroupsRequest: AWSPaginateStringToke
     }
 }
 
-extension GroundStation.ListGroundStationsRequest: AWSPaginateStringToken {
+extension GroundStation.ListGroundStationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> GroundStation.ListGroundStationsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -85,7 +85,7 @@ extension GroundStation.ListGroundStationsRequest: AWSPaginateStringToken {
     }
 }
 
-extension GroundStation.ListMissionProfilesRequest: AWSPaginateStringToken {
+extension GroundStation.ListMissionProfilesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> GroundStation.ListMissionProfilesRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -95,7 +95,7 @@ extension GroundStation.ListMissionProfilesRequest: AWSPaginateStringToken {
     }
 }
 
-extension GroundStation.ListSatellitesRequest: AWSPaginateStringToken {
+extension GroundStation.ListSatellitesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> GroundStation.ListSatellitesRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/GuardDuty/GuardDuty_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/GuardDuty/GuardDuty_Paginator.swift
@@ -48,7 +48,7 @@ extension GuardDuty {
 
 }
 
-extension GuardDuty.ListDetectorsRequest: AWSPaginateStringToken {
+extension GuardDuty.ListDetectorsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> GuardDuty.ListDetectorsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -58,7 +58,7 @@ extension GuardDuty.ListDetectorsRequest: AWSPaginateStringToken {
     }
 }
 
-extension GuardDuty.ListFiltersRequest: AWSPaginateStringToken {
+extension GuardDuty.ListFiltersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> GuardDuty.ListFiltersRequest {
         return .init(
             detectorId: self.detectorId, 
@@ -69,7 +69,7 @@ extension GuardDuty.ListFiltersRequest: AWSPaginateStringToken {
     }
 }
 
-extension GuardDuty.ListFindingsRequest: AWSPaginateStringToken {
+extension GuardDuty.ListFindingsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> GuardDuty.ListFindingsRequest {
         return .init(
             detectorId: self.detectorId, 
@@ -82,7 +82,7 @@ extension GuardDuty.ListFindingsRequest: AWSPaginateStringToken {
     }
 }
 
-extension GuardDuty.ListIPSetsRequest: AWSPaginateStringToken {
+extension GuardDuty.ListIPSetsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> GuardDuty.ListIPSetsRequest {
         return .init(
             detectorId: self.detectorId, 
@@ -93,7 +93,7 @@ extension GuardDuty.ListIPSetsRequest: AWSPaginateStringToken {
     }
 }
 
-extension GuardDuty.ListInvitationsRequest: AWSPaginateStringToken {
+extension GuardDuty.ListInvitationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> GuardDuty.ListInvitationsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -103,7 +103,7 @@ extension GuardDuty.ListInvitationsRequest: AWSPaginateStringToken {
     }
 }
 
-extension GuardDuty.ListMembersRequest: AWSPaginateStringToken {
+extension GuardDuty.ListMembersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> GuardDuty.ListMembersRequest {
         return .init(
             detectorId: self.detectorId, 
@@ -115,7 +115,7 @@ extension GuardDuty.ListMembersRequest: AWSPaginateStringToken {
     }
 }
 
-extension GuardDuty.ListPublishingDestinationsRequest: AWSPaginateStringToken {
+extension GuardDuty.ListPublishingDestinationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> GuardDuty.ListPublishingDestinationsRequest {
         return .init(
             detectorId: self.detectorId, 
@@ -126,7 +126,7 @@ extension GuardDuty.ListPublishingDestinationsRequest: AWSPaginateStringToken {
     }
 }
 
-extension GuardDuty.ListThreatIntelSetsRequest: AWSPaginateStringToken {
+extension GuardDuty.ListThreatIntelSetsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> GuardDuty.ListThreatIntelSetsRequest {
         return .init(
             detectorId: self.detectorId, 

--- a/Sources/AWSSDKSwift/Services/Health/Health_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Health/Health_Paginator.swift
@@ -43,7 +43,7 @@ extension Health {
 
 }
 
-extension Health.DescribeAffectedAccountsForOrganizationRequest: AWSPaginateStringToken {
+extension Health.DescribeAffectedAccountsForOrganizationRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Health.DescribeAffectedAccountsForOrganizationRequest {
         return .init(
             eventArn: self.eventArn, 
@@ -54,7 +54,7 @@ extension Health.DescribeAffectedAccountsForOrganizationRequest: AWSPaginateStri
     }
 }
 
-extension Health.DescribeAffectedEntitiesRequest: AWSPaginateStringToken {
+extension Health.DescribeAffectedEntitiesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Health.DescribeAffectedEntitiesRequest {
         return .init(
             filter: self.filter, 
@@ -66,7 +66,7 @@ extension Health.DescribeAffectedEntitiesRequest: AWSPaginateStringToken {
     }
 }
 
-extension Health.DescribeAffectedEntitiesForOrganizationRequest: AWSPaginateStringToken {
+extension Health.DescribeAffectedEntitiesForOrganizationRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Health.DescribeAffectedEntitiesForOrganizationRequest {
         return .init(
             locale: self.locale, 
@@ -78,7 +78,7 @@ extension Health.DescribeAffectedEntitiesForOrganizationRequest: AWSPaginateStri
     }
 }
 
-extension Health.DescribeEventAggregatesRequest: AWSPaginateStringToken {
+extension Health.DescribeEventAggregatesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Health.DescribeEventAggregatesRequest {
         return .init(
             aggregateField: self.aggregateField, 
@@ -90,7 +90,7 @@ extension Health.DescribeEventAggregatesRequest: AWSPaginateStringToken {
     }
 }
 
-extension Health.DescribeEventTypesRequest: AWSPaginateStringToken {
+extension Health.DescribeEventTypesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Health.DescribeEventTypesRequest {
         return .init(
             filter: self.filter, 
@@ -102,7 +102,7 @@ extension Health.DescribeEventTypesRequest: AWSPaginateStringToken {
     }
 }
 
-extension Health.DescribeEventsRequest: AWSPaginateStringToken {
+extension Health.DescribeEventsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Health.DescribeEventsRequest {
         return .init(
             filter: self.filter, 
@@ -114,7 +114,7 @@ extension Health.DescribeEventsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Health.DescribeEventsForOrganizationRequest: AWSPaginateStringToken {
+extension Health.DescribeEventsForOrganizationRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Health.DescribeEventsForOrganizationRequest {
         return .init(
             filter: self.filter, 

--- a/Sources/AWSSDKSwift/Services/IAM/IAM_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/IAM/IAM_Paginator.swift
@@ -138,7 +138,7 @@ extension IAM {
 
 }
 
-extension IAM.GetAccountAuthorizationDetailsRequest: AWSPaginateStringToken {
+extension IAM.GetAccountAuthorizationDetailsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IAM.GetAccountAuthorizationDetailsRequest {
         return .init(
             filter: self.filter, 
@@ -149,7 +149,7 @@ extension IAM.GetAccountAuthorizationDetailsRequest: AWSPaginateStringToken {
     }
 }
 
-extension IAM.GetGroupRequest: AWSPaginateStringToken {
+extension IAM.GetGroupRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IAM.GetGroupRequest {
         return .init(
             groupName: self.groupName, 
@@ -160,7 +160,7 @@ extension IAM.GetGroupRequest: AWSPaginateStringToken {
     }
 }
 
-extension IAM.ListAccessKeysRequest: AWSPaginateStringToken {
+extension IAM.ListAccessKeysRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IAM.ListAccessKeysRequest {
         return .init(
             marker: token, 
@@ -171,7 +171,7 @@ extension IAM.ListAccessKeysRequest: AWSPaginateStringToken {
     }
 }
 
-extension IAM.ListAccountAliasesRequest: AWSPaginateStringToken {
+extension IAM.ListAccountAliasesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IAM.ListAccountAliasesRequest {
         return .init(
             marker: token, 
@@ -181,7 +181,7 @@ extension IAM.ListAccountAliasesRequest: AWSPaginateStringToken {
     }
 }
 
-extension IAM.ListAttachedGroupPoliciesRequest: AWSPaginateStringToken {
+extension IAM.ListAttachedGroupPoliciesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IAM.ListAttachedGroupPoliciesRequest {
         return .init(
             groupName: self.groupName, 
@@ -193,7 +193,7 @@ extension IAM.ListAttachedGroupPoliciesRequest: AWSPaginateStringToken {
     }
 }
 
-extension IAM.ListAttachedRolePoliciesRequest: AWSPaginateStringToken {
+extension IAM.ListAttachedRolePoliciesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IAM.ListAttachedRolePoliciesRequest {
         return .init(
             marker: token, 
@@ -205,7 +205,7 @@ extension IAM.ListAttachedRolePoliciesRequest: AWSPaginateStringToken {
     }
 }
 
-extension IAM.ListAttachedUserPoliciesRequest: AWSPaginateStringToken {
+extension IAM.ListAttachedUserPoliciesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IAM.ListAttachedUserPoliciesRequest {
         return .init(
             marker: token, 
@@ -217,7 +217,7 @@ extension IAM.ListAttachedUserPoliciesRequest: AWSPaginateStringToken {
     }
 }
 
-extension IAM.ListEntitiesForPolicyRequest: AWSPaginateStringToken {
+extension IAM.ListEntitiesForPolicyRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IAM.ListEntitiesForPolicyRequest {
         return .init(
             entityFilter: self.entityFilter, 
@@ -231,7 +231,7 @@ extension IAM.ListEntitiesForPolicyRequest: AWSPaginateStringToken {
     }
 }
 
-extension IAM.ListGroupPoliciesRequest: AWSPaginateStringToken {
+extension IAM.ListGroupPoliciesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IAM.ListGroupPoliciesRequest {
         return .init(
             groupName: self.groupName, 
@@ -242,7 +242,7 @@ extension IAM.ListGroupPoliciesRequest: AWSPaginateStringToken {
     }
 }
 
-extension IAM.ListGroupsRequest: AWSPaginateStringToken {
+extension IAM.ListGroupsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IAM.ListGroupsRequest {
         return .init(
             marker: token, 
@@ -253,7 +253,7 @@ extension IAM.ListGroupsRequest: AWSPaginateStringToken {
     }
 }
 
-extension IAM.ListGroupsForUserRequest: AWSPaginateStringToken {
+extension IAM.ListGroupsForUserRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IAM.ListGroupsForUserRequest {
         return .init(
             marker: token, 
@@ -264,7 +264,7 @@ extension IAM.ListGroupsForUserRequest: AWSPaginateStringToken {
     }
 }
 
-extension IAM.ListInstanceProfilesRequest: AWSPaginateStringToken {
+extension IAM.ListInstanceProfilesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IAM.ListInstanceProfilesRequest {
         return .init(
             marker: token, 
@@ -275,7 +275,7 @@ extension IAM.ListInstanceProfilesRequest: AWSPaginateStringToken {
     }
 }
 
-extension IAM.ListInstanceProfilesForRoleRequest: AWSPaginateStringToken {
+extension IAM.ListInstanceProfilesForRoleRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IAM.ListInstanceProfilesForRoleRequest {
         return .init(
             marker: token, 
@@ -286,7 +286,7 @@ extension IAM.ListInstanceProfilesForRoleRequest: AWSPaginateStringToken {
     }
 }
 
-extension IAM.ListMFADevicesRequest: AWSPaginateStringToken {
+extension IAM.ListMFADevicesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IAM.ListMFADevicesRequest {
         return .init(
             marker: token, 
@@ -297,7 +297,7 @@ extension IAM.ListMFADevicesRequest: AWSPaginateStringToken {
     }
 }
 
-extension IAM.ListPoliciesRequest: AWSPaginateStringToken {
+extension IAM.ListPoliciesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IAM.ListPoliciesRequest {
         return .init(
             marker: token, 
@@ -311,7 +311,7 @@ extension IAM.ListPoliciesRequest: AWSPaginateStringToken {
     }
 }
 
-extension IAM.ListPolicyVersionsRequest: AWSPaginateStringToken {
+extension IAM.ListPolicyVersionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IAM.ListPolicyVersionsRequest {
         return .init(
             marker: token, 
@@ -322,7 +322,7 @@ extension IAM.ListPolicyVersionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension IAM.ListRolePoliciesRequest: AWSPaginateStringToken {
+extension IAM.ListRolePoliciesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IAM.ListRolePoliciesRequest {
         return .init(
             marker: token, 
@@ -333,7 +333,7 @@ extension IAM.ListRolePoliciesRequest: AWSPaginateStringToken {
     }
 }
 
-extension IAM.ListRolesRequest: AWSPaginateStringToken {
+extension IAM.ListRolesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IAM.ListRolesRequest {
         return .init(
             marker: token, 
@@ -344,7 +344,7 @@ extension IAM.ListRolesRequest: AWSPaginateStringToken {
     }
 }
 
-extension IAM.ListSSHPublicKeysRequest: AWSPaginateStringToken {
+extension IAM.ListSSHPublicKeysRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IAM.ListSSHPublicKeysRequest {
         return .init(
             marker: token, 
@@ -355,7 +355,7 @@ extension IAM.ListSSHPublicKeysRequest: AWSPaginateStringToken {
     }
 }
 
-extension IAM.ListServerCertificatesRequest: AWSPaginateStringToken {
+extension IAM.ListServerCertificatesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IAM.ListServerCertificatesRequest {
         return .init(
             marker: token, 
@@ -366,7 +366,7 @@ extension IAM.ListServerCertificatesRequest: AWSPaginateStringToken {
     }
 }
 
-extension IAM.ListSigningCertificatesRequest: AWSPaginateStringToken {
+extension IAM.ListSigningCertificatesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IAM.ListSigningCertificatesRequest {
         return .init(
             marker: token, 
@@ -377,7 +377,7 @@ extension IAM.ListSigningCertificatesRequest: AWSPaginateStringToken {
     }
 }
 
-extension IAM.ListUserPoliciesRequest: AWSPaginateStringToken {
+extension IAM.ListUserPoliciesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IAM.ListUserPoliciesRequest {
         return .init(
             marker: token, 
@@ -388,7 +388,7 @@ extension IAM.ListUserPoliciesRequest: AWSPaginateStringToken {
     }
 }
 
-extension IAM.ListUsersRequest: AWSPaginateStringToken {
+extension IAM.ListUsersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IAM.ListUsersRequest {
         return .init(
             marker: token, 
@@ -399,7 +399,7 @@ extension IAM.ListUsersRequest: AWSPaginateStringToken {
     }
 }
 
-extension IAM.ListVirtualMFADevicesRequest: AWSPaginateStringToken {
+extension IAM.ListVirtualMFADevicesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IAM.ListVirtualMFADevicesRequest {
         return .init(
             assignmentStatus: self.assignmentStatus, 
@@ -410,7 +410,7 @@ extension IAM.ListVirtualMFADevicesRequest: AWSPaginateStringToken {
     }
 }
 
-extension IAM.SimulateCustomPolicyRequest: AWSPaginateStringToken {
+extension IAM.SimulateCustomPolicyRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IAM.SimulateCustomPolicyRequest {
         return .init(
             actionNames: self.actionNames, 
@@ -429,7 +429,7 @@ extension IAM.SimulateCustomPolicyRequest: AWSPaginateStringToken {
     }
 }
 
-extension IAM.SimulatePrincipalPolicyRequest: AWSPaginateStringToken {
+extension IAM.SimulatePrincipalPolicyRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IAM.SimulatePrincipalPolicyRequest {
         return .init(
             actionNames: self.actionNames, 

--- a/Sources/AWSSDKSwift/Services/Imagebuilder/Imagebuilder_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Imagebuilder/Imagebuilder_Paginator.swift
@@ -53,7 +53,7 @@ extension Imagebuilder {
 
 }
 
-extension Imagebuilder.ListComponentBuildVersionsRequest: AWSPaginateStringToken {
+extension Imagebuilder.ListComponentBuildVersionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Imagebuilder.ListComponentBuildVersionsRequest {
         return .init(
             componentVersionArn: self.componentVersionArn, 
@@ -64,7 +64,7 @@ extension Imagebuilder.ListComponentBuildVersionsRequest: AWSPaginateStringToken
     }
 }
 
-extension Imagebuilder.ListComponentsRequest: AWSPaginateStringToken {
+extension Imagebuilder.ListComponentsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Imagebuilder.ListComponentsRequest {
         return .init(
             filters: self.filters, 
@@ -76,7 +76,7 @@ extension Imagebuilder.ListComponentsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Imagebuilder.ListDistributionConfigurationsRequest: AWSPaginateStringToken {
+extension Imagebuilder.ListDistributionConfigurationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Imagebuilder.ListDistributionConfigurationsRequest {
         return .init(
             filters: self.filters, 
@@ -87,7 +87,7 @@ extension Imagebuilder.ListDistributionConfigurationsRequest: AWSPaginateStringT
     }
 }
 
-extension Imagebuilder.ListImageBuildVersionsRequest: AWSPaginateStringToken {
+extension Imagebuilder.ListImageBuildVersionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Imagebuilder.ListImageBuildVersionsRequest {
         return .init(
             filters: self.filters, 
@@ -99,7 +99,7 @@ extension Imagebuilder.ListImageBuildVersionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Imagebuilder.ListImagePipelineImagesRequest: AWSPaginateStringToken {
+extension Imagebuilder.ListImagePipelineImagesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Imagebuilder.ListImagePipelineImagesRequest {
         return .init(
             filters: self.filters, 
@@ -111,7 +111,7 @@ extension Imagebuilder.ListImagePipelineImagesRequest: AWSPaginateStringToken {
     }
 }
 
-extension Imagebuilder.ListImagePipelinesRequest: AWSPaginateStringToken {
+extension Imagebuilder.ListImagePipelinesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Imagebuilder.ListImagePipelinesRequest {
         return .init(
             filters: self.filters, 
@@ -122,7 +122,7 @@ extension Imagebuilder.ListImagePipelinesRequest: AWSPaginateStringToken {
     }
 }
 
-extension Imagebuilder.ListImageRecipesRequest: AWSPaginateStringToken {
+extension Imagebuilder.ListImageRecipesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Imagebuilder.ListImageRecipesRequest {
         return .init(
             filters: self.filters, 
@@ -134,7 +134,7 @@ extension Imagebuilder.ListImageRecipesRequest: AWSPaginateStringToken {
     }
 }
 
-extension Imagebuilder.ListImagesRequest: AWSPaginateStringToken {
+extension Imagebuilder.ListImagesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Imagebuilder.ListImagesRequest {
         return .init(
             filters: self.filters, 
@@ -146,7 +146,7 @@ extension Imagebuilder.ListImagesRequest: AWSPaginateStringToken {
     }
 }
 
-extension Imagebuilder.ListInfrastructureConfigurationsRequest: AWSPaginateStringToken {
+extension Imagebuilder.ListInfrastructureConfigurationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Imagebuilder.ListInfrastructureConfigurationsRequest {
         return .init(
             filters: self.filters, 

--- a/Sources/AWSSDKSwift/Services/ImportExport/ImportExport_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/ImportExport/ImportExport_Paginator.swift
@@ -13,7 +13,7 @@ extension ImportExport {
 
 }
 
-extension ImportExport.ListJobsInput: AWSPaginateStringToken {
+extension ImportExport.ListJobsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ImportExport.ListJobsInput {
         return .init(
             aPIVersion: self.aPIVersion, 

--- a/Sources/AWSSDKSwift/Services/Inspector/Inspector_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Inspector/Inspector_Paginator.swift
@@ -58,7 +58,7 @@ extension Inspector {
 
 }
 
-extension Inspector.GetExclusionsPreviewRequest: AWSPaginateStringToken {
+extension Inspector.GetExclusionsPreviewRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Inspector.GetExclusionsPreviewRequest {
         return .init(
             assessmentTemplateArn: self.assessmentTemplateArn, 
@@ -71,7 +71,7 @@ extension Inspector.GetExclusionsPreviewRequest: AWSPaginateStringToken {
     }
 }
 
-extension Inspector.ListAssessmentRunAgentsRequest: AWSPaginateStringToken {
+extension Inspector.ListAssessmentRunAgentsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Inspector.ListAssessmentRunAgentsRequest {
         return .init(
             assessmentRunArn: self.assessmentRunArn, 
@@ -83,7 +83,7 @@ extension Inspector.ListAssessmentRunAgentsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Inspector.ListAssessmentRunsRequest: AWSPaginateStringToken {
+extension Inspector.ListAssessmentRunsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Inspector.ListAssessmentRunsRequest {
         return .init(
             assessmentTemplateArns: self.assessmentTemplateArns, 
@@ -95,7 +95,7 @@ extension Inspector.ListAssessmentRunsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Inspector.ListAssessmentTargetsRequest: AWSPaginateStringToken {
+extension Inspector.ListAssessmentTargetsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Inspector.ListAssessmentTargetsRequest {
         return .init(
             filter: self.filter, 
@@ -106,7 +106,7 @@ extension Inspector.ListAssessmentTargetsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Inspector.ListAssessmentTemplatesRequest: AWSPaginateStringToken {
+extension Inspector.ListAssessmentTemplatesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Inspector.ListAssessmentTemplatesRequest {
         return .init(
             assessmentTargetArns: self.assessmentTargetArns, 
@@ -118,7 +118,7 @@ extension Inspector.ListAssessmentTemplatesRequest: AWSPaginateStringToken {
     }
 }
 
-extension Inspector.ListEventSubscriptionsRequest: AWSPaginateStringToken {
+extension Inspector.ListEventSubscriptionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Inspector.ListEventSubscriptionsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -129,7 +129,7 @@ extension Inspector.ListEventSubscriptionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Inspector.ListExclusionsRequest: AWSPaginateStringToken {
+extension Inspector.ListExclusionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Inspector.ListExclusionsRequest {
         return .init(
             assessmentRunArn: self.assessmentRunArn, 
@@ -140,7 +140,7 @@ extension Inspector.ListExclusionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Inspector.ListFindingsRequest: AWSPaginateStringToken {
+extension Inspector.ListFindingsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Inspector.ListFindingsRequest {
         return .init(
             assessmentRunArns: self.assessmentRunArns, 
@@ -152,7 +152,7 @@ extension Inspector.ListFindingsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Inspector.ListRulesPackagesRequest: AWSPaginateStringToken {
+extension Inspector.ListRulesPackagesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Inspector.ListRulesPackagesRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -162,7 +162,7 @@ extension Inspector.ListRulesPackagesRequest: AWSPaginateStringToken {
     }
 }
 
-extension Inspector.PreviewAgentsRequest: AWSPaginateStringToken {
+extension Inspector.PreviewAgentsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Inspector.PreviewAgentsRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/IoT1ClickProjects/IoT1ClickProjects_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/IoT1ClickProjects/IoT1ClickProjects_Paginator.swift
@@ -18,7 +18,7 @@ extension IoT1ClickProjects {
 
 }
 
-extension IoT1ClickProjects.ListPlacementsRequest: AWSPaginateStringToken {
+extension IoT1ClickProjects.ListPlacementsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IoT1ClickProjects.ListPlacementsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -29,7 +29,7 @@ extension IoT1ClickProjects.ListPlacementsRequest: AWSPaginateStringToken {
     }
 }
 
-extension IoT1ClickProjects.ListProjectsRequest: AWSPaginateStringToken {
+extension IoT1ClickProjects.ListProjectsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IoT1ClickProjects.ListProjectsRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/IoTAnalytics/IoTAnalytics_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/IoTAnalytics/IoTAnalytics_Paginator.swift
@@ -33,7 +33,7 @@ extension IoTAnalytics {
 
 }
 
-extension IoTAnalytics.ListChannelsRequest: AWSPaginateStringToken {
+extension IoTAnalytics.ListChannelsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IoTAnalytics.ListChannelsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -43,7 +43,7 @@ extension IoTAnalytics.ListChannelsRequest: AWSPaginateStringToken {
     }
 }
 
-extension IoTAnalytics.ListDatasetContentsRequest: AWSPaginateStringToken {
+extension IoTAnalytics.ListDatasetContentsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IoTAnalytics.ListDatasetContentsRequest {
         return .init(
             datasetName: self.datasetName, 
@@ -56,7 +56,7 @@ extension IoTAnalytics.ListDatasetContentsRequest: AWSPaginateStringToken {
     }
 }
 
-extension IoTAnalytics.ListDatasetsRequest: AWSPaginateStringToken {
+extension IoTAnalytics.ListDatasetsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IoTAnalytics.ListDatasetsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -66,7 +66,7 @@ extension IoTAnalytics.ListDatasetsRequest: AWSPaginateStringToken {
     }
 }
 
-extension IoTAnalytics.ListDatastoresRequest: AWSPaginateStringToken {
+extension IoTAnalytics.ListDatastoresRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IoTAnalytics.ListDatastoresRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -76,7 +76,7 @@ extension IoTAnalytics.ListDatastoresRequest: AWSPaginateStringToken {
     }
 }
 
-extension IoTAnalytics.ListPipelinesRequest: AWSPaginateStringToken {
+extension IoTAnalytics.ListPipelinesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IoTAnalytics.ListPipelinesRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/IoTSecureTunneling/IoTSecureTunneling_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/IoTSecureTunneling/IoTSecureTunneling_Paginator.swift
@@ -13,7 +13,7 @@ extension IoTSecureTunneling {
 
 }
 
-extension IoTSecureTunneling.ListTunnelsRequest: AWSPaginateStringToken {
+extension IoTSecureTunneling.ListTunnelsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IoTSecureTunneling.ListTunnelsRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/IoTThingsGraph/IoTThingsGraph_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/IoTThingsGraph/IoTThingsGraph_Paginator.swift
@@ -58,7 +58,7 @@ extension IoTThingsGraph {
 
 }
 
-extension IoTThingsGraph.GetFlowTemplateRevisionsRequest: AWSPaginateStringToken {
+extension IoTThingsGraph.GetFlowTemplateRevisionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IoTThingsGraph.GetFlowTemplateRevisionsRequest {
         return .init(
             id: self.id, 
@@ -69,7 +69,7 @@ extension IoTThingsGraph.GetFlowTemplateRevisionsRequest: AWSPaginateStringToken
     }
 }
 
-extension IoTThingsGraph.GetSystemTemplateRevisionsRequest: AWSPaginateStringToken {
+extension IoTThingsGraph.GetSystemTemplateRevisionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IoTThingsGraph.GetSystemTemplateRevisionsRequest {
         return .init(
             id: self.id, 
@@ -80,7 +80,7 @@ extension IoTThingsGraph.GetSystemTemplateRevisionsRequest: AWSPaginateStringTok
     }
 }
 
-extension IoTThingsGraph.ListFlowExecutionMessagesRequest: AWSPaginateStringToken {
+extension IoTThingsGraph.ListFlowExecutionMessagesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IoTThingsGraph.ListFlowExecutionMessagesRequest {
         return .init(
             flowExecutionId: self.flowExecutionId, 
@@ -91,7 +91,7 @@ extension IoTThingsGraph.ListFlowExecutionMessagesRequest: AWSPaginateStringToke
     }
 }
 
-extension IoTThingsGraph.ListTagsForResourceRequest: AWSPaginateStringToken {
+extension IoTThingsGraph.ListTagsForResourceRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IoTThingsGraph.ListTagsForResourceRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -102,7 +102,7 @@ extension IoTThingsGraph.ListTagsForResourceRequest: AWSPaginateStringToken {
     }
 }
 
-extension IoTThingsGraph.SearchEntitiesRequest: AWSPaginateStringToken {
+extension IoTThingsGraph.SearchEntitiesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IoTThingsGraph.SearchEntitiesRequest {
         return .init(
             entityTypes: self.entityTypes, 
@@ -115,7 +115,7 @@ extension IoTThingsGraph.SearchEntitiesRequest: AWSPaginateStringToken {
     }
 }
 
-extension IoTThingsGraph.SearchFlowExecutionsRequest: AWSPaginateStringToken {
+extension IoTThingsGraph.SearchFlowExecutionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IoTThingsGraph.SearchFlowExecutionsRequest {
         return .init(
             endTime: self.endTime, 
@@ -129,7 +129,7 @@ extension IoTThingsGraph.SearchFlowExecutionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension IoTThingsGraph.SearchFlowTemplatesRequest: AWSPaginateStringToken {
+extension IoTThingsGraph.SearchFlowTemplatesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IoTThingsGraph.SearchFlowTemplatesRequest {
         return .init(
             filters: self.filters, 
@@ -140,7 +140,7 @@ extension IoTThingsGraph.SearchFlowTemplatesRequest: AWSPaginateStringToken {
     }
 }
 
-extension IoTThingsGraph.SearchSystemInstancesRequest: AWSPaginateStringToken {
+extension IoTThingsGraph.SearchSystemInstancesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IoTThingsGraph.SearchSystemInstancesRequest {
         return .init(
             filters: self.filters, 
@@ -151,7 +151,7 @@ extension IoTThingsGraph.SearchSystemInstancesRequest: AWSPaginateStringToken {
     }
 }
 
-extension IoTThingsGraph.SearchSystemTemplatesRequest: AWSPaginateStringToken {
+extension IoTThingsGraph.SearchSystemTemplatesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IoTThingsGraph.SearchSystemTemplatesRequest {
         return .init(
             filters: self.filters, 
@@ -162,7 +162,7 @@ extension IoTThingsGraph.SearchSystemTemplatesRequest: AWSPaginateStringToken {
     }
 }
 
-extension IoTThingsGraph.SearchThingsRequest: AWSPaginateStringToken {
+extension IoTThingsGraph.SearchThingsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> IoTThingsGraph.SearchThingsRequest {
         return .init(
             entityId: self.entityId, 

--- a/Sources/AWSSDKSwift/Services/KMS/KMS_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/KMS/KMS_Paginator.swift
@@ -28,7 +28,7 @@ extension KMS {
 
 }
 
-extension KMS.ListAliasesRequest: AWSPaginateStringToken {
+extension KMS.ListAliasesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> KMS.ListAliasesRequest {
         return .init(
             keyId: self.keyId, 
@@ -39,7 +39,7 @@ extension KMS.ListAliasesRequest: AWSPaginateStringToken {
     }
 }
 
-extension KMS.ListGrantsRequest: AWSPaginateStringToken {
+extension KMS.ListGrantsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> KMS.ListGrantsRequest {
         return .init(
             keyId: self.keyId, 
@@ -50,7 +50,7 @@ extension KMS.ListGrantsRequest: AWSPaginateStringToken {
     }
 }
 
-extension KMS.ListKeyPoliciesRequest: AWSPaginateStringToken {
+extension KMS.ListKeyPoliciesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> KMS.ListKeyPoliciesRequest {
         return .init(
             keyId: self.keyId, 
@@ -61,7 +61,7 @@ extension KMS.ListKeyPoliciesRequest: AWSPaginateStringToken {
     }
 }
 
-extension KMS.ListKeysRequest: AWSPaginateStringToken {
+extension KMS.ListKeysRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> KMS.ListKeysRequest {
         return .init(
             limit: self.limit, 

--- a/Sources/AWSSDKSwift/Services/Kafka/Kafka_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Kafka/Kafka_Paginator.swift
@@ -38,7 +38,7 @@ extension Kafka {
 
 }
 
-extension Kafka.ListClusterOperationsRequest: AWSPaginateStringToken {
+extension Kafka.ListClusterOperationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Kafka.ListClusterOperationsRequest {
         return .init(
             clusterArn: self.clusterArn, 
@@ -49,7 +49,7 @@ extension Kafka.ListClusterOperationsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Kafka.ListClustersRequest: AWSPaginateStringToken {
+extension Kafka.ListClustersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Kafka.ListClustersRequest {
         return .init(
             clusterNameFilter: self.clusterNameFilter, 
@@ -60,7 +60,7 @@ extension Kafka.ListClustersRequest: AWSPaginateStringToken {
     }
 }
 
-extension Kafka.ListConfigurationRevisionsRequest: AWSPaginateStringToken {
+extension Kafka.ListConfigurationRevisionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Kafka.ListConfigurationRevisionsRequest {
         return .init(
             arn: self.arn, 
@@ -71,7 +71,7 @@ extension Kafka.ListConfigurationRevisionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Kafka.ListConfigurationsRequest: AWSPaginateStringToken {
+extension Kafka.ListConfigurationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Kafka.ListConfigurationsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -81,7 +81,7 @@ extension Kafka.ListConfigurationsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Kafka.ListKafkaVersionsRequest: AWSPaginateStringToken {
+extension Kafka.ListKafkaVersionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Kafka.ListKafkaVersionsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -91,7 +91,7 @@ extension Kafka.ListKafkaVersionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Kafka.ListNodesRequest: AWSPaginateStringToken {
+extension Kafka.ListNodesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Kafka.ListNodesRequest {
         return .init(
             clusterArn: self.clusterArn, 

--- a/Sources/AWSSDKSwift/Services/Kafka/Kafka_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/Kafka/Kafka_Shapes.swift
@@ -428,8 +428,7 @@ extension Kafka {
         public let kafkaVersion: String
         /// LoggingInfo details.
         public let loggingInfo: LoggingInfo?
-        ///             The number of broker nodes in the cluster.
-        ///          
+        /// The number of Kafka broker nodes in the Amazon MSK cluster.
         public let numberOfBrokerNodes: Int
         /// The settings for open monitoring.
         public let openMonitoring: OpenMonitoringInfo?

--- a/Sources/AWSSDKSwift/Services/Kendra/Kendra_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Kendra/Kendra_Paginator.swift
@@ -23,7 +23,7 @@ extension Kendra {
 
 }
 
-extension Kendra.ListDataSourceSyncJobsRequest: AWSPaginateStringToken {
+extension Kendra.ListDataSourceSyncJobsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Kendra.ListDataSourceSyncJobsRequest {
         return .init(
             id: self.id, 
@@ -37,7 +37,7 @@ extension Kendra.ListDataSourceSyncJobsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Kendra.ListDataSourcesRequest: AWSPaginateStringToken {
+extension Kendra.ListDataSourcesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Kendra.ListDataSourcesRequest {
         return .init(
             indexId: self.indexId, 
@@ -48,7 +48,7 @@ extension Kendra.ListDataSourcesRequest: AWSPaginateStringToken {
     }
 }
 
-extension Kendra.ListIndicesRequest: AWSPaginateStringToken {
+extension Kendra.ListIndicesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Kendra.ListIndicesRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/Kinesis/Kinesis_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Kinesis/Kinesis_Paginator.swift
@@ -23,7 +23,7 @@ extension Kinesis {
 
 }
 
-extension Kinesis.DescribeStreamInput: AWSPaginateStringToken {
+extension Kinesis.DescribeStreamInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Kinesis.DescribeStreamInput {
         return .init(
             exclusiveStartShardId: token, 
@@ -34,7 +34,7 @@ extension Kinesis.DescribeStreamInput: AWSPaginateStringToken {
     }
 }
 
-extension Kinesis.ListStreamConsumersInput: AWSPaginateStringToken {
+extension Kinesis.ListStreamConsumersInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Kinesis.ListStreamConsumersInput {
         return .init(
             maxResults: self.maxResults, 
@@ -46,7 +46,7 @@ extension Kinesis.ListStreamConsumersInput: AWSPaginateStringToken {
     }
 }
 
-extension Kinesis.ListStreamsInput: AWSPaginateStringToken {
+extension Kinesis.ListStreamsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Kinesis.ListStreamsInput {
         return .init(
             exclusiveStartStreamName: token, 

--- a/Sources/AWSSDKSwift/Services/KinesisVideo/KinesisVideo_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/KinesisVideo/KinesisVideo_Paginator.swift
@@ -18,7 +18,7 @@ extension KinesisVideo {
 
 }
 
-extension KinesisVideo.ListSignalingChannelsInput: AWSPaginateStringToken {
+extension KinesisVideo.ListSignalingChannelsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> KinesisVideo.ListSignalingChannelsInput {
         return .init(
             channelNameCondition: self.channelNameCondition, 
@@ -29,7 +29,7 @@ extension KinesisVideo.ListSignalingChannelsInput: AWSPaginateStringToken {
     }
 }
 
-extension KinesisVideo.ListStreamsInput: AWSPaginateStringToken {
+extension KinesisVideo.ListStreamsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> KinesisVideo.ListStreamsInput {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/KinesisVideoArchivedMedia/KinesisVideoArchivedMedia_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/KinesisVideoArchivedMedia/KinesisVideoArchivedMedia_Paginator.swift
@@ -13,7 +13,7 @@ extension KinesisVideoArchivedMedia {
 
 }
 
-extension KinesisVideoArchivedMedia.ListFragmentsInput: AWSPaginateStringToken {
+extension KinesisVideoArchivedMedia.ListFragmentsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> KinesisVideoArchivedMedia.ListFragmentsInput {
         return .init(
             fragmentSelector: self.fragmentSelector, 

--- a/Sources/AWSSDKSwift/Services/LakeFormation/LakeFormation_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/LakeFormation/LakeFormation_Paginator.swift
@@ -23,7 +23,7 @@ extension LakeFormation {
 
 }
 
-extension LakeFormation.GetEffectivePermissionsForPathRequest: AWSPaginateStringToken {
+extension LakeFormation.GetEffectivePermissionsForPathRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> LakeFormation.GetEffectivePermissionsForPathRequest {
         return .init(
             catalogId: self.catalogId, 
@@ -35,7 +35,7 @@ extension LakeFormation.GetEffectivePermissionsForPathRequest: AWSPaginateString
     }
 }
 
-extension LakeFormation.ListPermissionsRequest: AWSPaginateStringToken {
+extension LakeFormation.ListPermissionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> LakeFormation.ListPermissionsRequest {
         return .init(
             catalogId: self.catalogId, 
@@ -49,7 +49,7 @@ extension LakeFormation.ListPermissionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension LakeFormation.ListResourcesRequest: AWSPaginateStringToken {
+extension LakeFormation.ListResourcesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> LakeFormation.ListResourcesRequest {
         return .init(
             filterConditionList: self.filterConditionList, 

--- a/Sources/AWSSDKSwift/Services/Lambda/Lambda_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Lambda/Lambda_Paginator.swift
@@ -48,7 +48,7 @@ extension Lambda {
 
 }
 
-extension Lambda.ListAliasesRequest: AWSPaginateStringToken {
+extension Lambda.ListAliasesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Lambda.ListAliasesRequest {
         return .init(
             functionName: self.functionName, 
@@ -60,7 +60,7 @@ extension Lambda.ListAliasesRequest: AWSPaginateStringToken {
     }
 }
 
-extension Lambda.ListEventSourceMappingsRequest: AWSPaginateStringToken {
+extension Lambda.ListEventSourceMappingsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Lambda.ListEventSourceMappingsRequest {
         return .init(
             eventSourceArn: self.eventSourceArn, 
@@ -72,7 +72,7 @@ extension Lambda.ListEventSourceMappingsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Lambda.ListFunctionEventInvokeConfigsRequest: AWSPaginateStringToken {
+extension Lambda.ListFunctionEventInvokeConfigsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Lambda.ListFunctionEventInvokeConfigsRequest {
         return .init(
             functionName: self.functionName, 
@@ -83,7 +83,7 @@ extension Lambda.ListFunctionEventInvokeConfigsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Lambda.ListFunctionsRequest: AWSPaginateStringToken {
+extension Lambda.ListFunctionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Lambda.ListFunctionsRequest {
         return .init(
             functionVersion: self.functionVersion, 
@@ -95,7 +95,7 @@ extension Lambda.ListFunctionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Lambda.ListLayerVersionsRequest: AWSPaginateStringToken {
+extension Lambda.ListLayerVersionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Lambda.ListLayerVersionsRequest {
         return .init(
             compatibleRuntime: self.compatibleRuntime, 
@@ -107,7 +107,7 @@ extension Lambda.ListLayerVersionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Lambda.ListLayersRequest: AWSPaginateStringToken {
+extension Lambda.ListLayersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Lambda.ListLayersRequest {
         return .init(
             compatibleRuntime: self.compatibleRuntime, 
@@ -118,7 +118,7 @@ extension Lambda.ListLayersRequest: AWSPaginateStringToken {
     }
 }
 
-extension Lambda.ListProvisionedConcurrencyConfigsRequest: AWSPaginateStringToken {
+extension Lambda.ListProvisionedConcurrencyConfigsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Lambda.ListProvisionedConcurrencyConfigsRequest {
         return .init(
             functionName: self.functionName, 
@@ -129,7 +129,7 @@ extension Lambda.ListProvisionedConcurrencyConfigsRequest: AWSPaginateStringToke
     }
 }
 
-extension Lambda.ListVersionsByFunctionRequest: AWSPaginateStringToken {
+extension Lambda.ListVersionsByFunctionRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Lambda.ListVersionsByFunctionRequest {
         return .init(
             functionName: self.functionName, 

--- a/Sources/AWSSDKSwift/Services/LexModelBuildingService/LexModelBuildingService_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/LexModelBuildingService/LexModelBuildingService_Paginator.swift
@@ -58,7 +58,7 @@ extension LexModelBuildingService {
 
 }
 
-extension LexModelBuildingService.GetBotAliasesRequest: AWSPaginateStringToken {
+extension LexModelBuildingService.GetBotAliasesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> LexModelBuildingService.GetBotAliasesRequest {
         return .init(
             botName: self.botName, 
@@ -70,7 +70,7 @@ extension LexModelBuildingService.GetBotAliasesRequest: AWSPaginateStringToken {
     }
 }
 
-extension LexModelBuildingService.GetBotChannelAssociationsRequest: AWSPaginateStringToken {
+extension LexModelBuildingService.GetBotChannelAssociationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> LexModelBuildingService.GetBotChannelAssociationsRequest {
         return .init(
             botAlias: self.botAlias, 
@@ -83,7 +83,7 @@ extension LexModelBuildingService.GetBotChannelAssociationsRequest: AWSPaginateS
     }
 }
 
-extension LexModelBuildingService.GetBotVersionsRequest: AWSPaginateStringToken {
+extension LexModelBuildingService.GetBotVersionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> LexModelBuildingService.GetBotVersionsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -94,7 +94,7 @@ extension LexModelBuildingService.GetBotVersionsRequest: AWSPaginateStringToken 
     }
 }
 
-extension LexModelBuildingService.GetBotsRequest: AWSPaginateStringToken {
+extension LexModelBuildingService.GetBotsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> LexModelBuildingService.GetBotsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -105,7 +105,7 @@ extension LexModelBuildingService.GetBotsRequest: AWSPaginateStringToken {
     }
 }
 
-extension LexModelBuildingService.GetBuiltinIntentsRequest: AWSPaginateStringToken {
+extension LexModelBuildingService.GetBuiltinIntentsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> LexModelBuildingService.GetBuiltinIntentsRequest {
         return .init(
             locale: self.locale, 
@@ -117,7 +117,7 @@ extension LexModelBuildingService.GetBuiltinIntentsRequest: AWSPaginateStringTok
     }
 }
 
-extension LexModelBuildingService.GetBuiltinSlotTypesRequest: AWSPaginateStringToken {
+extension LexModelBuildingService.GetBuiltinSlotTypesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> LexModelBuildingService.GetBuiltinSlotTypesRequest {
         return .init(
             locale: self.locale, 
@@ -129,7 +129,7 @@ extension LexModelBuildingService.GetBuiltinSlotTypesRequest: AWSPaginateStringT
     }
 }
 
-extension LexModelBuildingService.GetIntentVersionsRequest: AWSPaginateStringToken {
+extension LexModelBuildingService.GetIntentVersionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> LexModelBuildingService.GetIntentVersionsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -140,7 +140,7 @@ extension LexModelBuildingService.GetIntentVersionsRequest: AWSPaginateStringTok
     }
 }
 
-extension LexModelBuildingService.GetIntentsRequest: AWSPaginateStringToken {
+extension LexModelBuildingService.GetIntentsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> LexModelBuildingService.GetIntentsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -151,7 +151,7 @@ extension LexModelBuildingService.GetIntentsRequest: AWSPaginateStringToken {
     }
 }
 
-extension LexModelBuildingService.GetSlotTypeVersionsRequest: AWSPaginateStringToken {
+extension LexModelBuildingService.GetSlotTypeVersionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> LexModelBuildingService.GetSlotTypeVersionsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -162,7 +162,7 @@ extension LexModelBuildingService.GetSlotTypeVersionsRequest: AWSPaginateStringT
     }
 }
 
-extension LexModelBuildingService.GetSlotTypesRequest: AWSPaginateStringToken {
+extension LexModelBuildingService.GetSlotTypesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> LexModelBuildingService.GetSlotTypesRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/MTurk/MTurk_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/MTurk/MTurk_Paginator.swift
@@ -58,7 +58,7 @@ extension MTurk {
 
 }
 
-extension MTurk.ListAssignmentsForHITRequest: AWSPaginateStringToken {
+extension MTurk.ListAssignmentsForHITRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MTurk.ListAssignmentsForHITRequest {
         return .init(
             assignmentStatuses: self.assignmentStatuses, 
@@ -70,7 +70,7 @@ extension MTurk.ListAssignmentsForHITRequest: AWSPaginateStringToken {
     }
 }
 
-extension MTurk.ListBonusPaymentsRequest: AWSPaginateStringToken {
+extension MTurk.ListBonusPaymentsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MTurk.ListBonusPaymentsRequest {
         return .init(
             assignmentId: self.assignmentId, 
@@ -82,7 +82,7 @@ extension MTurk.ListBonusPaymentsRequest: AWSPaginateStringToken {
     }
 }
 
-extension MTurk.ListHITsRequest: AWSPaginateStringToken {
+extension MTurk.ListHITsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MTurk.ListHITsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -92,7 +92,7 @@ extension MTurk.ListHITsRequest: AWSPaginateStringToken {
     }
 }
 
-extension MTurk.ListHITsForQualificationTypeRequest: AWSPaginateStringToken {
+extension MTurk.ListHITsForQualificationTypeRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MTurk.ListHITsForQualificationTypeRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -103,7 +103,7 @@ extension MTurk.ListHITsForQualificationTypeRequest: AWSPaginateStringToken {
     }
 }
 
-extension MTurk.ListQualificationRequestsRequest: AWSPaginateStringToken {
+extension MTurk.ListQualificationRequestsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MTurk.ListQualificationRequestsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -114,7 +114,7 @@ extension MTurk.ListQualificationRequestsRequest: AWSPaginateStringToken {
     }
 }
 
-extension MTurk.ListQualificationTypesRequest: AWSPaginateStringToken {
+extension MTurk.ListQualificationTypesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MTurk.ListQualificationTypesRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -127,7 +127,7 @@ extension MTurk.ListQualificationTypesRequest: AWSPaginateStringToken {
     }
 }
 
-extension MTurk.ListReviewPolicyResultsForHITRequest: AWSPaginateStringToken {
+extension MTurk.ListReviewPolicyResultsForHITRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MTurk.ListReviewPolicyResultsForHITRequest {
         return .init(
             hITId: self.hITId, 
@@ -141,7 +141,7 @@ extension MTurk.ListReviewPolicyResultsForHITRequest: AWSPaginateStringToken {
     }
 }
 
-extension MTurk.ListReviewableHITsRequest: AWSPaginateStringToken {
+extension MTurk.ListReviewableHITsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MTurk.ListReviewableHITsRequest {
         return .init(
             hITTypeId: self.hITTypeId, 
@@ -153,7 +153,7 @@ extension MTurk.ListReviewableHITsRequest: AWSPaginateStringToken {
     }
 }
 
-extension MTurk.ListWorkerBlocksRequest: AWSPaginateStringToken {
+extension MTurk.ListWorkerBlocksRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MTurk.ListWorkerBlocksRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -163,7 +163,7 @@ extension MTurk.ListWorkerBlocksRequest: AWSPaginateStringToken {
     }
 }
 
-extension MTurk.ListWorkersWithQualificationTypeRequest: AWSPaginateStringToken {
+extension MTurk.ListWorkersWithQualificationTypeRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MTurk.ListWorkersWithQualificationTypeRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/MachineLearning/MachineLearning_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/MachineLearning/MachineLearning_Paginator.swift
@@ -28,7 +28,7 @@ extension MachineLearning {
 
 }
 
-extension MachineLearning.DescribeBatchPredictionsInput: AWSPaginateStringToken {
+extension MachineLearning.DescribeBatchPredictionsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MachineLearning.DescribeBatchPredictionsInput {
         return .init(
             eq: self.eq, 
@@ -47,7 +47,7 @@ extension MachineLearning.DescribeBatchPredictionsInput: AWSPaginateStringToken 
     }
 }
 
-extension MachineLearning.DescribeDataSourcesInput: AWSPaginateStringToken {
+extension MachineLearning.DescribeDataSourcesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MachineLearning.DescribeDataSourcesInput {
         return .init(
             eq: self.eq, 
@@ -66,7 +66,7 @@ extension MachineLearning.DescribeDataSourcesInput: AWSPaginateStringToken {
     }
 }
 
-extension MachineLearning.DescribeEvaluationsInput: AWSPaginateStringToken {
+extension MachineLearning.DescribeEvaluationsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MachineLearning.DescribeEvaluationsInput {
         return .init(
             eq: self.eq, 
@@ -85,7 +85,7 @@ extension MachineLearning.DescribeEvaluationsInput: AWSPaginateStringToken {
     }
 }
 
-extension MachineLearning.DescribeMLModelsInput: AWSPaginateStringToken {
+extension MachineLearning.DescribeMLModelsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MachineLearning.DescribeMLModelsInput {
         return .init(
             eq: self.eq, 

--- a/Sources/AWSSDKSwift/Services/Macie/Macie_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Macie/Macie_Paginator.swift
@@ -18,7 +18,7 @@ extension Macie {
 
 }
 
-extension Macie.ListMemberAccountsRequest: AWSPaginateStringToken {
+extension Macie.ListMemberAccountsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Macie.ListMemberAccountsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -28,7 +28,7 @@ extension Macie.ListMemberAccountsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Macie.ListS3ResourcesRequest: AWSPaginateStringToken {
+extension Macie.ListS3ResourcesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Macie.ListS3ResourcesRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/ManagedBlockchain/ManagedBlockchain_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/ManagedBlockchain/ManagedBlockchain_Paginator.swift
@@ -38,7 +38,7 @@ extension ManagedBlockchain {
 
 }
 
-extension ManagedBlockchain.ListInvitationsInput: AWSPaginateStringToken {
+extension ManagedBlockchain.ListInvitationsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ManagedBlockchain.ListInvitationsInput {
         return .init(
             maxResults: self.maxResults, 
@@ -48,7 +48,7 @@ extension ManagedBlockchain.ListInvitationsInput: AWSPaginateStringToken {
     }
 }
 
-extension ManagedBlockchain.ListMembersInput: AWSPaginateStringToken {
+extension ManagedBlockchain.ListMembersInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ManagedBlockchain.ListMembersInput {
         return .init(
             isOwned: self.isOwned, 
@@ -62,7 +62,7 @@ extension ManagedBlockchain.ListMembersInput: AWSPaginateStringToken {
     }
 }
 
-extension ManagedBlockchain.ListNetworksInput: AWSPaginateStringToken {
+extension ManagedBlockchain.ListNetworksInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ManagedBlockchain.ListNetworksInput {
         return .init(
             framework: self.framework, 
@@ -75,7 +75,7 @@ extension ManagedBlockchain.ListNetworksInput: AWSPaginateStringToken {
     }
 }
 
-extension ManagedBlockchain.ListNodesInput: AWSPaginateStringToken {
+extension ManagedBlockchain.ListNodesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ManagedBlockchain.ListNodesInput {
         return .init(
             maxResults: self.maxResults, 
@@ -88,7 +88,7 @@ extension ManagedBlockchain.ListNodesInput: AWSPaginateStringToken {
     }
 }
 
-extension ManagedBlockchain.ListProposalVotesInput: AWSPaginateStringToken {
+extension ManagedBlockchain.ListProposalVotesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ManagedBlockchain.ListProposalVotesInput {
         return .init(
             maxResults: self.maxResults, 
@@ -100,7 +100,7 @@ extension ManagedBlockchain.ListProposalVotesInput: AWSPaginateStringToken {
     }
 }
 
-extension ManagedBlockchain.ListProposalsInput: AWSPaginateStringToken {
+extension ManagedBlockchain.ListProposalsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ManagedBlockchain.ListProposalsInput {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/MarketplaceCatalog/MarketplaceCatalog_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/MarketplaceCatalog/MarketplaceCatalog_Paginator.swift
@@ -18,7 +18,7 @@ extension MarketplaceCatalog {
 
 }
 
-extension MarketplaceCatalog.ListChangeSetsRequest: AWSPaginateStringToken {
+extension MarketplaceCatalog.ListChangeSetsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MarketplaceCatalog.ListChangeSetsRequest {
         return .init(
             catalog: self.catalog, 
@@ -31,7 +31,7 @@ extension MarketplaceCatalog.ListChangeSetsRequest: AWSPaginateStringToken {
     }
 }
 
-extension MarketplaceCatalog.ListEntitiesRequest: AWSPaginateStringToken {
+extension MarketplaceCatalog.ListEntitiesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MarketplaceCatalog.ListEntitiesRequest {
         return .init(
             catalog: self.catalog, 

--- a/Sources/AWSSDKSwift/Services/MediaConnect/MediaConnect_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/MediaConnect/MediaConnect_Paginator.swift
@@ -18,7 +18,7 @@ extension MediaConnect {
 
 }
 
-extension MediaConnect.ListEntitlementsRequest: AWSPaginateStringToken {
+extension MediaConnect.ListEntitlementsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MediaConnect.ListEntitlementsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -28,7 +28,7 @@ extension MediaConnect.ListEntitlementsRequest: AWSPaginateStringToken {
     }
 }
 
-extension MediaConnect.ListFlowsRequest: AWSPaginateStringToken {
+extension MediaConnect.ListFlowsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MediaConnect.ListFlowsRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/MediaConvert/MediaConvert_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/MediaConvert/MediaConvert_Paginator.swift
@@ -33,7 +33,7 @@ extension MediaConvert {
 
 }
 
-extension MediaConvert.DescribeEndpointsRequest: AWSPaginateStringToken {
+extension MediaConvert.DescribeEndpointsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MediaConvert.DescribeEndpointsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -44,7 +44,7 @@ extension MediaConvert.DescribeEndpointsRequest: AWSPaginateStringToken {
     }
 }
 
-extension MediaConvert.ListJobTemplatesRequest: AWSPaginateStringToken {
+extension MediaConvert.ListJobTemplatesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MediaConvert.ListJobTemplatesRequest {
         return .init(
             category: self.category, 
@@ -57,7 +57,7 @@ extension MediaConvert.ListJobTemplatesRequest: AWSPaginateStringToken {
     }
 }
 
-extension MediaConvert.ListJobsRequest: AWSPaginateStringToken {
+extension MediaConvert.ListJobsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MediaConvert.ListJobsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -70,7 +70,7 @@ extension MediaConvert.ListJobsRequest: AWSPaginateStringToken {
     }
 }
 
-extension MediaConvert.ListPresetsRequest: AWSPaginateStringToken {
+extension MediaConvert.ListPresetsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MediaConvert.ListPresetsRequest {
         return .init(
             category: self.category, 
@@ -83,7 +83,7 @@ extension MediaConvert.ListPresetsRequest: AWSPaginateStringToken {
     }
 }
 
-extension MediaConvert.ListQueuesRequest: AWSPaginateStringToken {
+extension MediaConvert.ListQueuesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MediaConvert.ListQueuesRequest {
         return .init(
             listBy: self.listBy, 

--- a/Sources/AWSSDKSwift/Services/MediaLive/MediaLive_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/MediaLive/MediaLive_Paginator.swift
@@ -48,7 +48,7 @@ extension MediaLive {
 
 }
 
-extension MediaLive.DescribeScheduleRequest: AWSPaginateStringToken {
+extension MediaLive.DescribeScheduleRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MediaLive.DescribeScheduleRequest {
         return .init(
             channelId: self.channelId, 
@@ -59,7 +59,7 @@ extension MediaLive.DescribeScheduleRequest: AWSPaginateStringToken {
     }
 }
 
-extension MediaLive.ListChannelsRequest: AWSPaginateStringToken {
+extension MediaLive.ListChannelsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MediaLive.ListChannelsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -69,7 +69,7 @@ extension MediaLive.ListChannelsRequest: AWSPaginateStringToken {
     }
 }
 
-extension MediaLive.ListInputSecurityGroupsRequest: AWSPaginateStringToken {
+extension MediaLive.ListInputSecurityGroupsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MediaLive.ListInputSecurityGroupsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -79,7 +79,7 @@ extension MediaLive.ListInputSecurityGroupsRequest: AWSPaginateStringToken {
     }
 }
 
-extension MediaLive.ListInputsRequest: AWSPaginateStringToken {
+extension MediaLive.ListInputsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MediaLive.ListInputsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -89,7 +89,7 @@ extension MediaLive.ListInputsRequest: AWSPaginateStringToken {
     }
 }
 
-extension MediaLive.ListMultiplexProgramsRequest: AWSPaginateStringToken {
+extension MediaLive.ListMultiplexProgramsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MediaLive.ListMultiplexProgramsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -100,7 +100,7 @@ extension MediaLive.ListMultiplexProgramsRequest: AWSPaginateStringToken {
     }
 }
 
-extension MediaLive.ListMultiplexesRequest: AWSPaginateStringToken {
+extension MediaLive.ListMultiplexesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MediaLive.ListMultiplexesRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -110,7 +110,7 @@ extension MediaLive.ListMultiplexesRequest: AWSPaginateStringToken {
     }
 }
 
-extension MediaLive.ListOfferingsRequest: AWSPaginateStringToken {
+extension MediaLive.ListOfferingsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MediaLive.ListOfferingsRequest {
         return .init(
             channelClass: self.channelClass, 
@@ -130,7 +130,7 @@ extension MediaLive.ListOfferingsRequest: AWSPaginateStringToken {
     }
 }
 
-extension MediaLive.ListReservationsRequest: AWSPaginateStringToken {
+extension MediaLive.ListReservationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MediaLive.ListReservationsRequest {
         return .init(
             channelClass: self.channelClass, 

--- a/Sources/AWSSDKSwift/Services/MediaPackage/MediaPackage_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/MediaPackage/MediaPackage_Paginator.swift
@@ -23,7 +23,7 @@ extension MediaPackage {
 
 }
 
-extension MediaPackage.ListChannelsRequest: AWSPaginateStringToken {
+extension MediaPackage.ListChannelsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MediaPackage.ListChannelsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -33,7 +33,7 @@ extension MediaPackage.ListChannelsRequest: AWSPaginateStringToken {
     }
 }
 
-extension MediaPackage.ListHarvestJobsRequest: AWSPaginateStringToken {
+extension MediaPackage.ListHarvestJobsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MediaPackage.ListHarvestJobsRequest {
         return .init(
             includeChannelId: self.includeChannelId, 
@@ -45,7 +45,7 @@ extension MediaPackage.ListHarvestJobsRequest: AWSPaginateStringToken {
     }
 }
 
-extension MediaPackage.ListOriginEndpointsRequest: AWSPaginateStringToken {
+extension MediaPackage.ListOriginEndpointsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MediaPackage.ListOriginEndpointsRequest {
         return .init(
             channelId: self.channelId, 

--- a/Sources/AWSSDKSwift/Services/MediaPackageVod/MediaPackageVod_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/MediaPackageVod/MediaPackageVod_Paginator.swift
@@ -23,7 +23,7 @@ extension MediaPackageVod {
 
 }
 
-extension MediaPackageVod.ListAssetsRequest: AWSPaginateStringToken {
+extension MediaPackageVod.ListAssetsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MediaPackageVod.ListAssetsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -34,7 +34,7 @@ extension MediaPackageVod.ListAssetsRequest: AWSPaginateStringToken {
     }
 }
 
-extension MediaPackageVod.ListPackagingConfigurationsRequest: AWSPaginateStringToken {
+extension MediaPackageVod.ListPackagingConfigurationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MediaPackageVod.ListPackagingConfigurationsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -45,7 +45,7 @@ extension MediaPackageVod.ListPackagingConfigurationsRequest: AWSPaginateStringT
     }
 }
 
-extension MediaPackageVod.ListPackagingGroupsRequest: AWSPaginateStringToken {
+extension MediaPackageVod.ListPackagingGroupsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MediaPackageVod.ListPackagingGroupsRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/MediaStore/MediaStore_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/MediaStore/MediaStore_Paginator.swift
@@ -13,7 +13,7 @@ extension MediaStore {
 
 }
 
-extension MediaStore.ListContainersInput: AWSPaginateStringToken {
+extension MediaStore.ListContainersInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MediaStore.ListContainersInput {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/MediaStoreData/MediaStoreData_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/MediaStoreData/MediaStoreData_Paginator.swift
@@ -13,7 +13,7 @@ extension MediaStoreData {
 
 }
 
-extension MediaStoreData.ListItemsRequest: AWSPaginateStringToken {
+extension MediaStoreData.ListItemsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MediaStoreData.ListItemsRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/MediaTailor/MediaTailor_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/MediaTailor/MediaTailor_Shapes.swift
@@ -126,7 +126,7 @@ extension MediaTailor {
         public let livePreRollConfiguration: LivePreRollConfiguration?
         /// The identifier for the playback configuration.
         public let name: String?
-        /// The maximum duration of underfilled ad time (in seconds) allowed in an ad break.
+        /// The maximum duration of underfilled ad time (in seconds) allowed in an ad break. 
         public let personalizationThresholdSeconds: Int?
         /// The Amazon Resource Name (ARN) for the playback configuration. 
         public let playbackConfigurationArn: String?
@@ -343,7 +343,7 @@ extension MediaTailor {
         public let livePreRollConfiguration: LivePreRollConfiguration?
         /// The identifier for the playback configuration.
         public let name: String?
-        /// The maximum duration of underfilled ad time (in seconds) allowed in an ad break.
+        /// The maximum duration of underfilled ad time (in seconds) allowed in an ad break. 
         public let personalizationThresholdSeconds: Int?
         /// The URL for a high-quality video asset to transcode and use to fill in time that's not used by ads. AWS Elemental MediaTailor shows the slate to fill in gaps in media content. Configuring the slate is optional for non-VPAID configurations. For VPAID, the slate is required because MediaTailor provides it in the slots that are designated for dynamic ad content. The slate must be a high-quality asset that contains both audio and video. 
         public let slateAdUrl: String?

--- a/Sources/AWSSDKSwift/Services/MigrationHub/MigrationHub_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/MigrationHub/MigrationHub_Paginator.swift
@@ -33,7 +33,7 @@ extension MigrationHub {
 
 }
 
-extension MigrationHub.ListApplicationStatesRequest: AWSPaginateStringToken {
+extension MigrationHub.ListApplicationStatesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MigrationHub.ListApplicationStatesRequest {
         return .init(
             applicationIds: self.applicationIds, 
@@ -44,7 +44,7 @@ extension MigrationHub.ListApplicationStatesRequest: AWSPaginateStringToken {
     }
 }
 
-extension MigrationHub.ListCreatedArtifactsRequest: AWSPaginateStringToken {
+extension MigrationHub.ListCreatedArtifactsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MigrationHub.ListCreatedArtifactsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -56,7 +56,7 @@ extension MigrationHub.ListCreatedArtifactsRequest: AWSPaginateStringToken {
     }
 }
 
-extension MigrationHub.ListDiscoveredResourcesRequest: AWSPaginateStringToken {
+extension MigrationHub.ListDiscoveredResourcesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MigrationHub.ListDiscoveredResourcesRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -68,7 +68,7 @@ extension MigrationHub.ListDiscoveredResourcesRequest: AWSPaginateStringToken {
     }
 }
 
-extension MigrationHub.ListMigrationTasksRequest: AWSPaginateStringToken {
+extension MigrationHub.ListMigrationTasksRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MigrationHub.ListMigrationTasksRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -79,7 +79,7 @@ extension MigrationHub.ListMigrationTasksRequest: AWSPaginateStringToken {
     }
 }
 
-extension MigrationHub.ListProgressUpdateStreamsRequest: AWSPaginateStringToken {
+extension MigrationHub.ListProgressUpdateStreamsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MigrationHub.ListProgressUpdateStreamsRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/MigrationHubConfig/MigrationHubConfig_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/MigrationHubConfig/MigrationHubConfig_Paginator.swift
@@ -13,7 +13,7 @@ extension MigrationHubConfig {
 
 }
 
-extension MigrationHubConfig.DescribeHomeRegionControlsRequest: AWSPaginateStringToken {
+extension MigrationHubConfig.DescribeHomeRegionControlsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> MigrationHubConfig.DescribeHomeRegionControlsRequest {
         return .init(
             controlId: self.controlId, 

--- a/Sources/AWSSDKSwift/Services/Mobile/Mobile_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Mobile/Mobile_Paginator.swift
@@ -18,7 +18,7 @@ extension Mobile {
 
 }
 
-extension Mobile.ListBundlesRequest: AWSPaginateStringToken {
+extension Mobile.ListBundlesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Mobile.ListBundlesRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -28,7 +28,7 @@ extension Mobile.ListBundlesRequest: AWSPaginateStringToken {
     }
 }
 
-extension Mobile.ListProjectsRequest: AWSPaginateStringToken {
+extension Mobile.ListProjectsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Mobile.ListProjectsRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/Neptune/Neptune_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Neptune/Neptune_Paginator.swift
@@ -53,7 +53,7 @@ extension Neptune {
 
 }
 
-extension Neptune.DescribeDBEngineVersionsMessage: AWSPaginateStringToken {
+extension Neptune.DescribeDBEngineVersionsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Neptune.DescribeDBEngineVersionsMessage {
         return .init(
             dBParameterGroupFamily: self.dBParameterGroupFamily, 
@@ -70,7 +70,7 @@ extension Neptune.DescribeDBEngineVersionsMessage: AWSPaginateStringToken {
     }
 }
 
-extension Neptune.DescribeDBInstancesMessage: AWSPaginateStringToken {
+extension Neptune.DescribeDBInstancesMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Neptune.DescribeDBInstancesMessage {
         return .init(
             dBInstanceIdentifier: self.dBInstanceIdentifier, 
@@ -82,7 +82,7 @@ extension Neptune.DescribeDBInstancesMessage: AWSPaginateStringToken {
     }
 }
 
-extension Neptune.DescribeDBParameterGroupsMessage: AWSPaginateStringToken {
+extension Neptune.DescribeDBParameterGroupsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Neptune.DescribeDBParameterGroupsMessage {
         return .init(
             dBParameterGroupName: self.dBParameterGroupName, 
@@ -94,7 +94,7 @@ extension Neptune.DescribeDBParameterGroupsMessage: AWSPaginateStringToken {
     }
 }
 
-extension Neptune.DescribeDBParametersMessage: AWSPaginateStringToken {
+extension Neptune.DescribeDBParametersMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Neptune.DescribeDBParametersMessage {
         return .init(
             dBParameterGroupName: self.dBParameterGroupName, 
@@ -107,7 +107,7 @@ extension Neptune.DescribeDBParametersMessage: AWSPaginateStringToken {
     }
 }
 
-extension Neptune.DescribeDBSubnetGroupsMessage: AWSPaginateStringToken {
+extension Neptune.DescribeDBSubnetGroupsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Neptune.DescribeDBSubnetGroupsMessage {
         return .init(
             dBSubnetGroupName: self.dBSubnetGroupName, 
@@ -119,7 +119,7 @@ extension Neptune.DescribeDBSubnetGroupsMessage: AWSPaginateStringToken {
     }
 }
 
-extension Neptune.DescribeEngineDefaultParametersMessage: AWSPaginateStringToken {
+extension Neptune.DescribeEngineDefaultParametersMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Neptune.DescribeEngineDefaultParametersMessage {
         return .init(
             dBParameterGroupFamily: self.dBParameterGroupFamily, 
@@ -131,7 +131,7 @@ extension Neptune.DescribeEngineDefaultParametersMessage: AWSPaginateStringToken
     }
 }
 
-extension Neptune.DescribeEventSubscriptionsMessage: AWSPaginateStringToken {
+extension Neptune.DescribeEventSubscriptionsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Neptune.DescribeEventSubscriptionsMessage {
         return .init(
             filters: self.filters, 
@@ -143,7 +143,7 @@ extension Neptune.DescribeEventSubscriptionsMessage: AWSPaginateStringToken {
     }
 }
 
-extension Neptune.DescribeEventsMessage: AWSPaginateStringToken {
+extension Neptune.DescribeEventsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Neptune.DescribeEventsMessage {
         return .init(
             duration: self.duration, 
@@ -160,7 +160,7 @@ extension Neptune.DescribeEventsMessage: AWSPaginateStringToken {
     }
 }
 
-extension Neptune.DescribeOrderableDBInstanceOptionsMessage: AWSPaginateStringToken {
+extension Neptune.DescribeOrderableDBInstanceOptionsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Neptune.DescribeOrderableDBInstanceOptionsMessage {
         return .init(
             dBInstanceClass: self.dBInstanceClass, 

--- a/Sources/AWSSDKSwift/Services/NetworkManager/NetworkManager_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/NetworkManager/NetworkManager_Paginator.swift
@@ -43,7 +43,7 @@ extension NetworkManager {
 
 }
 
-extension NetworkManager.DescribeGlobalNetworksRequest: AWSPaginateStringToken {
+extension NetworkManager.DescribeGlobalNetworksRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> NetworkManager.DescribeGlobalNetworksRequest {
         return .init(
             globalNetworkIds: self.globalNetworkIds, 
@@ -54,7 +54,7 @@ extension NetworkManager.DescribeGlobalNetworksRequest: AWSPaginateStringToken {
     }
 }
 
-extension NetworkManager.GetCustomerGatewayAssociationsRequest: AWSPaginateStringToken {
+extension NetworkManager.GetCustomerGatewayAssociationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> NetworkManager.GetCustomerGatewayAssociationsRequest {
         return .init(
             customerGatewayArns: self.customerGatewayArns, 
@@ -66,7 +66,7 @@ extension NetworkManager.GetCustomerGatewayAssociationsRequest: AWSPaginateStrin
     }
 }
 
-extension NetworkManager.GetDevicesRequest: AWSPaginateStringToken {
+extension NetworkManager.GetDevicesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> NetworkManager.GetDevicesRequest {
         return .init(
             deviceIds: self.deviceIds, 
@@ -79,7 +79,7 @@ extension NetworkManager.GetDevicesRequest: AWSPaginateStringToken {
     }
 }
 
-extension NetworkManager.GetLinkAssociationsRequest: AWSPaginateStringToken {
+extension NetworkManager.GetLinkAssociationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> NetworkManager.GetLinkAssociationsRequest {
         return .init(
             deviceId: self.deviceId, 
@@ -92,7 +92,7 @@ extension NetworkManager.GetLinkAssociationsRequest: AWSPaginateStringToken {
     }
 }
 
-extension NetworkManager.GetLinksRequest: AWSPaginateStringToken {
+extension NetworkManager.GetLinksRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> NetworkManager.GetLinksRequest {
         return .init(
             globalNetworkId: self.globalNetworkId, 
@@ -107,7 +107,7 @@ extension NetworkManager.GetLinksRequest: AWSPaginateStringToken {
     }
 }
 
-extension NetworkManager.GetSitesRequest: AWSPaginateStringToken {
+extension NetworkManager.GetSitesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> NetworkManager.GetSitesRequest {
         return .init(
             globalNetworkId: self.globalNetworkId, 
@@ -119,7 +119,7 @@ extension NetworkManager.GetSitesRequest: AWSPaginateStringToken {
     }
 }
 
-extension NetworkManager.GetTransitGatewayRegistrationsRequest: AWSPaginateStringToken {
+extension NetworkManager.GetTransitGatewayRegistrationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> NetworkManager.GetTransitGatewayRegistrationsRequest {
         return .init(
             globalNetworkId: self.globalNetworkId, 

--- a/Sources/AWSSDKSwift/Services/OpsWorks/OpsWorks_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/OpsWorks/OpsWorks_Paginator.swift
@@ -13,7 +13,7 @@ extension OpsWorks {
 
 }
 
-extension OpsWorks.DescribeEcsClustersRequest: AWSPaginateStringToken {
+extension OpsWorks.DescribeEcsClustersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> OpsWorks.DescribeEcsClustersRequest {
         return .init(
             ecsClusterArns: self.ecsClusterArns, 

--- a/Sources/AWSSDKSwift/Services/Organizations/Organizations_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Organizations/Organizations_Paginator.swift
@@ -88,7 +88,7 @@ extension Organizations {
 
 }
 
-extension Organizations.ListAWSServiceAccessForOrganizationRequest: AWSPaginateStringToken {
+extension Organizations.ListAWSServiceAccessForOrganizationRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Organizations.ListAWSServiceAccessForOrganizationRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -98,7 +98,7 @@ extension Organizations.ListAWSServiceAccessForOrganizationRequest: AWSPaginateS
     }
 }
 
-extension Organizations.ListAccountsRequest: AWSPaginateStringToken {
+extension Organizations.ListAccountsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Organizations.ListAccountsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -108,7 +108,7 @@ extension Organizations.ListAccountsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Organizations.ListAccountsForParentRequest: AWSPaginateStringToken {
+extension Organizations.ListAccountsForParentRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Organizations.ListAccountsForParentRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -119,7 +119,7 @@ extension Organizations.ListAccountsForParentRequest: AWSPaginateStringToken {
     }
 }
 
-extension Organizations.ListChildrenRequest: AWSPaginateStringToken {
+extension Organizations.ListChildrenRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Organizations.ListChildrenRequest {
         return .init(
             childType: self.childType, 
@@ -131,7 +131,7 @@ extension Organizations.ListChildrenRequest: AWSPaginateStringToken {
     }
 }
 
-extension Organizations.ListCreateAccountStatusRequest: AWSPaginateStringToken {
+extension Organizations.ListCreateAccountStatusRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Organizations.ListCreateAccountStatusRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -142,7 +142,7 @@ extension Organizations.ListCreateAccountStatusRequest: AWSPaginateStringToken {
     }
 }
 
-extension Organizations.ListDelegatedAdministratorsRequest: AWSPaginateStringToken {
+extension Organizations.ListDelegatedAdministratorsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Organizations.ListDelegatedAdministratorsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -153,7 +153,7 @@ extension Organizations.ListDelegatedAdministratorsRequest: AWSPaginateStringTok
     }
 }
 
-extension Organizations.ListDelegatedServicesForAccountRequest: AWSPaginateStringToken {
+extension Organizations.ListDelegatedServicesForAccountRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Organizations.ListDelegatedServicesForAccountRequest {
         return .init(
             accountId: self.accountId, 
@@ -164,7 +164,7 @@ extension Organizations.ListDelegatedServicesForAccountRequest: AWSPaginateStrin
     }
 }
 
-extension Organizations.ListHandshakesForAccountRequest: AWSPaginateStringToken {
+extension Organizations.ListHandshakesForAccountRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Organizations.ListHandshakesForAccountRequest {
         return .init(
             filter: self.filter, 
@@ -175,7 +175,7 @@ extension Organizations.ListHandshakesForAccountRequest: AWSPaginateStringToken 
     }
 }
 
-extension Organizations.ListHandshakesForOrganizationRequest: AWSPaginateStringToken {
+extension Organizations.ListHandshakesForOrganizationRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Organizations.ListHandshakesForOrganizationRequest {
         return .init(
             filter: self.filter, 
@@ -186,7 +186,7 @@ extension Organizations.ListHandshakesForOrganizationRequest: AWSPaginateStringT
     }
 }
 
-extension Organizations.ListOrganizationalUnitsForParentRequest: AWSPaginateStringToken {
+extension Organizations.ListOrganizationalUnitsForParentRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Organizations.ListOrganizationalUnitsForParentRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -197,7 +197,7 @@ extension Organizations.ListOrganizationalUnitsForParentRequest: AWSPaginateStri
     }
 }
 
-extension Organizations.ListParentsRequest: AWSPaginateStringToken {
+extension Organizations.ListParentsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Organizations.ListParentsRequest {
         return .init(
             childId: self.childId, 
@@ -208,7 +208,7 @@ extension Organizations.ListParentsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Organizations.ListPoliciesRequest: AWSPaginateStringToken {
+extension Organizations.ListPoliciesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Organizations.ListPoliciesRequest {
         return .init(
             filter: self.filter, 
@@ -219,7 +219,7 @@ extension Organizations.ListPoliciesRequest: AWSPaginateStringToken {
     }
 }
 
-extension Organizations.ListPoliciesForTargetRequest: AWSPaginateStringToken {
+extension Organizations.ListPoliciesForTargetRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Organizations.ListPoliciesForTargetRequest {
         return .init(
             filter: self.filter, 
@@ -231,7 +231,7 @@ extension Organizations.ListPoliciesForTargetRequest: AWSPaginateStringToken {
     }
 }
 
-extension Organizations.ListRootsRequest: AWSPaginateStringToken {
+extension Organizations.ListRootsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Organizations.ListRootsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -241,7 +241,7 @@ extension Organizations.ListRootsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Organizations.ListTagsForResourceRequest: AWSPaginateStringToken {
+extension Organizations.ListTagsForResourceRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Organizations.ListTagsForResourceRequest {
         return .init(
             nextToken: token, 
@@ -251,7 +251,7 @@ extension Organizations.ListTagsForResourceRequest: AWSPaginateStringToken {
     }
 }
 
-extension Organizations.ListTargetsForPolicyRequest: AWSPaginateStringToken {
+extension Organizations.ListTargetsForPolicyRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Organizations.ListTargetsForPolicyRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/Outposts/Outposts_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Outposts/Outposts_Paginator.swift
@@ -18,7 +18,7 @@ extension Outposts {
 
 }
 
-extension Outposts.ListOutpostsInput: AWSPaginateStringToken {
+extension Outposts.ListOutpostsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Outposts.ListOutpostsInput {
         return .init(
             maxResults: self.maxResults, 
@@ -28,7 +28,7 @@ extension Outposts.ListOutpostsInput: AWSPaginateStringToken {
     }
 }
 
-extension Outposts.ListSitesInput: AWSPaginateStringToken {
+extension Outposts.ListSitesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Outposts.ListSitesInput {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/Personalize/Personalize_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Personalize/Personalize_Paginator.swift
@@ -58,7 +58,7 @@ extension Personalize {
 
 }
 
-extension Personalize.ListBatchInferenceJobsRequest: AWSPaginateStringToken {
+extension Personalize.ListBatchInferenceJobsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Personalize.ListBatchInferenceJobsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -69,7 +69,7 @@ extension Personalize.ListBatchInferenceJobsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Personalize.ListCampaignsRequest: AWSPaginateStringToken {
+extension Personalize.ListCampaignsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Personalize.ListCampaignsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -80,7 +80,7 @@ extension Personalize.ListCampaignsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Personalize.ListDatasetGroupsRequest: AWSPaginateStringToken {
+extension Personalize.ListDatasetGroupsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Personalize.ListDatasetGroupsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -90,7 +90,7 @@ extension Personalize.ListDatasetGroupsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Personalize.ListDatasetImportJobsRequest: AWSPaginateStringToken {
+extension Personalize.ListDatasetImportJobsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Personalize.ListDatasetImportJobsRequest {
         return .init(
             datasetArn: self.datasetArn, 
@@ -101,7 +101,7 @@ extension Personalize.ListDatasetImportJobsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Personalize.ListDatasetsRequest: AWSPaginateStringToken {
+extension Personalize.ListDatasetsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Personalize.ListDatasetsRequest {
         return .init(
             datasetGroupArn: self.datasetGroupArn, 
@@ -112,7 +112,7 @@ extension Personalize.ListDatasetsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Personalize.ListEventTrackersRequest: AWSPaginateStringToken {
+extension Personalize.ListEventTrackersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Personalize.ListEventTrackersRequest {
         return .init(
             datasetGroupArn: self.datasetGroupArn, 
@@ -123,7 +123,7 @@ extension Personalize.ListEventTrackersRequest: AWSPaginateStringToken {
     }
 }
 
-extension Personalize.ListRecipesRequest: AWSPaginateStringToken {
+extension Personalize.ListRecipesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Personalize.ListRecipesRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -134,7 +134,7 @@ extension Personalize.ListRecipesRequest: AWSPaginateStringToken {
     }
 }
 
-extension Personalize.ListSchemasRequest: AWSPaginateStringToken {
+extension Personalize.ListSchemasRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Personalize.ListSchemasRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -144,7 +144,7 @@ extension Personalize.ListSchemasRequest: AWSPaginateStringToken {
     }
 }
 
-extension Personalize.ListSolutionVersionsRequest: AWSPaginateStringToken {
+extension Personalize.ListSolutionVersionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Personalize.ListSolutionVersionsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -155,7 +155,7 @@ extension Personalize.ListSolutionVersionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Personalize.ListSolutionsRequest: AWSPaginateStringToken {
+extension Personalize.ListSolutionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Personalize.ListSolutionsRequest {
         return .init(
             datasetGroupArn: self.datasetGroupArn, 

--- a/Sources/AWSSDKSwift/Services/PinpointEmail/PinpointEmail_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/PinpointEmail/PinpointEmail_Paginator.swift
@@ -38,7 +38,7 @@ extension PinpointEmail {
 
 }
 
-extension PinpointEmail.GetDedicatedIpsRequest: AWSPaginateStringToken {
+extension PinpointEmail.GetDedicatedIpsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> PinpointEmail.GetDedicatedIpsRequest {
         return .init(
             nextToken: token, 
@@ -49,7 +49,7 @@ extension PinpointEmail.GetDedicatedIpsRequest: AWSPaginateStringToken {
     }
 }
 
-extension PinpointEmail.ListConfigurationSetsRequest: AWSPaginateStringToken {
+extension PinpointEmail.ListConfigurationSetsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> PinpointEmail.ListConfigurationSetsRequest {
         return .init(
             nextToken: token, 
@@ -59,7 +59,7 @@ extension PinpointEmail.ListConfigurationSetsRequest: AWSPaginateStringToken {
     }
 }
 
-extension PinpointEmail.ListDedicatedIpPoolsRequest: AWSPaginateStringToken {
+extension PinpointEmail.ListDedicatedIpPoolsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> PinpointEmail.ListDedicatedIpPoolsRequest {
         return .init(
             nextToken: token, 
@@ -69,7 +69,7 @@ extension PinpointEmail.ListDedicatedIpPoolsRequest: AWSPaginateStringToken {
     }
 }
 
-extension PinpointEmail.ListDeliverabilityTestReportsRequest: AWSPaginateStringToken {
+extension PinpointEmail.ListDeliverabilityTestReportsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> PinpointEmail.ListDeliverabilityTestReportsRequest {
         return .init(
             nextToken: token, 
@@ -79,7 +79,7 @@ extension PinpointEmail.ListDeliverabilityTestReportsRequest: AWSPaginateStringT
     }
 }
 
-extension PinpointEmail.ListDomainDeliverabilityCampaignsRequest: AWSPaginateStringToken {
+extension PinpointEmail.ListDomainDeliverabilityCampaignsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> PinpointEmail.ListDomainDeliverabilityCampaignsRequest {
         return .init(
             endDate: self.endDate, 
@@ -92,7 +92,7 @@ extension PinpointEmail.ListDomainDeliverabilityCampaignsRequest: AWSPaginateStr
     }
 }
 
-extension PinpointEmail.ListEmailIdentitiesRequest: AWSPaginateStringToken {
+extension PinpointEmail.ListEmailIdentitiesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> PinpointEmail.ListEmailIdentitiesRequest {
         return .init(
             nextToken: token, 

--- a/Sources/AWSSDKSwift/Services/Polly/Polly_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Polly/Polly_Paginator.swift
@@ -13,7 +13,7 @@ extension Polly {
 
 }
 
-extension Polly.ListSpeechSynthesisTasksInput: AWSPaginateStringToken {
+extension Polly.ListSpeechSynthesisTasksInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Polly.ListSpeechSynthesisTasksInput {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/Pricing/Pricing_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Pricing/Pricing_Paginator.swift
@@ -23,7 +23,7 @@ extension Pricing {
 
 }
 
-extension Pricing.DescribeServicesRequest: AWSPaginateStringToken {
+extension Pricing.DescribeServicesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Pricing.DescribeServicesRequest {
         return .init(
             formatVersion: self.formatVersion, 
@@ -35,7 +35,7 @@ extension Pricing.DescribeServicesRequest: AWSPaginateStringToken {
     }
 }
 
-extension Pricing.GetAttributeValuesRequest: AWSPaginateStringToken {
+extension Pricing.GetAttributeValuesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Pricing.GetAttributeValuesRequest {
         return .init(
             attributeName: self.attributeName, 
@@ -47,7 +47,7 @@ extension Pricing.GetAttributeValuesRequest: AWSPaginateStringToken {
     }
 }
 
-extension Pricing.GetProductsRequest: AWSPaginateStringToken {
+extension Pricing.GetProductsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Pricing.GetProductsRequest {
         return .init(
             filters: self.filters, 

--- a/Sources/AWSSDKSwift/Services/QLDB/QLDB_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/QLDB/QLDB_Paginator.swift
@@ -23,7 +23,7 @@ extension QLDB {
 
 }
 
-extension QLDB.ListJournalS3ExportsRequest: AWSPaginateStringToken {
+extension QLDB.ListJournalS3ExportsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> QLDB.ListJournalS3ExportsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -33,7 +33,7 @@ extension QLDB.ListJournalS3ExportsRequest: AWSPaginateStringToken {
     }
 }
 
-extension QLDB.ListJournalS3ExportsForLedgerRequest: AWSPaginateStringToken {
+extension QLDB.ListJournalS3ExportsForLedgerRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> QLDB.ListJournalS3ExportsForLedgerRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -44,7 +44,7 @@ extension QLDB.ListJournalS3ExportsForLedgerRequest: AWSPaginateStringToken {
     }
 }
 
-extension QLDB.ListLedgersRequest: AWSPaginateStringToken {
+extension QLDB.ListLedgersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> QLDB.ListLedgersRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/QuickSight/QuickSight_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/QuickSight/QuickSight_Paginator.swift
@@ -53,7 +53,7 @@ extension QuickSight {
 
 }
 
-extension QuickSight.ListDashboardVersionsRequest: AWSPaginateStringToken {
+extension QuickSight.ListDashboardVersionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> QuickSight.ListDashboardVersionsRequest {
         return .init(
             awsAccountId: self.awsAccountId, 
@@ -65,7 +65,7 @@ extension QuickSight.ListDashboardVersionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension QuickSight.ListDashboardsRequest: AWSPaginateStringToken {
+extension QuickSight.ListDashboardsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> QuickSight.ListDashboardsRequest {
         return .init(
             awsAccountId: self.awsAccountId, 
@@ -76,7 +76,7 @@ extension QuickSight.ListDashboardsRequest: AWSPaginateStringToken {
     }
 }
 
-extension QuickSight.ListDataSetsRequest: AWSPaginateStringToken {
+extension QuickSight.ListDataSetsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> QuickSight.ListDataSetsRequest {
         return .init(
             awsAccountId: self.awsAccountId, 
@@ -87,7 +87,7 @@ extension QuickSight.ListDataSetsRequest: AWSPaginateStringToken {
     }
 }
 
-extension QuickSight.ListDataSourcesRequest: AWSPaginateStringToken {
+extension QuickSight.ListDataSourcesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> QuickSight.ListDataSourcesRequest {
         return .init(
             awsAccountId: self.awsAccountId, 
@@ -98,7 +98,7 @@ extension QuickSight.ListDataSourcesRequest: AWSPaginateStringToken {
     }
 }
 
-extension QuickSight.ListIngestionsRequest: AWSPaginateStringToken {
+extension QuickSight.ListIngestionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> QuickSight.ListIngestionsRequest {
         return .init(
             awsAccountId: self.awsAccountId, 
@@ -110,7 +110,7 @@ extension QuickSight.ListIngestionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension QuickSight.ListTemplateAliasesRequest: AWSPaginateStringToken {
+extension QuickSight.ListTemplateAliasesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> QuickSight.ListTemplateAliasesRequest {
         return .init(
             awsAccountId: self.awsAccountId, 
@@ -122,7 +122,7 @@ extension QuickSight.ListTemplateAliasesRequest: AWSPaginateStringToken {
     }
 }
 
-extension QuickSight.ListTemplateVersionsRequest: AWSPaginateStringToken {
+extension QuickSight.ListTemplateVersionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> QuickSight.ListTemplateVersionsRequest {
         return .init(
             awsAccountId: self.awsAccountId, 
@@ -134,7 +134,7 @@ extension QuickSight.ListTemplateVersionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension QuickSight.ListTemplatesRequest: AWSPaginateStringToken {
+extension QuickSight.ListTemplatesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> QuickSight.ListTemplatesRequest {
         return .init(
             awsAccountId: self.awsAccountId, 
@@ -145,7 +145,7 @@ extension QuickSight.ListTemplatesRequest: AWSPaginateStringToken {
     }
 }
 
-extension QuickSight.SearchDashboardsRequest: AWSPaginateStringToken {
+extension QuickSight.SearchDashboardsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> QuickSight.SearchDashboardsRequest {
         return .init(
             awsAccountId: self.awsAccountId, 

--- a/Sources/AWSSDKSwift/Services/RAM/RAM_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/RAM/RAM_Paginator.swift
@@ -43,7 +43,7 @@ extension RAM {
 
 }
 
-extension RAM.GetResourcePoliciesRequest: AWSPaginateStringToken {
+extension RAM.GetResourcePoliciesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RAM.GetResourcePoliciesRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -55,7 +55,7 @@ extension RAM.GetResourcePoliciesRequest: AWSPaginateStringToken {
     }
 }
 
-extension RAM.GetResourceShareAssociationsRequest: AWSPaginateStringToken {
+extension RAM.GetResourceShareAssociationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RAM.GetResourceShareAssociationsRequest {
         return .init(
             associationStatus: self.associationStatus, 
@@ -70,7 +70,7 @@ extension RAM.GetResourceShareAssociationsRequest: AWSPaginateStringToken {
     }
 }
 
-extension RAM.GetResourceShareInvitationsRequest: AWSPaginateStringToken {
+extension RAM.GetResourceShareInvitationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RAM.GetResourceShareInvitationsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -82,7 +82,7 @@ extension RAM.GetResourceShareInvitationsRequest: AWSPaginateStringToken {
     }
 }
 
-extension RAM.GetResourceSharesRequest: AWSPaginateStringToken {
+extension RAM.GetResourceSharesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RAM.GetResourceSharesRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -97,7 +97,7 @@ extension RAM.GetResourceSharesRequest: AWSPaginateStringToken {
     }
 }
 
-extension RAM.ListPendingInvitationResourcesRequest: AWSPaginateStringToken {
+extension RAM.ListPendingInvitationResourcesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RAM.ListPendingInvitationResourcesRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -108,7 +108,7 @@ extension RAM.ListPendingInvitationResourcesRequest: AWSPaginateStringToken {
     }
 }
 
-extension RAM.ListPrincipalsRequest: AWSPaginateStringToken {
+extension RAM.ListPrincipalsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RAM.ListPrincipalsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -123,7 +123,7 @@ extension RAM.ListPrincipalsRequest: AWSPaginateStringToken {
     }
 }
 
-extension RAM.ListResourcesRequest: AWSPaginateStringToken {
+extension RAM.ListResourcesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RAM.ListResourcesRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/RDS/RDS_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/RDS/RDS_Paginator.swift
@@ -138,7 +138,7 @@ extension RDS {
 
 }
 
-extension RDS.DescribeCustomAvailabilityZonesMessage: AWSPaginateStringToken {
+extension RDS.DescribeCustomAvailabilityZonesMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RDS.DescribeCustomAvailabilityZonesMessage {
         return .init(
             customAvailabilityZoneId: self.customAvailabilityZoneId, 
@@ -150,7 +150,7 @@ extension RDS.DescribeCustomAvailabilityZonesMessage: AWSPaginateStringToken {
     }
 }
 
-extension RDS.DescribeDBClustersMessage: AWSPaginateStringToken {
+extension RDS.DescribeDBClustersMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RDS.DescribeDBClustersMessage {
         return .init(
             dBClusterIdentifier: self.dBClusterIdentifier, 
@@ -163,7 +163,7 @@ extension RDS.DescribeDBClustersMessage: AWSPaginateStringToken {
     }
 }
 
-extension RDS.DescribeDBEngineVersionsMessage: AWSPaginateStringToken {
+extension RDS.DescribeDBEngineVersionsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RDS.DescribeDBEngineVersionsMessage {
         return .init(
             dBParameterGroupFamily: self.dBParameterGroupFamily, 
@@ -181,7 +181,7 @@ extension RDS.DescribeDBEngineVersionsMessage: AWSPaginateStringToken {
     }
 }
 
-extension RDS.DescribeDBInstanceAutomatedBackupsMessage: AWSPaginateStringToken {
+extension RDS.DescribeDBInstanceAutomatedBackupsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RDS.DescribeDBInstanceAutomatedBackupsMessage {
         return .init(
             dBInstanceIdentifier: self.dBInstanceIdentifier, 
@@ -194,7 +194,7 @@ extension RDS.DescribeDBInstanceAutomatedBackupsMessage: AWSPaginateStringToken 
     }
 }
 
-extension RDS.DescribeDBInstancesMessage: AWSPaginateStringToken {
+extension RDS.DescribeDBInstancesMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RDS.DescribeDBInstancesMessage {
         return .init(
             dBInstanceIdentifier: self.dBInstanceIdentifier, 
@@ -206,7 +206,7 @@ extension RDS.DescribeDBInstancesMessage: AWSPaginateStringToken {
     }
 }
 
-extension RDS.DescribeDBLogFilesMessage: AWSPaginateStringToken {
+extension RDS.DescribeDBLogFilesMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RDS.DescribeDBLogFilesMessage {
         return .init(
             dBInstanceIdentifier: self.dBInstanceIdentifier, 
@@ -221,7 +221,7 @@ extension RDS.DescribeDBLogFilesMessage: AWSPaginateStringToken {
     }
 }
 
-extension RDS.DescribeDBParameterGroupsMessage: AWSPaginateStringToken {
+extension RDS.DescribeDBParameterGroupsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RDS.DescribeDBParameterGroupsMessage {
         return .init(
             dBParameterGroupName: self.dBParameterGroupName, 
@@ -233,7 +233,7 @@ extension RDS.DescribeDBParameterGroupsMessage: AWSPaginateStringToken {
     }
 }
 
-extension RDS.DescribeDBParametersMessage: AWSPaginateStringToken {
+extension RDS.DescribeDBParametersMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RDS.DescribeDBParametersMessage {
         return .init(
             dBParameterGroupName: self.dBParameterGroupName, 
@@ -246,7 +246,7 @@ extension RDS.DescribeDBParametersMessage: AWSPaginateStringToken {
     }
 }
 
-extension RDS.DescribeDBProxiesRequest: AWSPaginateStringToken {
+extension RDS.DescribeDBProxiesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RDS.DescribeDBProxiesRequest {
         return .init(
             dBProxyName: self.dBProxyName, 
@@ -258,7 +258,7 @@ extension RDS.DescribeDBProxiesRequest: AWSPaginateStringToken {
     }
 }
 
-extension RDS.DescribeDBProxyTargetGroupsRequest: AWSPaginateStringToken {
+extension RDS.DescribeDBProxyTargetGroupsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RDS.DescribeDBProxyTargetGroupsRequest {
         return .init(
             dBProxyName: self.dBProxyName, 
@@ -271,7 +271,7 @@ extension RDS.DescribeDBProxyTargetGroupsRequest: AWSPaginateStringToken {
     }
 }
 
-extension RDS.DescribeDBProxyTargetsRequest: AWSPaginateStringToken {
+extension RDS.DescribeDBProxyTargetsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RDS.DescribeDBProxyTargetsRequest {
         return .init(
             dBProxyName: self.dBProxyName, 
@@ -284,7 +284,7 @@ extension RDS.DescribeDBProxyTargetsRequest: AWSPaginateStringToken {
     }
 }
 
-extension RDS.DescribeDBSecurityGroupsMessage: AWSPaginateStringToken {
+extension RDS.DescribeDBSecurityGroupsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RDS.DescribeDBSecurityGroupsMessage {
         return .init(
             dBSecurityGroupName: self.dBSecurityGroupName, 
@@ -296,7 +296,7 @@ extension RDS.DescribeDBSecurityGroupsMessage: AWSPaginateStringToken {
     }
 }
 
-extension RDS.DescribeDBSnapshotsMessage: AWSPaginateStringToken {
+extension RDS.DescribeDBSnapshotsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RDS.DescribeDBSnapshotsMessage {
         return .init(
             dBInstanceIdentifier: self.dBInstanceIdentifier, 
@@ -313,7 +313,7 @@ extension RDS.DescribeDBSnapshotsMessage: AWSPaginateStringToken {
     }
 }
 
-extension RDS.DescribeDBSubnetGroupsMessage: AWSPaginateStringToken {
+extension RDS.DescribeDBSubnetGroupsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RDS.DescribeDBSubnetGroupsMessage {
         return .init(
             dBSubnetGroupName: self.dBSubnetGroupName, 
@@ -325,7 +325,7 @@ extension RDS.DescribeDBSubnetGroupsMessage: AWSPaginateStringToken {
     }
 }
 
-extension RDS.DescribeEngineDefaultParametersMessage: AWSPaginateStringToken {
+extension RDS.DescribeEngineDefaultParametersMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RDS.DescribeEngineDefaultParametersMessage {
         return .init(
             dBParameterGroupFamily: self.dBParameterGroupFamily, 
@@ -337,7 +337,7 @@ extension RDS.DescribeEngineDefaultParametersMessage: AWSPaginateStringToken {
     }
 }
 
-extension RDS.DescribeEventSubscriptionsMessage: AWSPaginateStringToken {
+extension RDS.DescribeEventSubscriptionsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RDS.DescribeEventSubscriptionsMessage {
         return .init(
             filters: self.filters, 
@@ -349,7 +349,7 @@ extension RDS.DescribeEventSubscriptionsMessage: AWSPaginateStringToken {
     }
 }
 
-extension RDS.DescribeEventsMessage: AWSPaginateStringToken {
+extension RDS.DescribeEventsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RDS.DescribeEventsMessage {
         return .init(
             duration: self.duration, 
@@ -366,7 +366,7 @@ extension RDS.DescribeEventsMessage: AWSPaginateStringToken {
     }
 }
 
-extension RDS.DescribeExportTasksMessage: AWSPaginateStringToken {
+extension RDS.DescribeExportTasksMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RDS.DescribeExportTasksMessage {
         return .init(
             exportTaskIdentifier: self.exportTaskIdentifier, 
@@ -379,7 +379,7 @@ extension RDS.DescribeExportTasksMessage: AWSPaginateStringToken {
     }
 }
 
-extension RDS.DescribeGlobalClustersMessage: AWSPaginateStringToken {
+extension RDS.DescribeGlobalClustersMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RDS.DescribeGlobalClustersMessage {
         return .init(
             filters: self.filters, 
@@ -391,7 +391,7 @@ extension RDS.DescribeGlobalClustersMessage: AWSPaginateStringToken {
     }
 }
 
-extension RDS.DescribeInstallationMediaMessage: AWSPaginateStringToken {
+extension RDS.DescribeInstallationMediaMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RDS.DescribeInstallationMediaMessage {
         return .init(
             filters: self.filters, 
@@ -403,7 +403,7 @@ extension RDS.DescribeInstallationMediaMessage: AWSPaginateStringToken {
     }
 }
 
-extension RDS.DescribeOptionGroupOptionsMessage: AWSPaginateStringToken {
+extension RDS.DescribeOptionGroupOptionsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RDS.DescribeOptionGroupOptionsMessage {
         return .init(
             engineName: self.engineName, 
@@ -416,7 +416,7 @@ extension RDS.DescribeOptionGroupOptionsMessage: AWSPaginateStringToken {
     }
 }
 
-extension RDS.DescribeOptionGroupsMessage: AWSPaginateStringToken {
+extension RDS.DescribeOptionGroupsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RDS.DescribeOptionGroupsMessage {
         return .init(
             engineName: self.engineName, 
@@ -430,7 +430,7 @@ extension RDS.DescribeOptionGroupsMessage: AWSPaginateStringToken {
     }
 }
 
-extension RDS.DescribeOrderableDBInstanceOptionsMessage: AWSPaginateStringToken {
+extension RDS.DescribeOrderableDBInstanceOptionsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RDS.DescribeOrderableDBInstanceOptionsMessage {
         return .init(
             dBInstanceClass: self.dBInstanceClass, 
@@ -446,7 +446,7 @@ extension RDS.DescribeOrderableDBInstanceOptionsMessage: AWSPaginateStringToken 
     }
 }
 
-extension RDS.DescribeReservedDBInstancesMessage: AWSPaginateStringToken {
+extension RDS.DescribeReservedDBInstancesMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RDS.DescribeReservedDBInstancesMessage {
         return .init(
             dBInstanceClass: self.dBInstanceClass, 
@@ -465,7 +465,7 @@ extension RDS.DescribeReservedDBInstancesMessage: AWSPaginateStringToken {
     }
 }
 
-extension RDS.DescribeReservedDBInstancesOfferingsMessage: AWSPaginateStringToken {
+extension RDS.DescribeReservedDBInstancesOfferingsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RDS.DescribeReservedDBInstancesOfferingsMessage {
         return .init(
             dBInstanceClass: self.dBInstanceClass, 
@@ -482,7 +482,7 @@ extension RDS.DescribeReservedDBInstancesOfferingsMessage: AWSPaginateStringToke
     }
 }
 
-extension RDS.DownloadDBLogFilePortionMessage: AWSPaginateStringToken {
+extension RDS.DownloadDBLogFilePortionMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RDS.DownloadDBLogFilePortionMessage {
         return .init(
             dBInstanceIdentifier: self.dBInstanceIdentifier, 

--- a/Sources/AWSSDKSwift/Services/Redshift/Redshift_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Redshift/Redshift_Paginator.swift
@@ -93,7 +93,7 @@ extension Redshift {
 
 }
 
-extension Redshift.DescribeClusterParameterGroupsMessage: AWSPaginateStringToken {
+extension Redshift.DescribeClusterParameterGroupsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Redshift.DescribeClusterParameterGroupsMessage {
         return .init(
             marker: token, 
@@ -106,7 +106,7 @@ extension Redshift.DescribeClusterParameterGroupsMessage: AWSPaginateStringToken
     }
 }
 
-extension Redshift.DescribeClusterParametersMessage: AWSPaginateStringToken {
+extension Redshift.DescribeClusterParametersMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Redshift.DescribeClusterParametersMessage {
         return .init(
             marker: token, 
@@ -118,7 +118,7 @@ extension Redshift.DescribeClusterParametersMessage: AWSPaginateStringToken {
     }
 }
 
-extension Redshift.DescribeClusterSecurityGroupsMessage: AWSPaginateStringToken {
+extension Redshift.DescribeClusterSecurityGroupsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Redshift.DescribeClusterSecurityGroupsMessage {
         return .init(
             clusterSecurityGroupName: self.clusterSecurityGroupName, 
@@ -131,7 +131,7 @@ extension Redshift.DescribeClusterSecurityGroupsMessage: AWSPaginateStringToken 
     }
 }
 
-extension Redshift.DescribeClusterSnapshotsMessage: AWSPaginateStringToken {
+extension Redshift.DescribeClusterSnapshotsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Redshift.DescribeClusterSnapshotsMessage {
         return .init(
             clusterExists: self.clusterExists, 
@@ -151,7 +151,7 @@ extension Redshift.DescribeClusterSnapshotsMessage: AWSPaginateStringToken {
     }
 }
 
-extension Redshift.DescribeClusterSubnetGroupsMessage: AWSPaginateStringToken {
+extension Redshift.DescribeClusterSubnetGroupsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Redshift.DescribeClusterSubnetGroupsMessage {
         return .init(
             clusterSubnetGroupName: self.clusterSubnetGroupName, 
@@ -164,7 +164,7 @@ extension Redshift.DescribeClusterSubnetGroupsMessage: AWSPaginateStringToken {
     }
 }
 
-extension Redshift.DescribeClusterVersionsMessage: AWSPaginateStringToken {
+extension Redshift.DescribeClusterVersionsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Redshift.DescribeClusterVersionsMessage {
         return .init(
             clusterParameterGroupFamily: self.clusterParameterGroupFamily, 
@@ -176,7 +176,7 @@ extension Redshift.DescribeClusterVersionsMessage: AWSPaginateStringToken {
     }
 }
 
-extension Redshift.DescribeClustersMessage: AWSPaginateStringToken {
+extension Redshift.DescribeClustersMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Redshift.DescribeClustersMessage {
         return .init(
             clusterIdentifier: self.clusterIdentifier, 
@@ -189,7 +189,7 @@ extension Redshift.DescribeClustersMessage: AWSPaginateStringToken {
     }
 }
 
-extension Redshift.DescribeDefaultClusterParametersMessage: AWSPaginateStringToken {
+extension Redshift.DescribeDefaultClusterParametersMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Redshift.DescribeDefaultClusterParametersMessage {
         return .init(
             marker: token, 
@@ -200,7 +200,7 @@ extension Redshift.DescribeDefaultClusterParametersMessage: AWSPaginateStringTok
     }
 }
 
-extension Redshift.DescribeEventSubscriptionsMessage: AWSPaginateStringToken {
+extension Redshift.DescribeEventSubscriptionsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Redshift.DescribeEventSubscriptionsMessage {
         return .init(
             marker: token, 
@@ -213,7 +213,7 @@ extension Redshift.DescribeEventSubscriptionsMessage: AWSPaginateStringToken {
     }
 }
 
-extension Redshift.DescribeEventsMessage: AWSPaginateStringToken {
+extension Redshift.DescribeEventsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Redshift.DescribeEventsMessage {
         return .init(
             duration: self.duration, 
@@ -228,7 +228,7 @@ extension Redshift.DescribeEventsMessage: AWSPaginateStringToken {
     }
 }
 
-extension Redshift.DescribeHsmClientCertificatesMessage: AWSPaginateStringToken {
+extension Redshift.DescribeHsmClientCertificatesMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Redshift.DescribeHsmClientCertificatesMessage {
         return .init(
             hsmClientCertificateIdentifier: self.hsmClientCertificateIdentifier, 
@@ -241,7 +241,7 @@ extension Redshift.DescribeHsmClientCertificatesMessage: AWSPaginateStringToken 
     }
 }
 
-extension Redshift.DescribeHsmConfigurationsMessage: AWSPaginateStringToken {
+extension Redshift.DescribeHsmConfigurationsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Redshift.DescribeHsmConfigurationsMessage {
         return .init(
             hsmConfigurationIdentifier: self.hsmConfigurationIdentifier, 
@@ -254,7 +254,7 @@ extension Redshift.DescribeHsmConfigurationsMessage: AWSPaginateStringToken {
     }
 }
 
-extension Redshift.DescribeNodeConfigurationOptionsMessage: AWSPaginateStringToken {
+extension Redshift.DescribeNodeConfigurationOptionsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Redshift.DescribeNodeConfigurationOptionsMessage {
         return .init(
             actionType: self.actionType, 
@@ -269,7 +269,7 @@ extension Redshift.DescribeNodeConfigurationOptionsMessage: AWSPaginateStringTok
     }
 }
 
-extension Redshift.DescribeOrderableClusterOptionsMessage: AWSPaginateStringToken {
+extension Redshift.DescribeOrderableClusterOptionsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Redshift.DescribeOrderableClusterOptionsMessage {
         return .init(
             clusterVersion: self.clusterVersion, 
@@ -281,7 +281,7 @@ extension Redshift.DescribeOrderableClusterOptionsMessage: AWSPaginateStringToke
     }
 }
 
-extension Redshift.DescribeReservedNodeOfferingsMessage: AWSPaginateStringToken {
+extension Redshift.DescribeReservedNodeOfferingsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Redshift.DescribeReservedNodeOfferingsMessage {
         return .init(
             marker: token, 
@@ -292,7 +292,7 @@ extension Redshift.DescribeReservedNodeOfferingsMessage: AWSPaginateStringToken 
     }
 }
 
-extension Redshift.DescribeReservedNodesMessage: AWSPaginateStringToken {
+extension Redshift.DescribeReservedNodesMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Redshift.DescribeReservedNodesMessage {
         return .init(
             marker: token, 
@@ -303,7 +303,7 @@ extension Redshift.DescribeReservedNodesMessage: AWSPaginateStringToken {
     }
 }
 
-extension Redshift.DescribeScheduledActionsMessage: AWSPaginateStringToken {
+extension Redshift.DescribeScheduledActionsMessage: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Redshift.DescribeScheduledActionsMessage {
         return .init(
             active: self.active, 

--- a/Sources/AWSSDKSwift/Services/Rekognition/Rekognition_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Rekognition/Rekognition_Paginator.swift
@@ -68,7 +68,7 @@ extension Rekognition {
 
 }
 
-extension Rekognition.DescribeProjectVersionsRequest: AWSPaginateStringToken {
+extension Rekognition.DescribeProjectVersionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Rekognition.DescribeProjectVersionsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -80,7 +80,7 @@ extension Rekognition.DescribeProjectVersionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Rekognition.DescribeProjectsRequest: AWSPaginateStringToken {
+extension Rekognition.DescribeProjectsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Rekognition.DescribeProjectsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -90,7 +90,7 @@ extension Rekognition.DescribeProjectsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Rekognition.GetCelebrityRecognitionRequest: AWSPaginateStringToken {
+extension Rekognition.GetCelebrityRecognitionRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Rekognition.GetCelebrityRecognitionRequest {
         return .init(
             jobId: self.jobId, 
@@ -102,7 +102,7 @@ extension Rekognition.GetCelebrityRecognitionRequest: AWSPaginateStringToken {
     }
 }
 
-extension Rekognition.GetContentModerationRequest: AWSPaginateStringToken {
+extension Rekognition.GetContentModerationRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Rekognition.GetContentModerationRequest {
         return .init(
             jobId: self.jobId, 
@@ -114,7 +114,7 @@ extension Rekognition.GetContentModerationRequest: AWSPaginateStringToken {
     }
 }
 
-extension Rekognition.GetFaceDetectionRequest: AWSPaginateStringToken {
+extension Rekognition.GetFaceDetectionRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Rekognition.GetFaceDetectionRequest {
         return .init(
             jobId: self.jobId, 
@@ -125,7 +125,7 @@ extension Rekognition.GetFaceDetectionRequest: AWSPaginateStringToken {
     }
 }
 
-extension Rekognition.GetFaceSearchRequest: AWSPaginateStringToken {
+extension Rekognition.GetFaceSearchRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Rekognition.GetFaceSearchRequest {
         return .init(
             jobId: self.jobId, 
@@ -137,7 +137,7 @@ extension Rekognition.GetFaceSearchRequest: AWSPaginateStringToken {
     }
 }
 
-extension Rekognition.GetLabelDetectionRequest: AWSPaginateStringToken {
+extension Rekognition.GetLabelDetectionRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Rekognition.GetLabelDetectionRequest {
         return .init(
             jobId: self.jobId, 
@@ -149,7 +149,7 @@ extension Rekognition.GetLabelDetectionRequest: AWSPaginateStringToken {
     }
 }
 
-extension Rekognition.GetPersonTrackingRequest: AWSPaginateStringToken {
+extension Rekognition.GetPersonTrackingRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Rekognition.GetPersonTrackingRequest {
         return .init(
             jobId: self.jobId, 
@@ -161,7 +161,7 @@ extension Rekognition.GetPersonTrackingRequest: AWSPaginateStringToken {
     }
 }
 
-extension Rekognition.GetTextDetectionRequest: AWSPaginateStringToken {
+extension Rekognition.GetTextDetectionRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Rekognition.GetTextDetectionRequest {
         return .init(
             jobId: self.jobId, 
@@ -172,7 +172,7 @@ extension Rekognition.GetTextDetectionRequest: AWSPaginateStringToken {
     }
 }
 
-extension Rekognition.ListCollectionsRequest: AWSPaginateStringToken {
+extension Rekognition.ListCollectionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Rekognition.ListCollectionsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -182,7 +182,7 @@ extension Rekognition.ListCollectionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Rekognition.ListFacesRequest: AWSPaginateStringToken {
+extension Rekognition.ListFacesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Rekognition.ListFacesRequest {
         return .init(
             collectionId: self.collectionId, 
@@ -193,7 +193,7 @@ extension Rekognition.ListFacesRequest: AWSPaginateStringToken {
     }
 }
 
-extension Rekognition.ListStreamProcessorsRequest: AWSPaginateStringToken {
+extension Rekognition.ListStreamProcessorsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Rekognition.ListStreamProcessorsRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/ResourceGroups/ResourceGroups_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/ResourceGroups/ResourceGroups_Paginator.swift
@@ -23,7 +23,7 @@ extension ResourceGroups {
 
 }
 
-extension ResourceGroups.ListGroupResourcesInput: AWSPaginateStringToken {
+extension ResourceGroups.ListGroupResourcesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ResourceGroups.ListGroupResourcesInput {
         return .init(
             filters: self.filters, 
@@ -35,7 +35,7 @@ extension ResourceGroups.ListGroupResourcesInput: AWSPaginateStringToken {
     }
 }
 
-extension ResourceGroups.ListGroupsInput: AWSPaginateStringToken {
+extension ResourceGroups.ListGroupsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ResourceGroups.ListGroupsInput {
         return .init(
             filters: self.filters, 
@@ -46,7 +46,7 @@ extension ResourceGroups.ListGroupsInput: AWSPaginateStringToken {
     }
 }
 
-extension ResourceGroups.SearchResourcesInput: AWSPaginateStringToken {
+extension ResourceGroups.SearchResourcesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ResourceGroups.SearchResourcesInput {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/ResourceGroupsTaggingAPI/ResourceGroupsTaggingAPI_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/ResourceGroupsTaggingAPI/ResourceGroupsTaggingAPI_Paginator.swift
@@ -28,7 +28,7 @@ extension ResourceGroupsTaggingAPI {
 
 }
 
-extension ResourceGroupsTaggingAPI.GetComplianceSummaryInput: AWSPaginateStringToken {
+extension ResourceGroupsTaggingAPI.GetComplianceSummaryInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ResourceGroupsTaggingAPI.GetComplianceSummaryInput {
         return .init(
             groupBy: self.groupBy, 
@@ -43,7 +43,7 @@ extension ResourceGroupsTaggingAPI.GetComplianceSummaryInput: AWSPaginateStringT
     }
 }
 
-extension ResourceGroupsTaggingAPI.GetResourcesInput: AWSPaginateStringToken {
+extension ResourceGroupsTaggingAPI.GetResourcesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ResourceGroupsTaggingAPI.GetResourcesInput {
         return .init(
             excludeCompliantResources: self.excludeCompliantResources, 
@@ -58,7 +58,7 @@ extension ResourceGroupsTaggingAPI.GetResourcesInput: AWSPaginateStringToken {
     }
 }
 
-extension ResourceGroupsTaggingAPI.GetTagKeysInput: AWSPaginateStringToken {
+extension ResourceGroupsTaggingAPI.GetTagKeysInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ResourceGroupsTaggingAPI.GetTagKeysInput {
         return .init(
             paginationToken: token
@@ -67,7 +67,7 @@ extension ResourceGroupsTaggingAPI.GetTagKeysInput: AWSPaginateStringToken {
     }
 }
 
-extension ResourceGroupsTaggingAPI.GetTagValuesInput: AWSPaginateStringToken {
+extension ResourceGroupsTaggingAPI.GetTagValuesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ResourceGroupsTaggingAPI.GetTagValuesInput {
         return .init(
             key: self.key, 

--- a/Sources/AWSSDKSwift/Services/RoboMaker/RoboMaker_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/RoboMaker/RoboMaker_Paginator.swift
@@ -43,7 +43,7 @@ extension RoboMaker {
 
 }
 
-extension RoboMaker.ListDeploymentJobsRequest: AWSPaginateStringToken {
+extension RoboMaker.ListDeploymentJobsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RoboMaker.ListDeploymentJobsRequest {
         return .init(
             filters: self.filters, 
@@ -54,7 +54,7 @@ extension RoboMaker.ListDeploymentJobsRequest: AWSPaginateStringToken {
     }
 }
 
-extension RoboMaker.ListFleetsRequest: AWSPaginateStringToken {
+extension RoboMaker.ListFleetsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RoboMaker.ListFleetsRequest {
         return .init(
             filters: self.filters, 
@@ -65,7 +65,7 @@ extension RoboMaker.ListFleetsRequest: AWSPaginateStringToken {
     }
 }
 
-extension RoboMaker.ListRobotApplicationsRequest: AWSPaginateStringToken {
+extension RoboMaker.ListRobotApplicationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RoboMaker.ListRobotApplicationsRequest {
         return .init(
             filters: self.filters, 
@@ -77,7 +77,7 @@ extension RoboMaker.ListRobotApplicationsRequest: AWSPaginateStringToken {
     }
 }
 
-extension RoboMaker.ListRobotsRequest: AWSPaginateStringToken {
+extension RoboMaker.ListRobotsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RoboMaker.ListRobotsRequest {
         return .init(
             filters: self.filters, 
@@ -88,7 +88,7 @@ extension RoboMaker.ListRobotsRequest: AWSPaginateStringToken {
     }
 }
 
-extension RoboMaker.ListSimulationApplicationsRequest: AWSPaginateStringToken {
+extension RoboMaker.ListSimulationApplicationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RoboMaker.ListSimulationApplicationsRequest {
         return .init(
             filters: self.filters, 
@@ -100,7 +100,7 @@ extension RoboMaker.ListSimulationApplicationsRequest: AWSPaginateStringToken {
     }
 }
 
-extension RoboMaker.ListSimulationJobBatchesRequest: AWSPaginateStringToken {
+extension RoboMaker.ListSimulationJobBatchesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RoboMaker.ListSimulationJobBatchesRequest {
         return .init(
             filters: self.filters, 
@@ -111,7 +111,7 @@ extension RoboMaker.ListSimulationJobBatchesRequest: AWSPaginateStringToken {
     }
 }
 
-extension RoboMaker.ListSimulationJobsRequest: AWSPaginateStringToken {
+extension RoboMaker.ListSimulationJobsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> RoboMaker.ListSimulationJobsRequest {
         return .init(
             filters: self.filters, 

--- a/Sources/AWSSDKSwift/Services/Route53/Route53_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Route53/Route53_Paginator.swift
@@ -23,7 +23,7 @@ extension Route53 {
 
 }
 
-extension Route53.ListHealthChecksRequest: AWSPaginateStringToken {
+extension Route53.ListHealthChecksRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Route53.ListHealthChecksRequest {
         return .init(
             marker: token, 
@@ -33,7 +33,7 @@ extension Route53.ListHealthChecksRequest: AWSPaginateStringToken {
     }
 }
 
-extension Route53.ListHostedZonesRequest: AWSPaginateStringToken {
+extension Route53.ListHostedZonesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Route53.ListHostedZonesRequest {
         return .init(
             delegationSetId: self.delegationSetId, 
@@ -44,7 +44,7 @@ extension Route53.ListHostedZonesRequest: AWSPaginateStringToken {
     }
 }
 
-extension Route53.ListResourceRecordSetsRequest: AWSPaginateStringToken {
+extension Route53.ListResourceRecordSetsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Route53.ListResourceRecordSetsRequest {
         return .init(
             hostedZoneId: self.hostedZoneId, 

--- a/Sources/AWSSDKSwift/Services/Route53Domains/Route53Domains_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Route53Domains/Route53Domains_Paginator.swift
@@ -18,7 +18,7 @@ extension Route53Domains {
 
 }
 
-extension Route53Domains.ListDomainsRequest: AWSPaginateStringToken {
+extension Route53Domains.ListDomainsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Route53Domains.ListDomainsRequest {
         return .init(
             marker: token, 
@@ -28,7 +28,7 @@ extension Route53Domains.ListDomainsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Route53Domains.ListOperationsRequest: AWSPaginateStringToken {
+extension Route53Domains.ListOperationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Route53Domains.ListOperationsRequest {
         return .init(
             marker: token, 

--- a/Sources/AWSSDKSwift/Services/Route53Resolver/Route53Resolver_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Route53Resolver/Route53Resolver_Paginator.swift
@@ -28,7 +28,7 @@ extension Route53Resolver {
 
 }
 
-extension Route53Resolver.ListResolverEndpointIpAddressesRequest: AWSPaginateStringToken {
+extension Route53Resolver.ListResolverEndpointIpAddressesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Route53Resolver.ListResolverEndpointIpAddressesRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -39,7 +39,7 @@ extension Route53Resolver.ListResolverEndpointIpAddressesRequest: AWSPaginateStr
     }
 }
 
-extension Route53Resolver.ListResolverEndpointsRequest: AWSPaginateStringToken {
+extension Route53Resolver.ListResolverEndpointsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Route53Resolver.ListResolverEndpointsRequest {
         return .init(
             filters: self.filters, 
@@ -50,7 +50,7 @@ extension Route53Resolver.ListResolverEndpointsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Route53Resolver.ListResolverRuleAssociationsRequest: AWSPaginateStringToken {
+extension Route53Resolver.ListResolverRuleAssociationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Route53Resolver.ListResolverRuleAssociationsRequest {
         return .init(
             filters: self.filters, 
@@ -61,7 +61,7 @@ extension Route53Resolver.ListResolverRuleAssociationsRequest: AWSPaginateString
     }
 }
 
-extension Route53Resolver.ListResolverRulesRequest: AWSPaginateStringToken {
+extension Route53Resolver.ListResolverRulesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Route53Resolver.ListResolverRulesRequest {
         return .init(
             filters: self.filters, 

--- a/Sources/AWSSDKSwift/Services/S3/S3_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/S3/S3_Paginator.swift
@@ -33,7 +33,7 @@ extension S3 {
 
 }
 
-extension S3.ListMultipartUploadsRequest: AWSPaginateStringToken {
+extension S3.ListMultipartUploadsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> S3.ListMultipartUploadsRequest {
         return .init(
             bucket: self.bucket, 
@@ -48,7 +48,7 @@ extension S3.ListMultipartUploadsRequest: AWSPaginateStringToken {
     }
 }
 
-extension S3.ListObjectVersionsRequest: AWSPaginateStringToken {
+extension S3.ListObjectVersionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> S3.ListObjectVersionsRequest {
         return .init(
             bucket: self.bucket, 
@@ -63,7 +63,7 @@ extension S3.ListObjectVersionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension S3.ListObjectsRequest: AWSPaginateStringToken {
+extension S3.ListObjectsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> S3.ListObjectsRequest {
         return .init(
             bucket: self.bucket, 
@@ -78,7 +78,7 @@ extension S3.ListObjectsRequest: AWSPaginateStringToken {
     }
 }
 
-extension S3.ListObjectsV2Request: AWSPaginateStringToken {
+extension S3.ListObjectsV2Request: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> S3.ListObjectsV2Request {
         return .init(
             bucket: self.bucket, 
@@ -95,7 +95,7 @@ extension S3.ListObjectsV2Request: AWSPaginateStringToken {
     }
 }
 
-extension S3.ListPartsRequest: AWSPaginateIntToken {
+extension S3.ListPartsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: Int) -> S3.ListPartsRequest {
         return .init(
             bucket: self.bucket, 

--- a/Sources/AWSSDKSwift/Services/S3Control/S3Control_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/S3Control/S3Control_Paginator.swift
@@ -18,7 +18,7 @@ extension S3Control {
 
 }
 
-extension S3Control.ListAccessPointsRequest: AWSPaginateStringToken {
+extension S3Control.ListAccessPointsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> S3Control.ListAccessPointsRequest {
         return .init(
             accountId: self.accountId, 
@@ -30,7 +30,7 @@ extension S3Control.ListAccessPointsRequest: AWSPaginateStringToken {
     }
 }
 
-extension S3Control.ListJobsRequest: AWSPaginateStringToken {
+extension S3Control.ListJobsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> S3Control.ListJobsRequest {
         return .init(
             accountId: self.accountId, 

--- a/Sources/AWSSDKSwift/Services/SES/SES_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/SES/SES_Paginator.swift
@@ -18,7 +18,7 @@ extension SES {
 
 }
 
-extension SES.ListCustomVerificationEmailTemplatesRequest: AWSPaginateStringToken {
+extension SES.ListCustomVerificationEmailTemplatesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SES.ListCustomVerificationEmailTemplatesRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -28,7 +28,7 @@ extension SES.ListCustomVerificationEmailTemplatesRequest: AWSPaginateStringToke
     }
 }
 
-extension SES.ListIdentitiesRequest: AWSPaginateStringToken {
+extension SES.ListIdentitiesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SES.ListIdentitiesRequest {
         return .init(
             identityType: self.identityType, 

--- a/Sources/AWSSDKSwift/Services/SESV2/SESV2_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/SESV2/SESV2_Paginator.swift
@@ -43,7 +43,7 @@ extension SESV2 {
 
 }
 
-extension SESV2.GetDedicatedIpsRequest: AWSPaginateStringToken {
+extension SESV2.GetDedicatedIpsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SESV2.GetDedicatedIpsRequest {
         return .init(
             nextToken: token, 
@@ -54,7 +54,7 @@ extension SESV2.GetDedicatedIpsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SESV2.ListConfigurationSetsRequest: AWSPaginateStringToken {
+extension SESV2.ListConfigurationSetsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SESV2.ListConfigurationSetsRequest {
         return .init(
             nextToken: token, 
@@ -64,7 +64,7 @@ extension SESV2.ListConfigurationSetsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SESV2.ListDedicatedIpPoolsRequest: AWSPaginateStringToken {
+extension SESV2.ListDedicatedIpPoolsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SESV2.ListDedicatedIpPoolsRequest {
         return .init(
             nextToken: token, 
@@ -74,7 +74,7 @@ extension SESV2.ListDedicatedIpPoolsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SESV2.ListDeliverabilityTestReportsRequest: AWSPaginateStringToken {
+extension SESV2.ListDeliverabilityTestReportsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SESV2.ListDeliverabilityTestReportsRequest {
         return .init(
             nextToken: token, 
@@ -84,7 +84,7 @@ extension SESV2.ListDeliverabilityTestReportsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SESV2.ListDomainDeliverabilityCampaignsRequest: AWSPaginateStringToken {
+extension SESV2.ListDomainDeliverabilityCampaignsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SESV2.ListDomainDeliverabilityCampaignsRequest {
         return .init(
             endDate: self.endDate, 
@@ -97,7 +97,7 @@ extension SESV2.ListDomainDeliverabilityCampaignsRequest: AWSPaginateStringToken
     }
 }
 
-extension SESV2.ListEmailIdentitiesRequest: AWSPaginateStringToken {
+extension SESV2.ListEmailIdentitiesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SESV2.ListEmailIdentitiesRequest {
         return .init(
             nextToken: token, 
@@ -107,7 +107,7 @@ extension SESV2.ListEmailIdentitiesRequest: AWSPaginateStringToken {
     }
 }
 
-extension SESV2.ListSuppressedDestinationsRequest: AWSPaginateStringToken {
+extension SESV2.ListSuppressedDestinationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SESV2.ListSuppressedDestinationsRequest {
         return .init(
             endDate: self.endDate, 

--- a/Sources/AWSSDKSwift/Services/SFN/SFN_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/SFN/SFN_Paginator.swift
@@ -28,7 +28,7 @@ extension SFN {
 
 }
 
-extension SFN.GetExecutionHistoryInput: AWSPaginateStringToken {
+extension SFN.GetExecutionHistoryInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SFN.GetExecutionHistoryInput {
         return .init(
             executionArn: self.executionArn, 
@@ -40,7 +40,7 @@ extension SFN.GetExecutionHistoryInput: AWSPaginateStringToken {
     }
 }
 
-extension SFN.ListActivitiesInput: AWSPaginateStringToken {
+extension SFN.ListActivitiesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SFN.ListActivitiesInput {
         return .init(
             maxResults: self.maxResults, 
@@ -50,7 +50,7 @@ extension SFN.ListActivitiesInput: AWSPaginateStringToken {
     }
 }
 
-extension SFN.ListExecutionsInput: AWSPaginateStringToken {
+extension SFN.ListExecutionsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SFN.ListExecutionsInput {
         return .init(
             maxResults: self.maxResults, 
@@ -62,7 +62,7 @@ extension SFN.ListExecutionsInput: AWSPaginateStringToken {
     }
 }
 
-extension SFN.ListStateMachinesInput: AWSPaginateStringToken {
+extension SFN.ListStateMachinesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SFN.ListStateMachinesInput {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/SMS/SMS_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/SMS/SMS_Paginator.swift
@@ -28,7 +28,7 @@ extension SMS {
 
 }
 
-extension SMS.GetConnectorsRequest: AWSPaginateStringToken {
+extension SMS.GetConnectorsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SMS.GetConnectorsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -38,7 +38,7 @@ extension SMS.GetConnectorsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SMS.GetReplicationJobsRequest: AWSPaginateStringToken {
+extension SMS.GetReplicationJobsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SMS.GetReplicationJobsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -49,7 +49,7 @@ extension SMS.GetReplicationJobsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SMS.GetReplicationRunsRequest: AWSPaginateStringToken {
+extension SMS.GetReplicationRunsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SMS.GetReplicationRunsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -60,7 +60,7 @@ extension SMS.GetReplicationRunsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SMS.GetServersRequest: AWSPaginateStringToken {
+extension SMS.GetServersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SMS.GetServersRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/SNS/SNS_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/SNS/SNS_Paginator.swift
@@ -33,7 +33,7 @@ extension SNS {
 
 }
 
-extension SNS.ListEndpointsByPlatformApplicationInput: AWSPaginateStringToken {
+extension SNS.ListEndpointsByPlatformApplicationInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SNS.ListEndpointsByPlatformApplicationInput {
         return .init(
             nextToken: token, 
@@ -43,7 +43,7 @@ extension SNS.ListEndpointsByPlatformApplicationInput: AWSPaginateStringToken {
     }
 }
 
-extension SNS.ListPlatformApplicationsInput: AWSPaginateStringToken {
+extension SNS.ListPlatformApplicationsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SNS.ListPlatformApplicationsInput {
         return .init(
             nextToken: token
@@ -52,7 +52,7 @@ extension SNS.ListPlatformApplicationsInput: AWSPaginateStringToken {
     }
 }
 
-extension SNS.ListSubscriptionsInput: AWSPaginateStringToken {
+extension SNS.ListSubscriptionsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SNS.ListSubscriptionsInput {
         return .init(
             nextToken: token
@@ -61,7 +61,7 @@ extension SNS.ListSubscriptionsInput: AWSPaginateStringToken {
     }
 }
 
-extension SNS.ListSubscriptionsByTopicInput: AWSPaginateStringToken {
+extension SNS.ListSubscriptionsByTopicInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SNS.ListSubscriptionsByTopicInput {
         return .init(
             nextToken: token, 
@@ -71,7 +71,7 @@ extension SNS.ListSubscriptionsByTopicInput: AWSPaginateStringToken {
     }
 }
 
-extension SNS.ListTopicsInput: AWSPaginateStringToken {
+extension SNS.ListTopicsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SNS.ListTopicsInput {
         return .init(
             nextToken: token

--- a/Sources/AWSSDKSwift/Services/SSM/SSM_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/SSM/SSM_Paginator.swift
@@ -53,7 +53,7 @@ extension SSM {
 
 }
 
-extension SSM.DescribeActivationsRequest: AWSPaginateStringToken {
+extension SSM.DescribeActivationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SSM.DescribeActivationsRequest {
         return .init(
             filters: self.filters, 
@@ -64,7 +64,7 @@ extension SSM.DescribeActivationsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SSM.DescribeInstanceInformationRequest: AWSPaginateStringToken {
+extension SSM.DescribeInstanceInformationRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SSM.DescribeInstanceInformationRequest {
         return .init(
             filters: self.filters, 
@@ -76,7 +76,7 @@ extension SSM.DescribeInstanceInformationRequest: AWSPaginateStringToken {
     }
 }
 
-extension SSM.DescribeParametersRequest: AWSPaginateStringToken {
+extension SSM.DescribeParametersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SSM.DescribeParametersRequest {
         return .init(
             filters: self.filters, 
@@ -88,7 +88,7 @@ extension SSM.DescribeParametersRequest: AWSPaginateStringToken {
     }
 }
 
-extension SSM.GetParameterHistoryRequest: AWSPaginateStringToken {
+extension SSM.GetParameterHistoryRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SSM.GetParameterHistoryRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -100,7 +100,7 @@ extension SSM.GetParameterHistoryRequest: AWSPaginateStringToken {
     }
 }
 
-extension SSM.GetParametersByPathRequest: AWSPaginateStringToken {
+extension SSM.GetParametersByPathRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SSM.GetParametersByPathRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -114,7 +114,7 @@ extension SSM.GetParametersByPathRequest: AWSPaginateStringToken {
     }
 }
 
-extension SSM.ListAssociationsRequest: AWSPaginateStringToken {
+extension SSM.ListAssociationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SSM.ListAssociationsRequest {
         return .init(
             associationFilterList: self.associationFilterList, 
@@ -125,7 +125,7 @@ extension SSM.ListAssociationsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SSM.ListCommandInvocationsRequest: AWSPaginateStringToken {
+extension SSM.ListCommandInvocationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SSM.ListCommandInvocationsRequest {
         return .init(
             commandId: self.commandId, 
@@ -139,7 +139,7 @@ extension SSM.ListCommandInvocationsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SSM.ListCommandsRequest: AWSPaginateStringToken {
+extension SSM.ListCommandsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SSM.ListCommandsRequest {
         return .init(
             commandId: self.commandId, 
@@ -152,7 +152,7 @@ extension SSM.ListCommandsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SSM.ListDocumentsRequest: AWSPaginateStringToken {
+extension SSM.ListDocumentsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SSM.ListDocumentsRequest {
         return .init(
             documentFilterList: self.documentFilterList, 

--- a/Sources/AWSSDKSwift/Services/SSO/SSO_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/SSO/SSO_Paginator.swift
@@ -18,7 +18,7 @@ extension SSO {
 
 }
 
-extension SSO.ListAccountRolesRequest: AWSPaginateStringToken {
+extension SSO.ListAccountRolesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SSO.ListAccountRolesRequest {
         return .init(
             accessToken: self.accessToken, 
@@ -30,7 +30,7 @@ extension SSO.ListAccountRolesRequest: AWSPaginateStringToken {
     }
 }
 
-extension SSO.ListAccountsRequest: AWSPaginateStringToken {
+extension SSO.ListAccountsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SSO.ListAccountsRequest {
         return .init(
             accessToken: self.accessToken, 

--- a/Sources/AWSSDKSwift/Services/SWF/SWF_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/SWF/SWF_Paginator.swift
@@ -43,7 +43,7 @@ extension SWF {
 
 }
 
-extension SWF.GetWorkflowExecutionHistoryInput: AWSPaginateStringToken {
+extension SWF.GetWorkflowExecutionHistoryInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SWF.GetWorkflowExecutionHistoryInput {
         return .init(
             domain: self.domain, 
@@ -56,7 +56,7 @@ extension SWF.GetWorkflowExecutionHistoryInput: AWSPaginateStringToken {
     }
 }
 
-extension SWF.ListActivityTypesInput: AWSPaginateStringToken {
+extension SWF.ListActivityTypesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SWF.ListActivityTypesInput {
         return .init(
             domain: self.domain, 
@@ -70,7 +70,7 @@ extension SWF.ListActivityTypesInput: AWSPaginateStringToken {
     }
 }
 
-extension SWF.ListClosedWorkflowExecutionsInput: AWSPaginateStringToken {
+extension SWF.ListClosedWorkflowExecutionsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SWF.ListClosedWorkflowExecutionsInput {
         return .init(
             closeStatusFilter: self.closeStatusFilter, 
@@ -88,7 +88,7 @@ extension SWF.ListClosedWorkflowExecutionsInput: AWSPaginateStringToken {
     }
 }
 
-extension SWF.ListDomainsInput: AWSPaginateStringToken {
+extension SWF.ListDomainsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SWF.ListDomainsInput {
         return .init(
             maximumPageSize: self.maximumPageSize, 
@@ -100,7 +100,7 @@ extension SWF.ListDomainsInput: AWSPaginateStringToken {
     }
 }
 
-extension SWF.ListOpenWorkflowExecutionsInput: AWSPaginateStringToken {
+extension SWF.ListOpenWorkflowExecutionsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SWF.ListOpenWorkflowExecutionsInput {
         return .init(
             domain: self.domain, 
@@ -116,7 +116,7 @@ extension SWF.ListOpenWorkflowExecutionsInput: AWSPaginateStringToken {
     }
 }
 
-extension SWF.ListWorkflowTypesInput: AWSPaginateStringToken {
+extension SWF.ListWorkflowTypesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SWF.ListWorkflowTypesInput {
         return .init(
             domain: self.domain, 
@@ -130,7 +130,7 @@ extension SWF.ListWorkflowTypesInput: AWSPaginateStringToken {
     }
 }
 
-extension SWF.PollForDecisionTaskInput: AWSPaginateStringToken {
+extension SWF.PollForDecisionTaskInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SWF.PollForDecisionTaskInput {
         return .init(
             domain: self.domain, 

--- a/Sources/AWSSDKSwift/Services/SageMaker/SageMaker_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/SageMaker/SageMaker_Paginator.swift
@@ -168,7 +168,7 @@ extension SageMaker {
 
 }
 
-extension SageMaker.ListAlgorithmsInput: AWSPaginateStringToken {
+extension SageMaker.ListAlgorithmsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SageMaker.ListAlgorithmsInput {
         return .init(
             creationTimeAfter: self.creationTimeAfter, 
@@ -183,7 +183,7 @@ extension SageMaker.ListAlgorithmsInput: AWSPaginateStringToken {
     }
 }
 
-extension SageMaker.ListAppsRequest: AWSPaginateStringToken {
+extension SageMaker.ListAppsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SageMaker.ListAppsRequest {
         return .init(
             domainIdEquals: self.domainIdEquals, 
@@ -197,7 +197,7 @@ extension SageMaker.ListAppsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SageMaker.ListAutoMLJobsRequest: AWSPaginateStringToken {
+extension SageMaker.ListAutoMLJobsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SageMaker.ListAutoMLJobsRequest {
         return .init(
             creationTimeAfter: self.creationTimeAfter, 
@@ -215,7 +215,7 @@ extension SageMaker.ListAutoMLJobsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SageMaker.ListCandidatesForAutoMLJobRequest: AWSPaginateStringToken {
+extension SageMaker.ListCandidatesForAutoMLJobRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SageMaker.ListCandidatesForAutoMLJobRequest {
         return .init(
             autoMLJobName: self.autoMLJobName, 
@@ -230,7 +230,7 @@ extension SageMaker.ListCandidatesForAutoMLJobRequest: AWSPaginateStringToken {
     }
 }
 
-extension SageMaker.ListCodeRepositoriesInput: AWSPaginateStringToken {
+extension SageMaker.ListCodeRepositoriesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SageMaker.ListCodeRepositoriesInput {
         return .init(
             creationTimeAfter: self.creationTimeAfter, 
@@ -247,7 +247,7 @@ extension SageMaker.ListCodeRepositoriesInput: AWSPaginateStringToken {
     }
 }
 
-extension SageMaker.ListCompilationJobsRequest: AWSPaginateStringToken {
+extension SageMaker.ListCompilationJobsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SageMaker.ListCompilationJobsRequest {
         return .init(
             creationTimeAfter: self.creationTimeAfter, 
@@ -265,7 +265,7 @@ extension SageMaker.ListCompilationJobsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SageMaker.ListDomainsRequest: AWSPaginateStringToken {
+extension SageMaker.ListDomainsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SageMaker.ListDomainsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -275,7 +275,7 @@ extension SageMaker.ListDomainsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SageMaker.ListEndpointConfigsInput: AWSPaginateStringToken {
+extension SageMaker.ListEndpointConfigsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SageMaker.ListEndpointConfigsInput {
         return .init(
             creationTimeAfter: self.creationTimeAfter, 
@@ -290,7 +290,7 @@ extension SageMaker.ListEndpointConfigsInput: AWSPaginateStringToken {
     }
 }
 
-extension SageMaker.ListEndpointsInput: AWSPaginateStringToken {
+extension SageMaker.ListEndpointsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SageMaker.ListEndpointsInput {
         return .init(
             creationTimeAfter: self.creationTimeAfter, 
@@ -308,7 +308,7 @@ extension SageMaker.ListEndpointsInput: AWSPaginateStringToken {
     }
 }
 
-extension SageMaker.ListExperimentsRequest: AWSPaginateStringToken {
+extension SageMaker.ListExperimentsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SageMaker.ListExperimentsRequest {
         return .init(
             createdAfter: self.createdAfter, 
@@ -322,7 +322,7 @@ extension SageMaker.ListExperimentsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SageMaker.ListFlowDefinitionsRequest: AWSPaginateStringToken {
+extension SageMaker.ListFlowDefinitionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SageMaker.ListFlowDefinitionsRequest {
         return .init(
             creationTimeAfter: self.creationTimeAfter, 
@@ -335,7 +335,7 @@ extension SageMaker.ListFlowDefinitionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SageMaker.ListHumanTaskUisRequest: AWSPaginateStringToken {
+extension SageMaker.ListHumanTaskUisRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SageMaker.ListHumanTaskUisRequest {
         return .init(
             creationTimeAfter: self.creationTimeAfter, 
@@ -348,7 +348,7 @@ extension SageMaker.ListHumanTaskUisRequest: AWSPaginateStringToken {
     }
 }
 
-extension SageMaker.ListHyperParameterTuningJobsRequest: AWSPaginateStringToken {
+extension SageMaker.ListHyperParameterTuningJobsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SageMaker.ListHyperParameterTuningJobsRequest {
         return .init(
             creationTimeAfter: self.creationTimeAfter, 
@@ -366,7 +366,7 @@ extension SageMaker.ListHyperParameterTuningJobsRequest: AWSPaginateStringToken 
     }
 }
 
-extension SageMaker.ListLabelingJobsRequest: AWSPaginateStringToken {
+extension SageMaker.ListLabelingJobsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SageMaker.ListLabelingJobsRequest {
         return .init(
             creationTimeAfter: self.creationTimeAfter, 
@@ -384,7 +384,7 @@ extension SageMaker.ListLabelingJobsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SageMaker.ListLabelingJobsForWorkteamRequest: AWSPaginateStringToken {
+extension SageMaker.ListLabelingJobsForWorkteamRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SageMaker.ListLabelingJobsForWorkteamRequest {
         return .init(
             creationTimeAfter: self.creationTimeAfter, 
@@ -400,7 +400,7 @@ extension SageMaker.ListLabelingJobsForWorkteamRequest: AWSPaginateStringToken {
     }
 }
 
-extension SageMaker.ListModelPackagesInput: AWSPaginateStringToken {
+extension SageMaker.ListModelPackagesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SageMaker.ListModelPackagesInput {
         return .init(
             creationTimeAfter: self.creationTimeAfter, 
@@ -415,7 +415,7 @@ extension SageMaker.ListModelPackagesInput: AWSPaginateStringToken {
     }
 }
 
-extension SageMaker.ListModelsInput: AWSPaginateStringToken {
+extension SageMaker.ListModelsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SageMaker.ListModelsInput {
         return .init(
             creationTimeAfter: self.creationTimeAfter, 
@@ -430,7 +430,7 @@ extension SageMaker.ListModelsInput: AWSPaginateStringToken {
     }
 }
 
-extension SageMaker.ListMonitoringExecutionsRequest: AWSPaginateStringToken {
+extension SageMaker.ListMonitoringExecutionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SageMaker.ListMonitoringExecutionsRequest {
         return .init(
             creationTimeAfter: self.creationTimeAfter, 
@@ -451,7 +451,7 @@ extension SageMaker.ListMonitoringExecutionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SageMaker.ListMonitoringSchedulesRequest: AWSPaginateStringToken {
+extension SageMaker.ListMonitoringSchedulesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SageMaker.ListMonitoringSchedulesRequest {
         return .init(
             creationTimeAfter: self.creationTimeAfter, 
@@ -470,7 +470,7 @@ extension SageMaker.ListMonitoringSchedulesRequest: AWSPaginateStringToken {
     }
 }
 
-extension SageMaker.ListNotebookInstanceLifecycleConfigsInput: AWSPaginateStringToken {
+extension SageMaker.ListNotebookInstanceLifecycleConfigsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SageMaker.ListNotebookInstanceLifecycleConfigsInput {
         return .init(
             creationTimeAfter: self.creationTimeAfter, 
@@ -487,7 +487,7 @@ extension SageMaker.ListNotebookInstanceLifecycleConfigsInput: AWSPaginateString
     }
 }
 
-extension SageMaker.ListNotebookInstancesInput: AWSPaginateStringToken {
+extension SageMaker.ListNotebookInstancesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SageMaker.ListNotebookInstancesInput {
         return .init(
             additionalCodeRepositoryEquals: self.additionalCodeRepositoryEquals, 
@@ -508,7 +508,7 @@ extension SageMaker.ListNotebookInstancesInput: AWSPaginateStringToken {
     }
 }
 
-extension SageMaker.ListProcessingJobsRequest: AWSPaginateStringToken {
+extension SageMaker.ListProcessingJobsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SageMaker.ListProcessingJobsRequest {
         return .init(
             creationTimeAfter: self.creationTimeAfter, 
@@ -526,7 +526,7 @@ extension SageMaker.ListProcessingJobsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SageMaker.ListSubscribedWorkteamsRequest: AWSPaginateStringToken {
+extension SageMaker.ListSubscribedWorkteamsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SageMaker.ListSubscribedWorkteamsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -537,7 +537,7 @@ extension SageMaker.ListSubscribedWorkteamsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SageMaker.ListTagsInput: AWSPaginateStringToken {
+extension SageMaker.ListTagsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SageMaker.ListTagsInput {
         return .init(
             maxResults: self.maxResults, 
@@ -548,7 +548,7 @@ extension SageMaker.ListTagsInput: AWSPaginateStringToken {
     }
 }
 
-extension SageMaker.ListTrainingJobsRequest: AWSPaginateStringToken {
+extension SageMaker.ListTrainingJobsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SageMaker.ListTrainingJobsRequest {
         return .init(
             creationTimeAfter: self.creationTimeAfter, 
@@ -566,7 +566,7 @@ extension SageMaker.ListTrainingJobsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SageMaker.ListTrainingJobsForHyperParameterTuningJobRequest: AWSPaginateStringToken {
+extension SageMaker.ListTrainingJobsForHyperParameterTuningJobRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SageMaker.ListTrainingJobsForHyperParameterTuningJobRequest {
         return .init(
             hyperParameterTuningJobName: self.hyperParameterTuningJobName, 
@@ -580,7 +580,7 @@ extension SageMaker.ListTrainingJobsForHyperParameterTuningJobRequest: AWSPagina
     }
 }
 
-extension SageMaker.ListTransformJobsRequest: AWSPaginateStringToken {
+extension SageMaker.ListTransformJobsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SageMaker.ListTransformJobsRequest {
         return .init(
             creationTimeAfter: self.creationTimeAfter, 
@@ -598,7 +598,7 @@ extension SageMaker.ListTransformJobsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SageMaker.ListTrialComponentsRequest: AWSPaginateStringToken {
+extension SageMaker.ListTrialComponentsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SageMaker.ListTrialComponentsRequest {
         return .init(
             createdAfter: self.createdAfter, 
@@ -615,7 +615,7 @@ extension SageMaker.ListTrialComponentsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SageMaker.ListTrialsRequest: AWSPaginateStringToken {
+extension SageMaker.ListTrialsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SageMaker.ListTrialsRequest {
         return .init(
             createdAfter: self.createdAfter, 
@@ -631,7 +631,7 @@ extension SageMaker.ListTrialsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SageMaker.ListUserProfilesRequest: AWSPaginateStringToken {
+extension SageMaker.ListUserProfilesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SageMaker.ListUserProfilesRequest {
         return .init(
             domainIdEquals: self.domainIdEquals, 
@@ -645,7 +645,7 @@ extension SageMaker.ListUserProfilesRequest: AWSPaginateStringToken {
     }
 }
 
-extension SageMaker.ListWorkteamsRequest: AWSPaginateStringToken {
+extension SageMaker.ListWorkteamsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SageMaker.ListWorkteamsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -658,7 +658,7 @@ extension SageMaker.ListWorkteamsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SageMaker.SearchRequest: AWSPaginateStringToken {
+extension SageMaker.SearchRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SageMaker.SearchRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/Schemas/Schemas_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Schemas/Schemas_Paginator.swift
@@ -33,7 +33,7 @@ extension Schemas {
 
 }
 
-extension Schemas.ListDiscoverersRequest: AWSPaginateStringToken {
+extension Schemas.ListDiscoverersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Schemas.ListDiscoverersRequest {
         return .init(
             discovererIdPrefix: self.discovererIdPrefix, 
@@ -45,7 +45,7 @@ extension Schemas.ListDiscoverersRequest: AWSPaginateStringToken {
     }
 }
 
-extension Schemas.ListRegistriesRequest: AWSPaginateStringToken {
+extension Schemas.ListRegistriesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Schemas.ListRegistriesRequest {
         return .init(
             limit: self.limit, 
@@ -57,7 +57,7 @@ extension Schemas.ListRegistriesRequest: AWSPaginateStringToken {
     }
 }
 
-extension Schemas.ListSchemaVersionsRequest: AWSPaginateStringToken {
+extension Schemas.ListSchemaVersionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Schemas.ListSchemaVersionsRequest {
         return .init(
             limit: self.limit, 
@@ -69,7 +69,7 @@ extension Schemas.ListSchemaVersionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Schemas.ListSchemasRequest: AWSPaginateStringToken {
+extension Schemas.ListSchemasRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Schemas.ListSchemasRequest {
         return .init(
             limit: self.limit, 
@@ -81,7 +81,7 @@ extension Schemas.ListSchemasRequest: AWSPaginateStringToken {
     }
 }
 
-extension Schemas.SearchSchemasRequest: AWSPaginateStringToken {
+extension Schemas.SearchSchemasRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Schemas.SearchSchemasRequest {
         return .init(
             keywords: self.keywords, 

--- a/Sources/AWSSDKSwift/Services/SecretsManager/SecretsManager_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/SecretsManager/SecretsManager_Paginator.swift
@@ -18,7 +18,7 @@ extension SecretsManager {
 
 }
 
-extension SecretsManager.ListSecretVersionIdsRequest: AWSPaginateStringToken {
+extension SecretsManager.ListSecretVersionIdsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SecretsManager.ListSecretVersionIdsRequest {
         return .init(
             includeDeprecated: self.includeDeprecated, 
@@ -30,7 +30,7 @@ extension SecretsManager.ListSecretVersionIdsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SecretsManager.ListSecretsRequest: AWSPaginateStringToken {
+extension SecretsManager.ListSecretsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SecretsManager.ListSecretsRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/SecurityHub/SecurityHub_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/SecurityHub/SecurityHub_Paginator.swift
@@ -58,7 +58,7 @@ extension SecurityHub {
 
 }
 
-extension SecurityHub.DescribeActionTargetsRequest: AWSPaginateStringToken {
+extension SecurityHub.DescribeActionTargetsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SecurityHub.DescribeActionTargetsRequest {
         return .init(
             actionTargetArns: self.actionTargetArns, 
@@ -69,7 +69,7 @@ extension SecurityHub.DescribeActionTargetsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SecurityHub.DescribeProductsRequest: AWSPaginateStringToken {
+extension SecurityHub.DescribeProductsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SecurityHub.DescribeProductsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -79,7 +79,7 @@ extension SecurityHub.DescribeProductsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SecurityHub.DescribeStandardsRequest: AWSPaginateStringToken {
+extension SecurityHub.DescribeStandardsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SecurityHub.DescribeStandardsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -89,7 +89,7 @@ extension SecurityHub.DescribeStandardsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SecurityHub.DescribeStandardsControlsRequest: AWSPaginateStringToken {
+extension SecurityHub.DescribeStandardsControlsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SecurityHub.DescribeStandardsControlsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -100,7 +100,7 @@ extension SecurityHub.DescribeStandardsControlsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SecurityHub.GetEnabledStandardsRequest: AWSPaginateStringToken {
+extension SecurityHub.GetEnabledStandardsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SecurityHub.GetEnabledStandardsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -111,7 +111,7 @@ extension SecurityHub.GetEnabledStandardsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SecurityHub.GetFindingsRequest: AWSPaginateStringToken {
+extension SecurityHub.GetFindingsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SecurityHub.GetFindingsRequest {
         return .init(
             filters: self.filters, 
@@ -123,7 +123,7 @@ extension SecurityHub.GetFindingsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SecurityHub.GetInsightsRequest: AWSPaginateStringToken {
+extension SecurityHub.GetInsightsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SecurityHub.GetInsightsRequest {
         return .init(
             insightArns: self.insightArns, 
@@ -134,7 +134,7 @@ extension SecurityHub.GetInsightsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SecurityHub.ListEnabledProductsForImportRequest: AWSPaginateStringToken {
+extension SecurityHub.ListEnabledProductsForImportRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SecurityHub.ListEnabledProductsForImportRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -144,7 +144,7 @@ extension SecurityHub.ListEnabledProductsForImportRequest: AWSPaginateStringToke
     }
 }
 
-extension SecurityHub.ListInvitationsRequest: AWSPaginateStringToken {
+extension SecurityHub.ListInvitationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SecurityHub.ListInvitationsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -154,7 +154,7 @@ extension SecurityHub.ListInvitationsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SecurityHub.ListMembersRequest: AWSPaginateStringToken {
+extension SecurityHub.ListMembersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SecurityHub.ListMembersRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/ServerlessApplicationRepository/ServerlessApplicationRepository_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/ServerlessApplicationRepository/ServerlessApplicationRepository_Paginator.swift
@@ -23,7 +23,7 @@ extension ServerlessApplicationRepository {
 
 }
 
-extension ServerlessApplicationRepository.ListApplicationDependenciesRequest: AWSPaginateStringToken {
+extension ServerlessApplicationRepository.ListApplicationDependenciesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ServerlessApplicationRepository.ListApplicationDependenciesRequest {
         return .init(
             applicationId: self.applicationId, 
@@ -35,7 +35,7 @@ extension ServerlessApplicationRepository.ListApplicationDependenciesRequest: AW
     }
 }
 
-extension ServerlessApplicationRepository.ListApplicationVersionsRequest: AWSPaginateStringToken {
+extension ServerlessApplicationRepository.ListApplicationVersionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ServerlessApplicationRepository.ListApplicationVersionsRequest {
         return .init(
             applicationId: self.applicationId, 
@@ -46,7 +46,7 @@ extension ServerlessApplicationRepository.ListApplicationVersionsRequest: AWSPag
     }
 }
 
-extension ServerlessApplicationRepository.ListApplicationsRequest: AWSPaginateStringToken {
+extension ServerlessApplicationRepository.ListApplicationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ServerlessApplicationRepository.ListApplicationsRequest {
         return .init(
             maxItems: self.maxItems, 

--- a/Sources/AWSSDKSwift/Services/ServiceCatalog/ServiceCatalog_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/ServiceCatalog/ServiceCatalog_Paginator.swift
@@ -93,7 +93,7 @@ extension ServiceCatalog {
 
 }
 
-extension ServiceCatalog.ListAcceptedPortfolioSharesInput: AWSPaginateStringToken {
+extension ServiceCatalog.ListAcceptedPortfolioSharesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ServiceCatalog.ListAcceptedPortfolioSharesInput {
         return .init(
             acceptLanguage: self.acceptLanguage, 
@@ -105,7 +105,7 @@ extension ServiceCatalog.ListAcceptedPortfolioSharesInput: AWSPaginateStringToke
     }
 }
 
-extension ServiceCatalog.ListBudgetsForResourceInput: AWSPaginateStringToken {
+extension ServiceCatalog.ListBudgetsForResourceInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ServiceCatalog.ListBudgetsForResourceInput {
         return .init(
             acceptLanguage: self.acceptLanguage, 
@@ -117,7 +117,7 @@ extension ServiceCatalog.ListBudgetsForResourceInput: AWSPaginateStringToken {
     }
 }
 
-extension ServiceCatalog.ListConstraintsForPortfolioInput: AWSPaginateStringToken {
+extension ServiceCatalog.ListConstraintsForPortfolioInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ServiceCatalog.ListConstraintsForPortfolioInput {
         return .init(
             acceptLanguage: self.acceptLanguage, 
@@ -130,7 +130,7 @@ extension ServiceCatalog.ListConstraintsForPortfolioInput: AWSPaginateStringToke
     }
 }
 
-extension ServiceCatalog.ListLaunchPathsInput: AWSPaginateStringToken {
+extension ServiceCatalog.ListLaunchPathsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ServiceCatalog.ListLaunchPathsInput {
         return .init(
             acceptLanguage: self.acceptLanguage, 
@@ -142,7 +142,7 @@ extension ServiceCatalog.ListLaunchPathsInput: AWSPaginateStringToken {
     }
 }
 
-extension ServiceCatalog.ListOrganizationPortfolioAccessInput: AWSPaginateStringToken {
+extension ServiceCatalog.ListOrganizationPortfolioAccessInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ServiceCatalog.ListOrganizationPortfolioAccessInput {
         return .init(
             acceptLanguage: self.acceptLanguage, 
@@ -155,7 +155,7 @@ extension ServiceCatalog.ListOrganizationPortfolioAccessInput: AWSPaginateString
     }
 }
 
-extension ServiceCatalog.ListPortfolioAccessInput: AWSPaginateStringToken {
+extension ServiceCatalog.ListPortfolioAccessInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ServiceCatalog.ListPortfolioAccessInput {
         return .init(
             acceptLanguage: self.acceptLanguage, 
@@ -168,7 +168,7 @@ extension ServiceCatalog.ListPortfolioAccessInput: AWSPaginateStringToken {
     }
 }
 
-extension ServiceCatalog.ListPortfoliosInput: AWSPaginateStringToken {
+extension ServiceCatalog.ListPortfoliosInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ServiceCatalog.ListPortfoliosInput {
         return .init(
             acceptLanguage: self.acceptLanguage, 
@@ -179,7 +179,7 @@ extension ServiceCatalog.ListPortfoliosInput: AWSPaginateStringToken {
     }
 }
 
-extension ServiceCatalog.ListPortfoliosForProductInput: AWSPaginateStringToken {
+extension ServiceCatalog.ListPortfoliosForProductInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ServiceCatalog.ListPortfoliosForProductInput {
         return .init(
             acceptLanguage: self.acceptLanguage, 
@@ -191,7 +191,7 @@ extension ServiceCatalog.ListPortfoliosForProductInput: AWSPaginateStringToken {
     }
 }
 
-extension ServiceCatalog.ListPrincipalsForPortfolioInput: AWSPaginateStringToken {
+extension ServiceCatalog.ListPrincipalsForPortfolioInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ServiceCatalog.ListPrincipalsForPortfolioInput {
         return .init(
             acceptLanguage: self.acceptLanguage, 
@@ -203,7 +203,7 @@ extension ServiceCatalog.ListPrincipalsForPortfolioInput: AWSPaginateStringToken
     }
 }
 
-extension ServiceCatalog.ListProvisioningArtifactsForServiceActionInput: AWSPaginateStringToken {
+extension ServiceCatalog.ListProvisioningArtifactsForServiceActionInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ServiceCatalog.ListProvisioningArtifactsForServiceActionInput {
         return .init(
             acceptLanguage: self.acceptLanguage, 
@@ -215,7 +215,7 @@ extension ServiceCatalog.ListProvisioningArtifactsForServiceActionInput: AWSPagi
     }
 }
 
-extension ServiceCatalog.ListResourcesForTagOptionInput: AWSPaginateStringToken {
+extension ServiceCatalog.ListResourcesForTagOptionInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ServiceCatalog.ListResourcesForTagOptionInput {
         return .init(
             pageSize: self.pageSize, 
@@ -227,7 +227,7 @@ extension ServiceCatalog.ListResourcesForTagOptionInput: AWSPaginateStringToken 
     }
 }
 
-extension ServiceCatalog.ListServiceActionsInput: AWSPaginateStringToken {
+extension ServiceCatalog.ListServiceActionsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ServiceCatalog.ListServiceActionsInput {
         return .init(
             acceptLanguage: self.acceptLanguage, 
@@ -238,7 +238,7 @@ extension ServiceCatalog.ListServiceActionsInput: AWSPaginateStringToken {
     }
 }
 
-extension ServiceCatalog.ListServiceActionsForProvisioningArtifactInput: AWSPaginateStringToken {
+extension ServiceCatalog.ListServiceActionsForProvisioningArtifactInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ServiceCatalog.ListServiceActionsForProvisioningArtifactInput {
         return .init(
             acceptLanguage: self.acceptLanguage, 
@@ -251,7 +251,7 @@ extension ServiceCatalog.ListServiceActionsForProvisioningArtifactInput: AWSPagi
     }
 }
 
-extension ServiceCatalog.ListTagOptionsInput: AWSPaginateStringToken {
+extension ServiceCatalog.ListTagOptionsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ServiceCatalog.ListTagOptionsInput {
         return .init(
             filters: self.filters, 
@@ -262,7 +262,7 @@ extension ServiceCatalog.ListTagOptionsInput: AWSPaginateStringToken {
     }
 }
 
-extension ServiceCatalog.SearchProductsInput: AWSPaginateStringToken {
+extension ServiceCatalog.SearchProductsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ServiceCatalog.SearchProductsInput {
         return .init(
             acceptLanguage: self.acceptLanguage, 
@@ -276,7 +276,7 @@ extension ServiceCatalog.SearchProductsInput: AWSPaginateStringToken {
     }
 }
 
-extension ServiceCatalog.SearchProductsAsAdminInput: AWSPaginateStringToken {
+extension ServiceCatalog.SearchProductsAsAdminInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ServiceCatalog.SearchProductsAsAdminInput {
         return .init(
             acceptLanguage: self.acceptLanguage, 
@@ -292,7 +292,7 @@ extension ServiceCatalog.SearchProductsAsAdminInput: AWSPaginateStringToken {
     }
 }
 
-extension ServiceCatalog.SearchProvisionedProductsInput: AWSPaginateStringToken {
+extension ServiceCatalog.SearchProvisionedProductsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ServiceCatalog.SearchProvisionedProductsInput {
         return .init(
             acceptLanguage: self.acceptLanguage, 

--- a/Sources/AWSSDKSwift/Services/ServiceDiscovery/ServiceDiscovery_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/ServiceDiscovery/ServiceDiscovery_Paginator.swift
@@ -33,7 +33,7 @@ extension ServiceDiscovery {
 
 }
 
-extension ServiceDiscovery.GetInstancesHealthStatusRequest: AWSPaginateStringToken {
+extension ServiceDiscovery.GetInstancesHealthStatusRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ServiceDiscovery.GetInstancesHealthStatusRequest {
         return .init(
             instances: self.instances, 
@@ -45,7 +45,7 @@ extension ServiceDiscovery.GetInstancesHealthStatusRequest: AWSPaginateStringTok
     }
 }
 
-extension ServiceDiscovery.ListInstancesRequest: AWSPaginateStringToken {
+extension ServiceDiscovery.ListInstancesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ServiceDiscovery.ListInstancesRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -56,7 +56,7 @@ extension ServiceDiscovery.ListInstancesRequest: AWSPaginateStringToken {
     }
 }
 
-extension ServiceDiscovery.ListNamespacesRequest: AWSPaginateStringToken {
+extension ServiceDiscovery.ListNamespacesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ServiceDiscovery.ListNamespacesRequest {
         return .init(
             filters: self.filters, 
@@ -67,7 +67,7 @@ extension ServiceDiscovery.ListNamespacesRequest: AWSPaginateStringToken {
     }
 }
 
-extension ServiceDiscovery.ListOperationsRequest: AWSPaginateStringToken {
+extension ServiceDiscovery.ListOperationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ServiceDiscovery.ListOperationsRequest {
         return .init(
             filters: self.filters, 
@@ -78,7 +78,7 @@ extension ServiceDiscovery.ListOperationsRequest: AWSPaginateStringToken {
     }
 }
 
-extension ServiceDiscovery.ListServicesRequest: AWSPaginateStringToken {
+extension ServiceDiscovery.ListServicesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ServiceDiscovery.ListServicesRequest {
         return .init(
             filters: self.filters, 

--- a/Sources/AWSSDKSwift/Services/ServiceQuotas/ServiceQuotas_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/ServiceQuotas/ServiceQuotas_Paginator.swift
@@ -38,7 +38,7 @@ extension ServiceQuotas {
 
 }
 
-extension ServiceQuotas.ListAWSDefaultServiceQuotasRequest: AWSPaginateStringToken {
+extension ServiceQuotas.ListAWSDefaultServiceQuotasRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ServiceQuotas.ListAWSDefaultServiceQuotasRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -49,7 +49,7 @@ extension ServiceQuotas.ListAWSDefaultServiceQuotasRequest: AWSPaginateStringTok
     }
 }
 
-extension ServiceQuotas.ListRequestedServiceQuotaChangeHistoryRequest: AWSPaginateStringToken {
+extension ServiceQuotas.ListRequestedServiceQuotaChangeHistoryRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ServiceQuotas.ListRequestedServiceQuotaChangeHistoryRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -61,7 +61,7 @@ extension ServiceQuotas.ListRequestedServiceQuotaChangeHistoryRequest: AWSPagina
     }
 }
 
-extension ServiceQuotas.ListRequestedServiceQuotaChangeHistoryByQuotaRequest: AWSPaginateStringToken {
+extension ServiceQuotas.ListRequestedServiceQuotaChangeHistoryByQuotaRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ServiceQuotas.ListRequestedServiceQuotaChangeHistoryByQuotaRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -74,7 +74,7 @@ extension ServiceQuotas.ListRequestedServiceQuotaChangeHistoryByQuotaRequest: AW
     }
 }
 
-extension ServiceQuotas.ListServiceQuotaIncreaseRequestsInTemplateRequest: AWSPaginateStringToken {
+extension ServiceQuotas.ListServiceQuotaIncreaseRequestsInTemplateRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ServiceQuotas.ListServiceQuotaIncreaseRequestsInTemplateRequest {
         return .init(
             awsRegion: self.awsRegion, 
@@ -86,7 +86,7 @@ extension ServiceQuotas.ListServiceQuotaIncreaseRequestsInTemplateRequest: AWSPa
     }
 }
 
-extension ServiceQuotas.ListServiceQuotasRequest: AWSPaginateStringToken {
+extension ServiceQuotas.ListServiceQuotasRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ServiceQuotas.ListServiceQuotasRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -97,7 +97,7 @@ extension ServiceQuotas.ListServiceQuotasRequest: AWSPaginateStringToken {
     }
 }
 
-extension ServiceQuotas.ListServicesRequest: AWSPaginateStringToken {
+extension ServiceQuotas.ListServicesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> ServiceQuotas.ListServicesRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/Signer/Signer_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Signer/Signer_Paginator.swift
@@ -23,7 +23,7 @@ extension Signer {
 
 }
 
-extension Signer.ListSigningJobsRequest: AWSPaginateStringToken {
+extension Signer.ListSigningJobsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Signer.ListSigningJobsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -36,7 +36,7 @@ extension Signer.ListSigningJobsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Signer.ListSigningPlatformsRequest: AWSPaginateStringToken {
+extension Signer.ListSigningPlatformsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Signer.ListSigningPlatformsRequest {
         return .init(
             category: self.category, 
@@ -49,7 +49,7 @@ extension Signer.ListSigningPlatformsRequest: AWSPaginateStringToken {
     }
 }
 
-extension Signer.ListSigningProfilesRequest: AWSPaginateStringToken {
+extension Signer.ListSigningProfilesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Signer.ListSigningProfilesRequest {
         return .init(
             includeCanceled: self.includeCanceled, 

--- a/Sources/AWSSDKSwift/Services/SimpleDB/SimpleDB_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/SimpleDB/SimpleDB_Paginator.swift
@@ -18,7 +18,7 @@ extension SimpleDB {
 
 }
 
-extension SimpleDB.ListDomainsRequest: AWSPaginateStringToken {
+extension SimpleDB.ListDomainsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SimpleDB.ListDomainsRequest {
         return .init(
             maxNumberOfDomains: self.maxNumberOfDomains, 
@@ -28,7 +28,7 @@ extension SimpleDB.ListDomainsRequest: AWSPaginateStringToken {
     }
 }
 
-extension SimpleDB.SelectRequest: AWSPaginateStringToken {
+extension SimpleDB.SelectRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> SimpleDB.SelectRequest {
         return .init(
             consistentRead: self.consistentRead, 

--- a/Sources/AWSSDKSwift/Services/Snowball/Snowball_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Snowball/Snowball_Paginator.swift
@@ -18,7 +18,7 @@ extension Snowball {
 
 }
 
-extension Snowball.DescribeAddressesRequest: AWSPaginateStringToken {
+extension Snowball.DescribeAddressesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Snowball.DescribeAddressesRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -28,7 +28,7 @@ extension Snowball.DescribeAddressesRequest: AWSPaginateStringToken {
     }
 }
 
-extension Snowball.ListJobsRequest: AWSPaginateStringToken {
+extension Snowball.ListJobsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Snowball.ListJobsRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/StorageGateway/StorageGateway_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/StorageGateway/StorageGateway_Paginator.swift
@@ -53,7 +53,7 @@ extension StorageGateway {
 
 }
 
-extension StorageGateway.DescribeTapeArchivesInput: AWSPaginateStringToken {
+extension StorageGateway.DescribeTapeArchivesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> StorageGateway.DescribeTapeArchivesInput {
         return .init(
             limit: self.limit, 
@@ -64,7 +64,7 @@ extension StorageGateway.DescribeTapeArchivesInput: AWSPaginateStringToken {
     }
 }
 
-extension StorageGateway.DescribeTapeRecoveryPointsInput: AWSPaginateStringToken {
+extension StorageGateway.DescribeTapeRecoveryPointsInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> StorageGateway.DescribeTapeRecoveryPointsInput {
         return .init(
             gatewayARN: self.gatewayARN, 
@@ -75,7 +75,7 @@ extension StorageGateway.DescribeTapeRecoveryPointsInput: AWSPaginateStringToken
     }
 }
 
-extension StorageGateway.DescribeTapesInput: AWSPaginateStringToken {
+extension StorageGateway.DescribeTapesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> StorageGateway.DescribeTapesInput {
         return .init(
             gatewayARN: self.gatewayARN, 
@@ -87,7 +87,7 @@ extension StorageGateway.DescribeTapesInput: AWSPaginateStringToken {
     }
 }
 
-extension StorageGateway.DescribeVTLDevicesInput: AWSPaginateStringToken {
+extension StorageGateway.DescribeVTLDevicesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> StorageGateway.DescribeVTLDevicesInput {
         return .init(
             gatewayARN: self.gatewayARN, 
@@ -99,7 +99,7 @@ extension StorageGateway.DescribeVTLDevicesInput: AWSPaginateStringToken {
     }
 }
 
-extension StorageGateway.ListFileSharesInput: AWSPaginateStringToken {
+extension StorageGateway.ListFileSharesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> StorageGateway.ListFileSharesInput {
         return .init(
             gatewayARN: self.gatewayARN, 
@@ -110,7 +110,7 @@ extension StorageGateway.ListFileSharesInput: AWSPaginateStringToken {
     }
 }
 
-extension StorageGateway.ListGatewaysInput: AWSPaginateStringToken {
+extension StorageGateway.ListGatewaysInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> StorageGateway.ListGatewaysInput {
         return .init(
             limit: self.limit, 
@@ -120,7 +120,7 @@ extension StorageGateway.ListGatewaysInput: AWSPaginateStringToken {
     }
 }
 
-extension StorageGateway.ListTagsForResourceInput: AWSPaginateStringToken {
+extension StorageGateway.ListTagsForResourceInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> StorageGateway.ListTagsForResourceInput {
         return .init(
             limit: self.limit, 
@@ -131,7 +131,7 @@ extension StorageGateway.ListTagsForResourceInput: AWSPaginateStringToken {
     }
 }
 
-extension StorageGateway.ListTapesInput: AWSPaginateStringToken {
+extension StorageGateway.ListTapesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> StorageGateway.ListTapesInput {
         return .init(
             limit: self.limit, 
@@ -142,7 +142,7 @@ extension StorageGateway.ListTapesInput: AWSPaginateStringToken {
     }
 }
 
-extension StorageGateway.ListVolumesInput: AWSPaginateStringToken {
+extension StorageGateway.ListVolumesInput: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> StorageGateway.ListVolumesInput {
         return .init(
             gatewayARN: self.gatewayARN, 

--- a/Sources/AWSSDKSwift/Services/Support/Support_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Support/Support_Paginator.swift
@@ -18,7 +18,7 @@ extension Support {
 
 }
 
-extension Support.DescribeCasesRequest: AWSPaginateStringToken {
+extension Support.DescribeCasesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Support.DescribeCasesRequest {
         return .init(
             afterTime: self.afterTime, 
@@ -35,7 +35,7 @@ extension Support.DescribeCasesRequest: AWSPaginateStringToken {
     }
 }
 
-extension Support.DescribeCommunicationsRequest: AWSPaginateStringToken {
+extension Support.DescribeCommunicationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Support.DescribeCommunicationsRequest {
         return .init(
             afterTime: self.afterTime, 

--- a/Sources/AWSSDKSwift/Services/TranscribeService/TranscribeService_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/TranscribeService/TranscribeService_Paginator.swift
@@ -23,7 +23,7 @@ extension TranscribeService {
 
 }
 
-extension TranscribeService.ListTranscriptionJobsRequest: AWSPaginateStringToken {
+extension TranscribeService.ListTranscriptionJobsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> TranscribeService.ListTranscriptionJobsRequest {
         return .init(
             jobNameContains: self.jobNameContains, 
@@ -35,7 +35,7 @@ extension TranscribeService.ListTranscriptionJobsRequest: AWSPaginateStringToken
     }
 }
 
-extension TranscribeService.ListVocabulariesRequest: AWSPaginateStringToken {
+extension TranscribeService.ListVocabulariesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> TranscribeService.ListVocabulariesRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -47,7 +47,7 @@ extension TranscribeService.ListVocabulariesRequest: AWSPaginateStringToken {
     }
 }
 
-extension TranscribeService.ListVocabularyFiltersRequest: AWSPaginateStringToken {
+extension TranscribeService.ListVocabularyFiltersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> TranscribeService.ListVocabularyFiltersRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/Transfer/Transfer_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Transfer/Transfer_Paginator.swift
@@ -23,7 +23,7 @@ extension Transfer {
 
 }
 
-extension Transfer.ListServersRequest: AWSPaginateStringToken {
+extension Transfer.ListServersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Transfer.ListServersRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -33,7 +33,7 @@ extension Transfer.ListServersRequest: AWSPaginateStringToken {
     }
 }
 
-extension Transfer.ListTagsForResourceRequest: AWSPaginateStringToken {
+extension Transfer.ListTagsForResourceRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Transfer.ListTagsForResourceRequest {
         return .init(
             arn: self.arn, 
@@ -44,7 +44,7 @@ extension Transfer.ListTagsForResourceRequest: AWSPaginateStringToken {
     }
 }
 
-extension Transfer.ListUsersRequest: AWSPaginateStringToken {
+extension Transfer.ListUsersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Transfer.ListUsersRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/Translate/Translate_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/Translate/Translate_Paginator.swift
@@ -18,7 +18,7 @@ extension Translate {
 
 }
 
-extension Translate.ListTerminologiesRequest: AWSPaginateStringToken {
+extension Translate.ListTerminologiesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Translate.ListTerminologiesRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -28,7 +28,7 @@ extension Translate.ListTerminologiesRequest: AWSPaginateStringToken {
     }
 }
 
-extension Translate.ListTextTranslationJobsRequest: AWSPaginateStringToken {
+extension Translate.ListTextTranslationJobsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> Translate.ListTextTranslationJobsRequest {
         return .init(
             filter: self.filter, 

--- a/Sources/AWSSDKSwift/Services/WorkDocs/WorkDocs_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/WorkDocs/WorkDocs_Paginator.swift
@@ -23,7 +23,7 @@ extension WorkDocs {
 
 }
 
-extension WorkDocs.DescribeDocumentVersionsRequest: AWSPaginateStringToken {
+extension WorkDocs.DescribeDocumentVersionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> WorkDocs.DescribeDocumentVersionsRequest {
         return .init(
             authenticationToken: self.authenticationToken, 
@@ -37,7 +37,7 @@ extension WorkDocs.DescribeDocumentVersionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension WorkDocs.DescribeFolderContentsRequest: AWSPaginateStringToken {
+extension WorkDocs.DescribeFolderContentsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> WorkDocs.DescribeFolderContentsRequest {
         return .init(
             authenticationToken: self.authenticationToken, 
@@ -53,7 +53,7 @@ extension WorkDocs.DescribeFolderContentsRequest: AWSPaginateStringToken {
     }
 }
 
-extension WorkDocs.DescribeUsersRequest: AWSPaginateStringToken {
+extension WorkDocs.DescribeUsersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> WorkDocs.DescribeUsersRequest {
         return .init(
             authenticationToken: self.authenticationToken, 

--- a/Sources/AWSSDKSwift/Services/WorkLink/WorkLink_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/WorkLink/WorkLink_Paginator.swift
@@ -33,7 +33,7 @@ extension WorkLink {
 
 }
 
-extension WorkLink.ListDevicesRequest: AWSPaginateStringToken {
+extension WorkLink.ListDevicesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> WorkLink.ListDevicesRequest {
         return .init(
             fleetArn: self.fleetArn, 
@@ -44,7 +44,7 @@ extension WorkLink.ListDevicesRequest: AWSPaginateStringToken {
     }
 }
 
-extension WorkLink.ListDomainsRequest: AWSPaginateStringToken {
+extension WorkLink.ListDomainsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> WorkLink.ListDomainsRequest {
         return .init(
             fleetArn: self.fleetArn, 
@@ -55,7 +55,7 @@ extension WorkLink.ListDomainsRequest: AWSPaginateStringToken {
     }
 }
 
-extension WorkLink.ListFleetsRequest: AWSPaginateStringToken {
+extension WorkLink.ListFleetsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> WorkLink.ListFleetsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -65,7 +65,7 @@ extension WorkLink.ListFleetsRequest: AWSPaginateStringToken {
     }
 }
 
-extension WorkLink.ListWebsiteAuthorizationProvidersRequest: AWSPaginateStringToken {
+extension WorkLink.ListWebsiteAuthorizationProvidersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> WorkLink.ListWebsiteAuthorizationProvidersRequest {
         return .init(
             fleetArn: self.fleetArn, 
@@ -76,7 +76,7 @@ extension WorkLink.ListWebsiteAuthorizationProvidersRequest: AWSPaginateStringTo
     }
 }
 
-extension WorkLink.ListWebsiteCertificateAuthoritiesRequest: AWSPaginateStringToken {
+extension WorkLink.ListWebsiteCertificateAuthoritiesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> WorkLink.ListWebsiteCertificateAuthoritiesRequest {
         return .init(
             fleetArn: self.fleetArn, 

--- a/Sources/AWSSDKSwift/Services/WorkMail/WorkMail_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/WorkMail/WorkMail_Paginator.swift
@@ -48,7 +48,7 @@ extension WorkMail {
 
 }
 
-extension WorkMail.ListAliasesRequest: AWSPaginateStringToken {
+extension WorkMail.ListAliasesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> WorkMail.ListAliasesRequest {
         return .init(
             entityId: self.entityId, 
@@ -60,7 +60,7 @@ extension WorkMail.ListAliasesRequest: AWSPaginateStringToken {
     }
 }
 
-extension WorkMail.ListGroupMembersRequest: AWSPaginateStringToken {
+extension WorkMail.ListGroupMembersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> WorkMail.ListGroupMembersRequest {
         return .init(
             groupId: self.groupId, 
@@ -72,7 +72,7 @@ extension WorkMail.ListGroupMembersRequest: AWSPaginateStringToken {
     }
 }
 
-extension WorkMail.ListGroupsRequest: AWSPaginateStringToken {
+extension WorkMail.ListGroupsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> WorkMail.ListGroupsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -83,7 +83,7 @@ extension WorkMail.ListGroupsRequest: AWSPaginateStringToken {
     }
 }
 
-extension WorkMail.ListMailboxPermissionsRequest: AWSPaginateStringToken {
+extension WorkMail.ListMailboxPermissionsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> WorkMail.ListMailboxPermissionsRequest {
         return .init(
             entityId: self.entityId, 
@@ -95,7 +95,7 @@ extension WorkMail.ListMailboxPermissionsRequest: AWSPaginateStringToken {
     }
 }
 
-extension WorkMail.ListOrganizationsRequest: AWSPaginateStringToken {
+extension WorkMail.ListOrganizationsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> WorkMail.ListOrganizationsRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -105,7 +105,7 @@ extension WorkMail.ListOrganizationsRequest: AWSPaginateStringToken {
     }
 }
 
-extension WorkMail.ListResourceDelegatesRequest: AWSPaginateStringToken {
+extension WorkMail.ListResourceDelegatesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> WorkMail.ListResourceDelegatesRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -117,7 +117,7 @@ extension WorkMail.ListResourceDelegatesRequest: AWSPaginateStringToken {
     }
 }
 
-extension WorkMail.ListResourcesRequest: AWSPaginateStringToken {
+extension WorkMail.ListResourcesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> WorkMail.ListResourcesRequest {
         return .init(
             maxResults: self.maxResults, 
@@ -128,7 +128,7 @@ extension WorkMail.ListResourcesRequest: AWSPaginateStringToken {
     }
 }
 
-extension WorkMail.ListUsersRequest: AWSPaginateStringToken {
+extension WorkMail.ListUsersRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> WorkMail.ListUsersRequest {
         return .init(
             maxResults: self.maxResults, 

--- a/Sources/AWSSDKSwift/Services/WorkSpaces/WorkSpaces_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/WorkSpaces/WorkSpaces_Paginator.swift
@@ -23,7 +23,7 @@ extension WorkSpaces {
 
 }
 
-extension WorkSpaces.DescribeWorkspaceBundlesRequest: AWSPaginateStringToken {
+extension WorkSpaces.DescribeWorkspaceBundlesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> WorkSpaces.DescribeWorkspaceBundlesRequest {
         return .init(
             bundleIds: self.bundleIds, 
@@ -34,7 +34,7 @@ extension WorkSpaces.DescribeWorkspaceBundlesRequest: AWSPaginateStringToken {
     }
 }
 
-extension WorkSpaces.DescribeWorkspaceDirectoriesRequest: AWSPaginateStringToken {
+extension WorkSpaces.DescribeWorkspaceDirectoriesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> WorkSpaces.DescribeWorkspaceDirectoriesRequest {
         return .init(
             directoryIds: self.directoryIds, 
@@ -45,7 +45,7 @@ extension WorkSpaces.DescribeWorkspaceDirectoriesRequest: AWSPaginateStringToken
     }
 }
 
-extension WorkSpaces.DescribeWorkspacesRequest: AWSPaginateStringToken {
+extension WorkSpaces.DescribeWorkspacesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> WorkSpaces.DescribeWorkspacesRequest {
         return .init(
             bundleId: self.bundleId, 

--- a/Sources/AWSSDKSwift/Services/XRay/XRay_Paginator.swift
+++ b/Sources/AWSSDKSwift/Services/XRay/XRay_Paginator.swift
@@ -48,7 +48,7 @@ extension XRay {
 
 }
 
-extension XRay.BatchGetTracesRequest: AWSPaginateStringToken {
+extension XRay.BatchGetTracesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> XRay.BatchGetTracesRequest {
         return .init(
             nextToken: token, 
@@ -58,7 +58,7 @@ extension XRay.BatchGetTracesRequest: AWSPaginateStringToken {
     }
 }
 
-extension XRay.GetGroupsRequest: AWSPaginateStringToken {
+extension XRay.GetGroupsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> XRay.GetGroupsRequest {
         return .init(
             nextToken: token
@@ -67,7 +67,7 @@ extension XRay.GetGroupsRequest: AWSPaginateStringToken {
     }
 }
 
-extension XRay.GetSamplingRulesRequest: AWSPaginateStringToken {
+extension XRay.GetSamplingRulesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> XRay.GetSamplingRulesRequest {
         return .init(
             nextToken: token
@@ -76,7 +76,7 @@ extension XRay.GetSamplingRulesRequest: AWSPaginateStringToken {
     }
 }
 
-extension XRay.GetSamplingStatisticSummariesRequest: AWSPaginateStringToken {
+extension XRay.GetSamplingStatisticSummariesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> XRay.GetSamplingStatisticSummariesRequest {
         return .init(
             nextToken: token
@@ -85,7 +85,7 @@ extension XRay.GetSamplingStatisticSummariesRequest: AWSPaginateStringToken {
     }
 }
 
-extension XRay.GetServiceGraphRequest: AWSPaginateStringToken {
+extension XRay.GetServiceGraphRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> XRay.GetServiceGraphRequest {
         return .init(
             endTime: self.endTime, 
@@ -98,7 +98,7 @@ extension XRay.GetServiceGraphRequest: AWSPaginateStringToken {
     }
 }
 
-extension XRay.GetTimeSeriesServiceStatisticsRequest: AWSPaginateStringToken {
+extension XRay.GetTimeSeriesServiceStatisticsRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> XRay.GetTimeSeriesServiceStatisticsRequest {
         return .init(
             endTime: self.endTime, 
@@ -113,7 +113,7 @@ extension XRay.GetTimeSeriesServiceStatisticsRequest: AWSPaginateStringToken {
     }
 }
 
-extension XRay.GetTraceGraphRequest: AWSPaginateStringToken {
+extension XRay.GetTraceGraphRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> XRay.GetTraceGraphRequest {
         return .init(
             nextToken: token, 
@@ -123,7 +123,7 @@ extension XRay.GetTraceGraphRequest: AWSPaginateStringToken {
     }
 }
 
-extension XRay.GetTraceSummariesRequest: AWSPaginateStringToken {
+extension XRay.GetTraceSummariesRequest: AWSPaginateToken {
     public func usingPaginationToken(_ token: String) -> XRay.GetTraceSummariesRequest {
         return .init(
             endTime: self.endTime, 


### PR DESCRIPTION
Associated PR in aws-sdk-swift-core is https://github.com/swift-aws/aws-sdk-swift-core/pull/231

Replace `AWSPaginateStringToken` and `AWSPaginateIntToken` with `AWSPaginateToken` which has an associated type `Token`. This allows us to generalize all the paginate code and allow for tokens that are not strings or integers. Also allows us to enable pagination for the few operations in DynamoDB that used Dictionaries as tokens.