### PR TITLE
Payload objects in Responses now use AWSPayload

### DIFF
--- a/CodeGenerator/Sources/CodeGenerator/Models/API.swift
+++ b/CodeGenerator/Sources/CodeGenerator/Models/API.swift
@@ -469,11 +469,10 @@ class Shape: Decodable, Patchable {
     func postProcess() {
         switch self.type {
         case .structure(let structure):
-            if self.usedInInput {
-                if let payload = self.payload {
-                    if case .blob(let min, let max) = structure.members[payload]?.shape.type {
-                        structure.members[payload]!.shape = Shape(type: .payload(min: min, max: max), name: "AWSPayload")
-                    }
+            // set raw payloads to be a payload object
+            if let payload = self.payload {
+                if case .blob(let min, let max) = structure.members[payload]?.shape.type {
+                    structure.members[payload]!.shape = Shape(type: .payload(min: min, max: max), name: "AWSPayload")
                 }
             }
 

--- a/Package.swift
+++ b/Package.swift
@@ -228,7 +228,7 @@ let package = Package(
         .library(name: "AWSXRay", targets: ["AWSXRay"])
     ],
     dependencies: [
-        .package(url: "https://github.com/swift-aws/aws-sdk-swift-core.git", .branch("payload-object-in-response"))
+        .package(url: "https://github.com/swift-aws/aws-sdk-swift-core.git", .branch("master"))
     ],
     targets: [
         .target(name: "AWSACM", dependencies: ["AWSSDKSwiftCore"], path: "./Sources/AWSSDKSwift/Services/ACM"),

--- a/Package.swift
+++ b/Package.swift
@@ -228,7 +228,7 @@ let package = Package(
         .library(name: "AWSXRay", targets: ["AWSXRay"])
     ],
     dependencies: [
-        .package(url: "https://github.com/swift-aws/aws-sdk-swift-core.git", .branch("master"))
+        .package(url: "https://github.com/swift-aws/aws-sdk-swift-core.git", .branch("payload-object-in-response"))
     ],
     targets: [
         .target(name: "AWSACM", dependencies: ["AWSSDKSwiftCore"], path: "./Sources/AWSSDKSwift/Services/ACM"),

--- a/Sources/AWSSDKSwift/Services/APIGateway/APIGateway_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/APIGateway/APIGateway_Shapes.swift
@@ -1819,13 +1819,13 @@ extension APIGateway {
         ]
 
         /// The binary blob response to GetExport, which contains the export.
-        public let body: Data?
+        public let body: AWSPayload?
         /// The content-disposition header value in the HTTP response.
         public let contentDisposition: String?
         /// The content-type header value in the HTTP response. This will correspond to a valid 'accept' type in the request.
         public let contentType: String?
 
-        public init(body: Data? = nil, contentDisposition: String? = nil, contentType: String? = nil) {
+        public init(body: AWSPayload? = nil, contentDisposition: String? = nil, contentType: String? = nil) {
             self.body = body
             self.contentDisposition = contentDisposition
             self.contentType = contentType
@@ -3868,13 +3868,13 @@ extension APIGateway {
         ]
 
         /// The binary blob response to GetSdk, which contains the generated SDK.
-        public let body: Data?
+        public let body: AWSPayload?
         /// The content-disposition header value in the HTTP response.
         public let contentDisposition: String?
         /// The content-type header value in the HTTP response.
         public let contentType: String?
 
-        public init(body: Data? = nil, contentDisposition: String? = nil, contentType: String? = nil) {
+        public init(body: AWSPayload? = nil, contentDisposition: String? = nil, contentType: String? = nil) {
             self.body = body
             self.contentDisposition = contentDisposition
             self.contentType = contentType

--- a/Sources/AWSSDKSwift/Services/ApiGatewayV2/ApiGatewayV2_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/ApiGatewayV2/ApiGatewayV2_Shapes.swift
@@ -1603,9 +1603,9 @@ extension ApiGatewayV2 {
             AWSMemberEncoding(label: "body", encoding: .blob)
         ]
 
-        public let body: Data?
+        public let body: AWSPayload?
 
-        public init(body: Data? = nil) {
+        public init(body: AWSPayload? = nil) {
             self.body = body
         }
 

--- a/Sources/AWSSDKSwift/Services/AppConfig/AppConfig_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/AppConfig/AppConfig_Shapes.swift
@@ -128,11 +128,11 @@ extension AppConfig {
         /// The configuration version.
         public let configurationVersion: String?
         /// The content of the configuration or the configuration data.
-        public let content: Data?
+        public let content: AWSPayload?
         /// A standard MIME type describing the format of the configuration content. For more information, see Content-Type.
         public let contentType: String?
 
-        public init(configurationVersion: String? = nil, content: Data? = nil, contentType: String? = nil) {
+        public init(configurationVersion: String? = nil, content: AWSPayload? = nil, contentType: String? = nil) {
             self.configurationVersion = configurationVersion
             self.content = content
             self.contentType = contentType

--- a/Sources/AWSSDKSwift/Services/AppSync/AppSync_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/AppSync/AppSync_Shapes.swift
@@ -1261,9 +1261,9 @@ extension AppSync {
         ]
 
         /// The schema, in GraphQL Schema Definition Language (SDL) format. For more information, see the GraphQL SDL documentation.
-        public let schema: Data?
+        public let schema: AWSPayload?
 
-        public init(schema: Data? = nil) {
+        public init(schema: AWSPayload? = nil) {
             self.schema = schema
         }
 

--- a/Sources/AWSSDKSwift/Services/CodeGuruProfiler/CodeGuruProfiler_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/CodeGuruProfiler/CodeGuruProfiler_Shapes.swift
@@ -342,9 +342,9 @@ extension CodeGuruProfiler {
         /// The content type of the profile in the payload. It is either application/json or the default application/x-amzn-ion.
         public let contentType: String
         /// Information about the profile.
-        public let profile: Data
+        public let profile: AWSPayload
 
-        public init(contentEncoding: String? = nil, contentType: String, profile: Data) {
+        public init(contentEncoding: String? = nil, contentType: String, profile: AWSPayload) {
             self.contentEncoding = contentEncoding
             self.contentType = contentType
             self.profile = profile

--- a/Sources/AWSSDKSwift/Services/EBS/EBS_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/EBS/EBS_Shapes.swift
@@ -109,7 +109,7 @@ extension EBS {
         ]
 
         /// The data content of the block.
-        public let blockData: Data?
+        public let blockData: AWSPayload?
         /// The checksum generated for the block, which is Base64 encoded.
         public let checksum: String?
         /// The algorithm used to generate the checksum for the block, such as SHA256.
@@ -117,7 +117,7 @@ extension EBS {
         /// The size of the data in the block.
         public let dataLength: Int?
 
-        public init(blockData: Data? = nil, checksum: String? = nil, checksumAlgorithm: ChecksumAlgorithm? = nil, dataLength: Int? = nil) {
+        public init(blockData: AWSPayload? = nil, checksum: String? = nil, checksumAlgorithm: ChecksumAlgorithm? = nil, dataLength: Int? = nil) {
             self.blockData = blockData
             self.checksum = checksum
             self.checksumAlgorithm = checksumAlgorithm

--- a/Sources/AWSSDKSwift/Services/Glacier/Glacier_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/Glacier/Glacier_Shapes.swift
@@ -625,7 +625,7 @@ extension Glacier {
         /// The description of an archive.
         public let archiveDescription: String?
         /// The job data, either archive data or inventory data.
-        public let body: Data?
+        public let body: AWSPayload?
         /// The checksum of the data in the response. This header is returned only when retrieving the output for an archive retrieval job. Furthermore, this header appears only under the following conditions:   You get the entire range of the archive.   You request a range to return of the archive that starts and ends on a multiple of 1 MB. For example, if you have an 3.1 MB archive and you specify a range to return that starts at 1 MB and ends at 2 MB, then the x-amz-sha256-tree-hash is returned as a response header.   You request a range of the archive to return that starts on a multiple of 1 MB and goes to the end of the archive. For example, if you have a 3.1 MB archive and you specify a range that starts at 2 MB and ends at 3.1 MB (the end of the archive), then the x-amz-sha256-tree-hash is returned as a response header.  
         public let checksum: String?
         /// The range of bytes returned by Amazon S3 Glacier. If only partial output is downloaded, the response provides the range of bytes Amazon S3 Glacier returned. For example, bytes 0-1048575/8388608 returns the first 1 MB from 8 MB.
@@ -635,7 +635,7 @@ extension Glacier {
         /// The HTTP response code for a job output request. The value depends on whether a range was specified in the request.
         public let status: Int?
 
-        public init(acceptRanges: String? = nil, archiveDescription: String? = nil, body: Data? = nil, checksum: String? = nil, contentRange: String? = nil, contentType: String? = nil, status: Int? = nil) {
+        public init(acceptRanges: String? = nil, archiveDescription: String? = nil, body: AWSPayload? = nil, checksum: String? = nil, contentRange: String? = nil, contentType: String? = nil, status: Int? = nil) {
             self.acceptRanges = acceptRanges
             self.archiveDescription = archiveDescription
             self.body = body

--- a/Sources/AWSSDKSwift/Services/IoTDataPlane/IoTDataPlane_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/IoTDataPlane/IoTDataPlane_Shapes.swift
@@ -51,9 +51,9 @@ extension IoTDataPlane {
         ]
 
         /// The state information, in JSON format.
-        public let payload: Data
+        public let payload: AWSPayload
 
-        public init(payload: Data) {
+        public init(payload: AWSPayload) {
             self.payload = payload
         }
 
@@ -91,9 +91,9 @@ extension IoTDataPlane {
         ]
 
         /// The state information, in JSON format.
-        public let payload: Data?
+        public let payload: AWSPayload?
 
-        public init(payload: Data? = nil) {
+        public init(payload: AWSPayload? = nil) {
             self.payload = payload
         }
 
@@ -167,9 +167,9 @@ extension IoTDataPlane {
         ]
 
         /// The state information, in JSON format.
-        public let payload: Data?
+        public let payload: AWSPayload?
 
-        public init(payload: Data? = nil) {
+        public init(payload: AWSPayload? = nil) {
             self.payload = payload
         }
 

--- a/Sources/AWSSDKSwift/Services/KinesisVideoArchivedMedia/KinesisVideoArchivedMedia_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/KinesisVideoArchivedMedia/KinesisVideoArchivedMedia_Shapes.swift
@@ -253,9 +253,9 @@ extension KinesisVideoArchivedMedia {
         /// The content type of the media in the requested clip.
         public let contentType: String?
         /// Traditional MP4 file that contains the media clip from the specified video stream. The output will contain the first 100 MB or the first 200 fragments from the specified start timestamp. For more information, see Kinesis Video Streams Limits. 
-        public let payload: Data?
+        public let payload: AWSPayload?
 
-        public init(contentType: String? = nil, payload: Data? = nil) {
+        public init(contentType: String? = nil, payload: AWSPayload? = nil) {
             self.contentType = contentType
             self.payload = payload
         }
@@ -450,9 +450,9 @@ extension KinesisVideoArchivedMedia {
         /// The content type of the requested media.
         public let contentType: String?
         /// The payload that Kinesis Video Streams returns is a sequence of chunks from the specified stream. For information about the chunks, see PutMedia. The chunks that Kinesis Video Streams returns in the GetMediaForFragmentList call also include the following additional Matroska (MKV) tags:    AWS_KINESISVIDEO_FRAGMENT_NUMBER - Fragment number returned in the chunk.   AWS_KINESISVIDEO_SERVER_SIDE_TIMESTAMP - Server-side timestamp of the fragment.   AWS_KINESISVIDEO_PRODUCER_SIDE_TIMESTAMP - Producer-side timestamp of the fragment.   The following tags will be included if an exception occurs:   AWS_KINESISVIDEO_FRAGMENT_NUMBER - The number of the fragment that threw the exception   AWS_KINESISVIDEO_EXCEPTION_ERROR_CODE - The integer code of the exception   AWS_KINESISVIDEO_EXCEPTION_MESSAGE - A text description of the exception  
-        public let payload: Data?
+        public let payload: AWSPayload?
 
-        public init(contentType: String? = nil, payload: Data? = nil) {
+        public init(contentType: String? = nil, payload: AWSPayload? = nil) {
             self.contentType = contentType
             self.payload = payload
         }

--- a/Sources/AWSSDKSwift/Services/KinesisVideoMedia/KinesisVideoMedia_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/KinesisVideoMedia/KinesisVideoMedia_Shapes.swift
@@ -75,9 +75,9 @@ extension KinesisVideoMedia {
         /// The content type of the requested media.
         public let contentType: String?
         ///  The payload Kinesis Video Streams returns is a sequence of chunks from the specified stream. For information about the chunks, see . The chunks that Kinesis Video Streams returns in the GetMedia call also include the following additional Matroska (MKV) tags:    AWS_KINESISVIDEO_CONTINUATION_TOKEN (UTF-8 string) - In the event your GetMedia call terminates, you can use this continuation token in your next request to get the next chunk where the last request terminated.   AWS_KINESISVIDEO_MILLIS_BEHIND_NOW (UTF-8 string) - Client applications can use this tag value to determine how far behind the chunk returned in the response is from the latest chunk on the stream.    AWS_KINESISVIDEO_FRAGMENT_NUMBER - Fragment number returned in the chunk.   AWS_KINESISVIDEO_SERVER_TIMESTAMP - Server timestamp of the fragment.   AWS_KINESISVIDEO_PRODUCER_TIMESTAMP - Producer timestamp of the fragment.   The following tags will be present if an error occurs:   AWS_KINESISVIDEO_ERROR_CODE - String description of an error that caused GetMedia to stop.   AWS_KINESISVIDEO_ERROR_ID: Integer code of the error.   The error codes are as follows:   3002 - Error writing to the stream   4000 - Requested fragment is not found   4500 - Access denied for the stream's KMS key   4501 - Stream's KMS key is disabled   4502 - Validation error on the stream's KMS key   4503 - KMS key specified in the stream is unavailable   4504 - Invalid usage of the KMS key specified in the stream   4505 - Invalid state of the KMS key specified in the stream   4506 - Unable to find the KMS key specified in the stream   5000 - Internal error  
-        public let payload: Data?
+        public let payload: AWSPayload?
 
-        public init(contentType: String? = nil, payload: Data? = nil) {
+        public init(contentType: String? = nil, payload: AWSPayload? = nil) {
             self.contentType = contentType
             self.payload = payload
         }

--- a/Sources/AWSSDKSwift/Services/Lambda/Lambda_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/Lambda/Lambda_Shapes.swift
@@ -1668,11 +1668,11 @@ extension Lambda {
         /// The last 4 KB of the execution log, which is base64 encoded.
         public let logResult: String?
         /// The response from the function, or an error object.
-        public let payload: Data?
+        public let payload: AWSPayload?
         /// The HTTP status code is in the 200 range for a successful request. For the RequestResponse invocation type, this status code is 200. For the Event invocation type, this status code is 202. For the DryRun invocation type, the status code is 204.
         public let statusCode: Int?
 
-        public init(executedVersion: String? = nil, functionError: String? = nil, logResult: String? = nil, payload: Data? = nil, statusCode: Int? = nil) {
+        public init(executedVersion: String? = nil, functionError: String? = nil, logResult: String? = nil, payload: AWSPayload? = nil, statusCode: Int? = nil) {
             self.executedVersion = executedVersion
             self.functionError = functionError
             self.logResult = logResult

--- a/Sources/AWSSDKSwift/Services/LexRuntimeService/LexRuntimeService_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/LexRuntimeService/LexRuntimeService_Shapes.swift
@@ -390,7 +390,7 @@ extension LexRuntimeService {
         ]
 
         /// The prompt (or statement) to convey to the user. This is based on the bot configuration and context. For example, if Amazon Lex did not understand the user intent, it sends the clarificationPrompt configured for the bot. If the intent requires confirmation before taking the fulfillment action, it sends the confirmationPrompt. Another example: Suppose that the Lambda function successfully fulfilled the intent, and sent a message to convey to the user. Then Amazon Lex sends that message in the response. 
-        public let audioStream: Data?
+        public let audioStream: AWSPayload?
         /// Content type as specified in the Accept HTTP header in the request.
         public let contentType: String?
         /// Identifies the current state of the user interaction. Amazon Lex returns one of the following values as dialogState. The client can optionally use this information to customize the user interface.     ElicitIntent - Amazon Lex wants to elicit the user's intent. Consider the following examples:   For example, a user might utter an intent ("I want to order a pizza"). If Amazon Lex cannot infer the user intent from this utterance, it will return this dialog state.     ConfirmIntent - Amazon Lex is expecting a "yes" or "no" response.  For example, Amazon Lex wants user confirmation before fulfilling an intent. Instead of a simple "yes" or "no" response, a user might respond with additional information. For example, "yes, but make it a thick crust pizza" or "no, I want to order a drink." Amazon Lex can process such additional information (in these examples, update the crust type slot or change the intent from OrderPizza to OrderDrink).     ElicitSlot - Amazon Lex is expecting the value of a slot for the current intent.   For example, suppose that in the response Amazon Lex sends this message: "What size pizza would you like?". A user might reply with the slot value (e.g., "medium"). The user might also provide additional information in the response (e.g., "medium thick crust pizza"). Amazon Lex can process such additional information appropriately.     Fulfilled - Conveys that the Lambda function has successfully fulfilled the intent.     ReadyForFulfillment - Conveys that the client has to fulfill the request.     Failed - Conveys that the conversation with the user failed.   This can happen for various reasons, including that the user does not provide an appropriate response to prompts from the service (you can configure how many times Amazon Lex can prompt a user for specific information), or if the Lambda function fails to fulfill the intent.   
@@ -414,7 +414,7 @@ extension LexRuntimeService {
         ///  If the dialogState value is ElicitSlot, returns the name of the slot for which Amazon Lex is eliciting a value. 
         public let slotToElicit: String?
 
-        public init(audioStream: Data? = nil, contentType: String? = nil, dialogState: DialogState? = nil, inputTranscript: String? = nil, intentName: String? = nil, message: String? = nil, messageFormat: MessageFormatType? = nil, sentimentResponse: String? = nil, sessionAttributes: String? = nil, sessionId: String? = nil, slots: String? = nil, slotToElicit: String? = nil) {
+        public init(audioStream: AWSPayload? = nil, contentType: String? = nil, dialogState: DialogState? = nil, inputTranscript: String? = nil, intentName: String? = nil, message: String? = nil, messageFormat: MessageFormatType? = nil, sentimentResponse: String? = nil, sessionAttributes: String? = nil, sessionId: String? = nil, slots: String? = nil, slotToElicit: String? = nil) {
             self.audioStream = audioStream
             self.contentType = contentType
             self.dialogState = dialogState
@@ -608,7 +608,7 @@ extension LexRuntimeService {
         ]
 
         /// The audio version of the message to convey to the user.
-        public let audioStream: Data?
+        public let audioStream: AWSPayload?
         /// Content type as specified in the Accept HTTP header in the request.
         public let contentType: String?
         ///     ConfirmIntent - Amazon Lex is expecting a "yes" or "no" response to confirm the intent before fulfilling an intent.    ElicitIntent - Amazon Lex wants to elicit the user's intent.    ElicitSlot - Amazon Lex is expecting the value of a slot for the current intent.    Failed - Conveys that the conversation with the user has failed. This can happen for various reasons, including the user does not provide an appropriate response to prompts from the service, or if the Lambda function fails to fulfill the intent.    Fulfilled - Conveys that the Lambda function has sucessfully fulfilled the intent.    ReadyForFulfillment - Conveys that the client has to fulfill the intent.  
@@ -628,7 +628,7 @@ extension LexRuntimeService {
         /// If the dialogState is ElicitSlot, returns the name of the slot for which Amazon Lex is eliciting a value.
         public let slotToElicit: String?
 
-        public init(audioStream: Data? = nil, contentType: String? = nil, dialogState: DialogState? = nil, intentName: String? = nil, message: String? = nil, messageFormat: MessageFormatType? = nil, sessionAttributes: String? = nil, sessionId: String? = nil, slots: String? = nil, slotToElicit: String? = nil) {
+        public init(audioStream: AWSPayload? = nil, contentType: String? = nil, dialogState: DialogState? = nil, intentName: String? = nil, message: String? = nil, messageFormat: MessageFormatType? = nil, sessionAttributes: String? = nil, sessionId: String? = nil, slots: String? = nil, slotToElicit: String? = nil) {
             self.audioStream = audioStream
             self.contentType = contentType
             self.dialogState = dialogState

--- a/Sources/AWSSDKSwift/Services/MediaStoreData/MediaStoreData_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/MediaStoreData/MediaStoreData_Shapes.swift
@@ -167,7 +167,7 @@ extension MediaStoreData {
         ]
 
         /// The bytes of the object. 
-        public let body: Data?
+        public let body: AWSPayload?
         /// An optional CacheControl header that allows the caller to control the object's cache behavior. Headers can be passed in as specified in the HTTP spec at https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9. Headers with a custom user-defined value are also accepted.
         public let cacheControl: String?
         /// The length of the object in bytes.
@@ -183,7 +183,7 @@ extension MediaStoreData {
         /// The HTML status code of the request. Status codes ranging from 200 to 299 indicate success. All other status codes indicate the type of error that occurred.
         public let statusCode: Int
 
-        public init(body: Data? = nil, cacheControl: String? = nil, contentLength: Int64? = nil, contentRange: String? = nil, contentType: String? = nil, eTag: String? = nil, lastModified: TimeStamp? = nil, statusCode: Int) {
+        public init(body: AWSPayload? = nil, cacheControl: String? = nil, contentLength: Int64? = nil, contentRange: String? = nil, contentType: String? = nil, eTag: String? = nil, lastModified: TimeStamp? = nil, statusCode: Int) {
             self.body = body
             self.cacheControl = cacheControl
             self.contentLength = contentLength

--- a/Sources/AWSSDKSwift/Services/Polly/Polly_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/Polly/Polly_Shapes.swift
@@ -713,13 +713,13 @@ extension Polly {
         ]
 
         ///  Stream containing the synthesized speech. 
-        public let audioStream: Data?
+        public let audioStream: AWSPayload?
         ///  Specifies the type audio stream. This should reflect the OutputFormat parameter in your request.     If you request mp3 as the OutputFormat, the ContentType returned is audio/mpeg.     If you request ogg_vorbis as the OutputFormat, the ContentType returned is audio/ogg.     If you request pcm as the OutputFormat, the ContentType returned is audio/pcm in a signed 16-bit, 1 channel (mono), little-endian format.    If you request json as the OutputFormat, the ContentType returned is audio/json.    
         public let contentType: String?
         /// Number of characters synthesized.
         public let requestCharacters: Int?
 
-        public init(audioStream: Data? = nil, contentType: String? = nil, requestCharacters: Int? = nil) {
+        public init(audioStream: AWSPayload? = nil, contentType: String? = nil, requestCharacters: Int? = nil) {
             self.audioStream = audioStream
             self.contentType = contentType
             self.requestCharacters = requestCharacters

--- a/Sources/AWSSDKSwift/Services/S3/S3_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/S3/S3_Shapes.swift
@@ -2962,7 +2962,7 @@ extension S3 {
         /// Indicates that a range of bytes was specified.
         public let acceptRanges: String?
         /// Object data.
-        public let body: Data?
+        public let body: AWSPayload?
         /// Specifies caching behavior along the request/reply chain.
         public let cacheControl: String?
         /// Specifies presentational information for the object.
@@ -3021,7 +3021,7 @@ extension S3 {
         /// If the bucket is configured as a website, redirects requests for this object to another object in the same bucket or to an external URL. Amazon S3 stores the value of this header in the object metadata.
         public let websiteRedirectLocation: String?
 
-        public init(acceptRanges: String? = nil, body: Data? = nil, cacheControl: String? = nil, contentDisposition: String? = nil, contentEncoding: String? = nil, contentLanguage: String? = nil, contentLength: Int64? = nil, contentRange: String? = nil, contentType: String? = nil, deleteMarker: Bool? = nil, eTag: String? = nil, expiration: String? = nil, expires: TimeStamp? = nil, lastModified: TimeStamp? = nil, metadata: [String: String]? = nil, missingMeta: Int? = nil, objectLockLegalHoldStatus: ObjectLockLegalHoldStatus? = nil, objectLockMode: ObjectLockMode? = nil, objectLockRetainUntilDate: TimeStamp? = nil, partsCount: Int? = nil, replicationStatus: ReplicationStatus? = nil, requestCharged: RequestCharged? = nil, restore: String? = nil, serverSideEncryption: ServerSideEncryption? = nil, sSECustomerAlgorithm: String? = nil, sSECustomerKeyMD5: String? = nil, sSEKMSKeyId: String? = nil, storageClass: StorageClass? = nil, tagCount: Int? = nil, versionId: String? = nil, websiteRedirectLocation: String? = nil) {
+        public init(acceptRanges: String? = nil, body: AWSPayload? = nil, cacheControl: String? = nil, contentDisposition: String? = nil, contentEncoding: String? = nil, contentLanguage: String? = nil, contentLength: Int64? = nil, contentRange: String? = nil, contentType: String? = nil, deleteMarker: Bool? = nil, eTag: String? = nil, expiration: String? = nil, expires: TimeStamp? = nil, lastModified: TimeStamp? = nil, metadata: [String: String]? = nil, missingMeta: Int? = nil, objectLockLegalHoldStatus: ObjectLockLegalHoldStatus? = nil, objectLockMode: ObjectLockMode? = nil, objectLockRetainUntilDate: TimeStamp? = nil, partsCount: Int? = nil, replicationStatus: ReplicationStatus? = nil, requestCharged: RequestCharged? = nil, restore: String? = nil, serverSideEncryption: ServerSideEncryption? = nil, sSECustomerAlgorithm: String? = nil, sSECustomerKeyMD5: String? = nil, sSEKMSKeyId: String? = nil, storageClass: StorageClass? = nil, tagCount: Int? = nil, versionId: String? = nil, websiteRedirectLocation: String? = nil) {
             self.acceptRanges = acceptRanges
             self.body = body
             self.cacheControl = cacheControl
@@ -3287,10 +3287,10 @@ extension S3 {
         ]
 
         /// A Bencoded dictionary as defined by the BitTorrent specification
-        public let body: Data?
+        public let body: AWSPayload?
         public let requestCharged: RequestCharged?
 
-        public init(body: Data? = nil, requestCharged: RequestCharged? = nil) {
+        public init(body: AWSPayload? = nil, requestCharged: RequestCharged? = nil) {
             self.body = body
             self.requestCharged = requestCharged
         }

--- a/Sources/AWSSDKSwift/Services/SageMakerRuntime/SageMakerRuntime_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/SageMakerRuntime/SageMakerRuntime_Shapes.swift
@@ -85,7 +85,7 @@ extension SageMakerRuntime {
         ]
 
         /// Includes the inference provided by the model. For information about the format of the response body, see Common Data Formats—Inference.
-        public let body: Data
+        public let body: AWSPayload
         /// The MIME type of the inference returned in the response body.
         public let contentType: String?
         /// Provides additional information in the response about the inference returned by a model hosted at an Amazon SageMaker endpoint. The information is an opaque value that is forwarded verbatim. You could use this value, for example, to return an ID received in the CustomAttributes header of a request or other metadata that a service endpoint was programmed to produce. The value must consist of no more than 1024 visible US-ASCII characters as specified in Section 3.3.6. Field Value Components of the Hypertext Transfer Protocol (HTTP/1.1). If the customer wants the custom attribute returned, the model must set the custom attribute to be included on the way back.  This feature is currently supported in the AWS SDKs but not in the Amazon SageMaker Python SDK.
@@ -93,7 +93,7 @@ extension SageMakerRuntime {
         /// Identifies the production variant that was invoked.
         public let invokedProductionVariant: String?
 
-        public init(body: Data, contentType: String? = nil, customAttributes: String? = nil, invokedProductionVariant: String? = nil) {
+        public init(body: AWSPayload, contentType: String? = nil, customAttributes: String? = nil, invokedProductionVariant: String? = nil) {
             self.body = body
             self.contentType = contentType
             self.customAttributes = customAttributes

--- a/Sources/AWSSDKSwift/Services/Schemas/Schemas_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/Schemas/Schemas_Shapes.swift
@@ -532,9 +532,9 @@ extension Schemas {
             AWSMemberEncoding(label: "body", location: .body(locationName: "Body"), encoding: .blob)
         ]
 
-        public let body: Data?
+        public let body: AWSPayload?
 
-        public init(body: Data? = nil) {
+        public init(body: AWSPayload? = nil) {
             self.body = body
         }
 

--- a/Sources/AWSSDKSwift/Services/WorkMailMessageFlow/WorkMailMessageFlow_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/WorkMailMessageFlow/WorkMailMessageFlow_Shapes.swift
@@ -51,9 +51,9 @@ extension WorkMailMessageFlow {
         ]
 
         /// The raw content of the email message, in MIME format.
-        public let messageContent: Data
+        public let messageContent: AWSPayload
 
-        public init(messageContent: Data) {
+        public init(messageContent: AWSPayload) {
             self.messageContent = messageContent
         }
 


### PR DESCRIPTION
Sibling PR to https://github.com/swift-aws/aws-sdk-swift-core/pull/243

Added Code Generator changes to output AWSPayload objects in responses and run it. 