### PR TITLE
Remove region parameter from services that don't require a region

### DIFF
--- a/CodeGenerator/Sources/CodeGenerator/AWSService.swift
+++ b/CodeGenerator/Sources/CodeGenerator/AWSService.swift
@@ -232,6 +232,19 @@ extension AWSService {
             context["errorTypes"] = serviceErrorName
         }
 
+        // service is considered regionalized if any of its service definitions across all partitions say it is.
+        // if no service details are found in the endpoints then it is assumed the service is regionalized
+        let isRegionalized: Bool? = self.endpoints.partitions.reduce(nil) {
+            var isRegionalized = false
+            if let service = $1.services[api.metadata.endpointPrefix] {
+                isRegionalized = service.isRegionalized ?? true
+            } else {
+                return $0
+            }
+            return ($0 ?? false) || isRegionalized
+        } ?? true
+        context["regionalized"] = isRegionalized
+        
         // Operations
         var operationContexts: [OperationContext] = []
         for operation in api.operations {

--- a/CodeGenerator/Templates/api.stencil
+++ b/CodeGenerator/Templates/api.stencil
@@ -28,7 +28,9 @@ public struct {{ name }} {
     ///     - accessKeyId: Public access key provided by AWS
     ///     - secretAccessKey: Private access key provided by AWS
     ///     - sessionToken: Token provided by STS.AssumeRole() which allows access to another AWS account
+{% if regionalized %}
     ///     - region: Region of server you want to communicate with
+{% endif %}
     ///     - endpoint: Custom endpoint URL to use instead of standard AWS servers
     ///     - middlewares: Array of middlewares to apply to requests and responses
     ///     - httpClientProvider: HTTPClient to use. Use `createNew` if the client should manage its own HTTPClient.
@@ -36,7 +38,9 @@ public struct {{ name }} {
         accessKeyId: String? = nil,
         secretAccessKey: String? = nil,
         sessionToken: String? = nil,
+{% if regionalized %}
         region: AWSSDKSwiftCore.Region? = nil,
+{% endif %}
         endpoint: String? = nil,
         middlewares: [AWSServiceMiddleware] = [],
         httpClientProvider: AWSClient.HTTPClientProvider = .createNew
@@ -48,7 +52,11 @@ public struct {{ name }} {
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
             sessionToken: sessionToken,
+{% if regionalized %}
             region: region,
+{% else %}
+            region: nil,
+{% endif %}
 {% if amzTarget %}
             amzTarget: "{{amzTarget}}",
 {% endif %}

--- a/Sources/AWSSDKSwift/Services/Budgets/Budgets_API.swift
+++ b/Sources/AWSSDKSwift/Services/Budgets/Budgets_API.swift
@@ -36,7 +36,6 @@ public struct Budgets {
     ///     - accessKeyId: Public access key provided by AWS
     ///     - secretAccessKey: Private access key provided by AWS
     ///     - sessionToken: Token provided by STS.AssumeRole() which allows access to another AWS account
-    ///     - region: Region of server you want to communicate with
     ///     - endpoint: Custom endpoint URL to use instead of standard AWS servers
     ///     - middlewares: Array of middlewares to apply to requests and responses
     ///     - httpClientProvider: HTTPClient to use. Use `createNew` if the client should manage its own HTTPClient.
@@ -44,7 +43,6 @@ public struct Budgets {
         accessKeyId: String? = nil,
         secretAccessKey: String? = nil,
         sessionToken: String? = nil,
-        region: AWSSDKSwiftCore.Region? = nil,
         endpoint: String? = nil,
         middlewares: [AWSServiceMiddleware] = [],
         httpClientProvider: AWSClient.HTTPClientProvider = .createNew
@@ -53,7 +51,7 @@ public struct Budgets {
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
             sessionToken: sessionToken,
-            region: region,
+            region: nil,
             amzTarget: "AWSBudgetServiceGateway",
             service: "budgets",
             serviceProtocol: .json(version: "1.1"),

--- a/Sources/AWSSDKSwift/Services/Chime/Chime_API.swift
+++ b/Sources/AWSSDKSwift/Services/Chime/Chime_API.swift
@@ -36,7 +36,6 @@ public struct Chime {
     ///     - accessKeyId: Public access key provided by AWS
     ///     - secretAccessKey: Private access key provided by AWS
     ///     - sessionToken: Token provided by STS.AssumeRole() which allows access to another AWS account
-    ///     - region: Region of server you want to communicate with
     ///     - endpoint: Custom endpoint URL to use instead of standard AWS servers
     ///     - middlewares: Array of middlewares to apply to requests and responses
     ///     - httpClientProvider: HTTPClient to use. Use `createNew` if the client should manage its own HTTPClient.
@@ -44,7 +43,6 @@ public struct Chime {
         accessKeyId: String? = nil,
         secretAccessKey: String? = nil,
         sessionToken: String? = nil,
-        region: AWSSDKSwiftCore.Region? = nil,
         endpoint: String? = nil,
         middlewares: [AWSServiceMiddleware] = [],
         httpClientProvider: AWSClient.HTTPClientProvider = .createNew
@@ -53,7 +51,7 @@ public struct Chime {
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
             sessionToken: sessionToken,
-            region: region,
+            region: nil,
             service: "chime",
             serviceProtocol: .restjson,
             apiVersion: "2018-05-01",

--- a/Sources/AWSSDKSwift/Services/CloudFront/CloudFront_API.swift
+++ b/Sources/AWSSDKSwift/Services/CloudFront/CloudFront_API.swift
@@ -36,7 +36,6 @@ public struct CloudFront {
     ///     - accessKeyId: Public access key provided by AWS
     ///     - secretAccessKey: Private access key provided by AWS
     ///     - sessionToken: Token provided by STS.AssumeRole() which allows access to another AWS account
-    ///     - region: Region of server you want to communicate with
     ///     - endpoint: Custom endpoint URL to use instead of standard AWS servers
     ///     - middlewares: Array of middlewares to apply to requests and responses
     ///     - httpClientProvider: HTTPClient to use. Use `createNew` if the client should manage its own HTTPClient.
@@ -44,7 +43,6 @@ public struct CloudFront {
         accessKeyId: String? = nil,
         secretAccessKey: String? = nil,
         sessionToken: String? = nil,
-        region: AWSSDKSwiftCore.Region? = nil,
         endpoint: String? = nil,
         middlewares: [AWSServiceMiddleware] = [],
         httpClientProvider: AWSClient.HTTPClientProvider = .createNew
@@ -53,7 +51,7 @@ public struct CloudFront {
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
             sessionToken: sessionToken,
-            region: region,
+            region: nil,
             service: "cloudfront",
             serviceProtocol: .restxml,
             apiVersion: "2019-03-26",

--- a/Sources/AWSSDKSwift/Services/CostExplorer/CostExplorer_API.swift
+++ b/Sources/AWSSDKSwift/Services/CostExplorer/CostExplorer_API.swift
@@ -36,7 +36,6 @@ public struct CostExplorer {
     ///     - accessKeyId: Public access key provided by AWS
     ///     - secretAccessKey: Private access key provided by AWS
     ///     - sessionToken: Token provided by STS.AssumeRole() which allows access to another AWS account
-    ///     - region: Region of server you want to communicate with
     ///     - endpoint: Custom endpoint URL to use instead of standard AWS servers
     ///     - middlewares: Array of middlewares to apply to requests and responses
     ///     - httpClientProvider: HTTPClient to use. Use `createNew` if the client should manage its own HTTPClient.
@@ -44,7 +43,6 @@ public struct CostExplorer {
         accessKeyId: String? = nil,
         secretAccessKey: String? = nil,
         sessionToken: String? = nil,
-        region: AWSSDKSwiftCore.Region? = nil,
         endpoint: String? = nil,
         middlewares: [AWSServiceMiddleware] = [],
         httpClientProvider: AWSClient.HTTPClientProvider = .createNew
@@ -53,7 +51,7 @@ public struct CostExplorer {
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
             sessionToken: sessionToken,
-            region: region,
+            region: nil,
             amzTarget: "AWSInsightsIndexService",
             service: "ce",
             serviceProtocol: .json(version: "1.1"),

--- a/Sources/AWSSDKSwift/Services/IAM/IAM_API.swift
+++ b/Sources/AWSSDKSwift/Services/IAM/IAM_API.swift
@@ -36,7 +36,6 @@ public struct IAM {
     ///     - accessKeyId: Public access key provided by AWS
     ///     - secretAccessKey: Private access key provided by AWS
     ///     - sessionToken: Token provided by STS.AssumeRole() which allows access to another AWS account
-    ///     - region: Region of server you want to communicate with
     ///     - endpoint: Custom endpoint URL to use instead of standard AWS servers
     ///     - middlewares: Array of middlewares to apply to requests and responses
     ///     - httpClientProvider: HTTPClient to use. Use `createNew` if the client should manage its own HTTPClient.
@@ -44,7 +43,6 @@ public struct IAM {
         accessKeyId: String? = nil,
         secretAccessKey: String? = nil,
         sessionToken: String? = nil,
-        region: AWSSDKSwiftCore.Region? = nil,
         endpoint: String? = nil,
         middlewares: [AWSServiceMiddleware] = [],
         httpClientProvider: AWSClient.HTTPClientProvider = .createNew
@@ -53,7 +51,7 @@ public struct IAM {
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
             sessionToken: sessionToken,
-            region: region,
+            region: nil,
             service: "iam",
             serviceProtocol: .query,
             apiVersion: "2010-05-08",

--- a/Sources/AWSSDKSwift/Services/ImportExport/ImportExport_API.swift
+++ b/Sources/AWSSDKSwift/Services/ImportExport/ImportExport_API.swift
@@ -36,7 +36,6 @@ public struct ImportExport {
     ///     - accessKeyId: Public access key provided by AWS
     ///     - secretAccessKey: Private access key provided by AWS
     ///     - sessionToken: Token provided by STS.AssumeRole() which allows access to another AWS account
-    ///     - region: Region of server you want to communicate with
     ///     - endpoint: Custom endpoint URL to use instead of standard AWS servers
     ///     - middlewares: Array of middlewares to apply to requests and responses
     ///     - httpClientProvider: HTTPClient to use. Use `createNew` if the client should manage its own HTTPClient.
@@ -44,7 +43,6 @@ public struct ImportExport {
         accessKeyId: String? = nil,
         secretAccessKey: String? = nil,
         sessionToken: String? = nil,
-        region: AWSSDKSwiftCore.Region? = nil,
         endpoint: String? = nil,
         middlewares: [AWSServiceMiddleware] = [],
         httpClientProvider: AWSClient.HTTPClientProvider = .createNew
@@ -53,7 +51,7 @@ public struct ImportExport {
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
             sessionToken: sessionToken,
-            region: region,
+            region: nil,
             service: "importexport",
             serviceProtocol: .query,
             apiVersion: "2010-06-01",

--- a/Sources/AWSSDKSwift/Services/MTurk/MTurk_API.swift
+++ b/Sources/AWSSDKSwift/Services/MTurk/MTurk_API.swift
@@ -36,7 +36,6 @@ public struct MTurk {
     ///     - accessKeyId: Public access key provided by AWS
     ///     - secretAccessKey: Private access key provided by AWS
     ///     - sessionToken: Token provided by STS.AssumeRole() which allows access to another AWS account
-    ///     - region: Region of server you want to communicate with
     ///     - endpoint: Custom endpoint URL to use instead of standard AWS servers
     ///     - middlewares: Array of middlewares to apply to requests and responses
     ///     - httpClientProvider: HTTPClient to use. Use `createNew` if the client should manage its own HTTPClient.
@@ -44,7 +43,6 @@ public struct MTurk {
         accessKeyId: String? = nil,
         secretAccessKey: String? = nil,
         sessionToken: String? = nil,
-        region: AWSSDKSwiftCore.Region? = nil,
         endpoint: String? = nil,
         middlewares: [AWSServiceMiddleware] = [],
         httpClientProvider: AWSClient.HTTPClientProvider = .createNew
@@ -53,7 +51,7 @@ public struct MTurk {
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
             sessionToken: sessionToken,
-            region: region,
+            region: nil,
             amzTarget: "MTurkRequesterServiceV20170117",
             service: "mturk-requester",
             serviceProtocol: .json(version: "1.1"),

--- a/Sources/AWSSDKSwift/Services/Organizations/Organizations_API.swift
+++ b/Sources/AWSSDKSwift/Services/Organizations/Organizations_API.swift
@@ -36,7 +36,6 @@ public struct Organizations {
     ///     - accessKeyId: Public access key provided by AWS
     ///     - secretAccessKey: Private access key provided by AWS
     ///     - sessionToken: Token provided by STS.AssumeRole() which allows access to another AWS account
-    ///     - region: Region of server you want to communicate with
     ///     - endpoint: Custom endpoint URL to use instead of standard AWS servers
     ///     - middlewares: Array of middlewares to apply to requests and responses
     ///     - httpClientProvider: HTTPClient to use. Use `createNew` if the client should manage its own HTTPClient.
@@ -44,7 +43,6 @@ public struct Organizations {
         accessKeyId: String? = nil,
         secretAccessKey: String? = nil,
         sessionToken: String? = nil,
-        region: AWSSDKSwiftCore.Region? = nil,
         endpoint: String? = nil,
         middlewares: [AWSServiceMiddleware] = [],
         httpClientProvider: AWSClient.HTTPClientProvider = .createNew
@@ -53,7 +51,7 @@ public struct Organizations {
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
             sessionToken: sessionToken,
-            region: region,
+            region: nil,
             amzTarget: "AWSOrganizationsV20161128",
             service: "organizations",
             serviceProtocol: .json(version: "1.1"),

--- a/Sources/AWSSDKSwift/Services/Route53/Route53_API.swift
+++ b/Sources/AWSSDKSwift/Services/Route53/Route53_API.swift
@@ -36,7 +36,6 @@ public struct Route53 {
     ///     - accessKeyId: Public access key provided by AWS
     ///     - secretAccessKey: Private access key provided by AWS
     ///     - sessionToken: Token provided by STS.AssumeRole() which allows access to another AWS account
-    ///     - region: Region of server you want to communicate with
     ///     - endpoint: Custom endpoint URL to use instead of standard AWS servers
     ///     - middlewares: Array of middlewares to apply to requests and responses
     ///     - httpClientProvider: HTTPClient to use. Use `createNew` if the client should manage its own HTTPClient.
@@ -44,7 +43,6 @@ public struct Route53 {
         accessKeyId: String? = nil,
         secretAccessKey: String? = nil,
         sessionToken: String? = nil,
-        region: AWSSDKSwiftCore.Region? = nil,
         endpoint: String? = nil,
         middlewares: [AWSServiceMiddleware] = [],
         httpClientProvider: AWSClient.HTTPClientProvider = .createNew
@@ -53,7 +51,7 @@ public struct Route53 {
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
             sessionToken: sessionToken,
-            region: region,
+            region: nil,
             service: "route53",
             serviceProtocol: .restxml,
             apiVersion: "2013-04-01",

--- a/Sources/AWSSDKSwift/Services/SavingsPlans/SavingsPlans_API.swift
+++ b/Sources/AWSSDKSwift/Services/SavingsPlans/SavingsPlans_API.swift
@@ -36,7 +36,6 @@ public struct SavingsPlans {
     ///     - accessKeyId: Public access key provided by AWS
     ///     - secretAccessKey: Private access key provided by AWS
     ///     - sessionToken: Token provided by STS.AssumeRole() which allows access to another AWS account
-    ///     - region: Region of server you want to communicate with
     ///     - endpoint: Custom endpoint URL to use instead of standard AWS servers
     ///     - middlewares: Array of middlewares to apply to requests and responses
     ///     - httpClientProvider: HTTPClient to use. Use `createNew` if the client should manage its own HTTPClient.
@@ -44,7 +43,6 @@ public struct SavingsPlans {
         accessKeyId: String? = nil,
         secretAccessKey: String? = nil,
         sessionToken: String? = nil,
-        region: AWSSDKSwiftCore.Region? = nil,
         endpoint: String? = nil,
         middlewares: [AWSServiceMiddleware] = [],
         httpClientProvider: AWSClient.HTTPClientProvider = .createNew
@@ -53,7 +51,7 @@ public struct SavingsPlans {
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
             sessionToken: sessionToken,
-            region: region,
+            region: nil,
             service: "savingsplans",
             serviceProtocol: .restjson,
             apiVersion: "2019-06-28",

--- a/Sources/AWSSDKSwift/Services/Shield/Shield_API.swift
+++ b/Sources/AWSSDKSwift/Services/Shield/Shield_API.swift
@@ -36,7 +36,6 @@ public struct Shield {
     ///     - accessKeyId: Public access key provided by AWS
     ///     - secretAccessKey: Private access key provided by AWS
     ///     - sessionToken: Token provided by STS.AssumeRole() which allows access to another AWS account
-    ///     - region: Region of server you want to communicate with
     ///     - endpoint: Custom endpoint URL to use instead of standard AWS servers
     ///     - middlewares: Array of middlewares to apply to requests and responses
     ///     - httpClientProvider: HTTPClient to use. Use `createNew` if the client should manage its own HTTPClient.
@@ -44,7 +43,6 @@ public struct Shield {
         accessKeyId: String? = nil,
         secretAccessKey: String? = nil,
         sessionToken: String? = nil,
-        region: AWSSDKSwiftCore.Region? = nil,
         endpoint: String? = nil,
         middlewares: [AWSServiceMiddleware] = [],
         httpClientProvider: AWSClient.HTTPClientProvider = .createNew
@@ -53,7 +51,7 @@ public struct Shield {
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
             sessionToken: sessionToken,
-            region: region,
+            region: nil,
             amzTarget: "AWSShield_20160616",
             service: "shield",
             serviceProtocol: .json(version: "1.1"),

--- a/Sources/AWSSDKSwift/Services/WAF/WAF_API.swift
+++ b/Sources/AWSSDKSwift/Services/WAF/WAF_API.swift
@@ -36,7 +36,6 @@ public struct WAF {
     ///     - accessKeyId: Public access key provided by AWS
     ///     - secretAccessKey: Private access key provided by AWS
     ///     - sessionToken: Token provided by STS.AssumeRole() which allows access to another AWS account
-    ///     - region: Region of server you want to communicate with
     ///     - endpoint: Custom endpoint URL to use instead of standard AWS servers
     ///     - middlewares: Array of middlewares to apply to requests and responses
     ///     - httpClientProvider: HTTPClient to use. Use `createNew` if the client should manage its own HTTPClient.
@@ -44,7 +43,6 @@ public struct WAF {
         accessKeyId: String? = nil,
         secretAccessKey: String? = nil,
         sessionToken: String? = nil,
-        region: AWSSDKSwiftCore.Region? = nil,
         endpoint: String? = nil,
         middlewares: [AWSServiceMiddleware] = [],
         httpClientProvider: AWSClient.HTTPClientProvider = .createNew
@@ -53,7 +51,7 @@ public struct WAF {
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
             sessionToken: sessionToken,
-            region: region,
+            region: nil,
             amzTarget: "AWSWAF_20150824",
             service: "waf",
             serviceProtocol: .json(version: "1.1"),

--- a/Tests/AWSSDKSwiftTests/Services/IAM/IAMTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/IAM/IAMTests.swift
@@ -24,7 +24,6 @@ class IAMTests: XCTestCase {
     let client = IAM(
         accessKeyId: "key",
         secretAccessKey: "secret",
-        region: .useast1,
         endpoint: ProcessInfo.processInfo.environment["IAM_ENDPOINT"] ?? "http://localhost:4593",
         middlewares: (ProcessInfo.processInfo.environment["AWS_ENABLE_LOGGING"] == "true") ? [AWSLoggingMiddleware()] : [],
         httpClientProvider: .createNew


### PR DESCRIPTION
If it is left in the user can specify an invalid region