### PR TITLE
Cleanup tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,12 +33,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image: ['swift:5.1.5', 'swift:5.2']
+        image: ['swift:5.1', 'swift:5.2']
     services:
       localstack:
         image: localstack/localstack
         env:
-          SERVICES: 'apigateway,dynamodb,iam,s3,sns,sqs,ssm'
+          SERVICES: 'apigateway,dynamodb,iam,s3,sns,sqs,ssm,sts'
         options: >-
           --health-cmd "awslocal s3 ls"
           --health-interval 10s
@@ -50,11 +50,12 @@ jobs:
       env:
         APIGATEWAY_ENDPOINT : "http://localstack:4567"
         DYNAMODB_ENDPOINT   : "http://localstack:4569"
+        IAM_ENDPOINT        : "http://localstack:4593"
         S3_ENDPOINT         : "http://localstack:4572"
         SNS_ENDPOINT        : "http://localstack:4575"
         SQS_ENDPOINT        : "http://localstack:4576"
         SSM_ENDPOINT        : "http://localstack:4583"
-        IAM_ENDPOINT        : "http://localstack:4593"
+        STS_ENDPOINT        : "http://localstack:4592"
     steps:
     - name: Checkout
       uses: actions/checkout@v1

--- a/Package.swift
+++ b/Package.swift
@@ -486,7 +486,8 @@ let package = Package(
             "AWSSES",
             "AWSSNS",
             "AWSSQS",
-            "AWSSSM"
+            "AWSSSM",
+            "AWSSTS"
         ])
     ]
 )

--- a/Tests/AWSSDKSwiftTests/Services/APIGateway/APIGatewayTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/APIGateway/APIGatewayTests.swift
@@ -99,25 +99,25 @@ class APIGatewayTests: XCTestCase {
         let response = testRestApi(name: name) { id in
             // get parent resource
             let request = APIGateway.GetResourcesRequest(restApiId: id)
-            return self.apiGateway.getResources(request).map { (id, $0) }
-                .flatMapThrowing { (id: String, response: APIGateway.Resources) throws -> (String, String) in
+            return self.apiGateway.getResources(request)
+                .flatMapThrowing { response throws -> String in
                     let items = try XCTUnwrap(response.items)
                     XCTAssertEqual(items.count, 1)
                     let parentId = try XCTUnwrap(items[0].id)
-                    return (id, parentId)
+                    return parentId
             }
             // create new resource
-            .flatMap { (id: String, parentId: String) -> EventLoopFuture<(String, APIGateway.Resource)> in
+            .flatMap { parentId -> EventLoopFuture<APIGateway.Resource> in
                 let request = APIGateway.CreateResourceRequest(parentId: parentId, pathPart: "test&*8345", restApiId: id)
-                return self.apiGateway.createResource(request).map { return (id, $0) }
+                return self.apiGateway.createResource(request)
             }
             // extract resource id
-            .flatMapThrowing { (id, response) in
+            .flatMapThrowing { (response) throws -> String in
                 let resourceId = try XCTUnwrap(response.id)
-                return (id, resourceId)
+                return resourceId
             }
             // get resource
-            .flatMap { (id: String, resourceId: String) -> EventLoopFuture<APIGateway.Resource> in
+            .flatMap { resourceId -> EventLoopFuture<APIGateway.Resource> in
                 let request = APIGateway.GetResourceRequest(resourceId: resourceId, restApiId: id)
                 return self.apiGateway.getResource(request)
             }

--- a/Tests/AWSSDKSwiftTests/Services/APIGateway/APIGatewayTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/APIGateway/APIGatewayTests.swift
@@ -33,8 +33,15 @@ class APIGatewayTests: XCTestCase {
     )
     static let restApiName: String = "awssdkswift-APIGatewayTests"
     static var restApiId: String!
-    
+
     override class func setUp() {
+        if TestEnvironment.isUsingLocalstack {
+            print("Connecting to Localstack")
+        } else {
+            print("Connecting to AWS")
+        }
+        /// If we create a rest api for each test, when we delete them APIGateway will throttle and we will most likely not delete the all APIs
+        /// So we create one API to be used by all tests
         let eventLoop = self.apiGateway.client.eventLoopGroup.next()
         let createResult = createRestApi(name: restApiName, on: eventLoop)
             .flatMapThrowing { response in

--- a/Tests/AWSSDKSwiftTests/Services/APIGateway/APIGatewayTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/APIGateway/APIGatewayTests.swift
@@ -12,9 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import XCTest
-
 @testable import AWSAPIGateway
 
 enum APIGatewayTestsError: Error {
@@ -141,11 +139,26 @@ class APIGatewayTests: XCTestCase {
         XCTAssertNoThrow(try response.wait())
     }
 
+    func testError() {
+        let response = Self.apiGateway.getModels(.init(restApiId: "invalid-rest-api-id"))
+            .map { _ in }
+            .flatMapErrorThrowing { error in
+                switch error {
+                case APIGatewayErrorType.notFoundException(_):
+                    return
+                default:
+                    throw error
+                }
+        }
+        XCTAssertNoThrow(try response.wait())
+    }
+
     static var allTests: [(String, (APIGatewayTests) -> () throws -> Void)] {
         return [
             ("testGetRestApis", testGetRestApis),
             ("testGetRestApi", testGetRestApi),
             ("testCreateGetResource", testCreateGetResource),
+            ("testError", testError),
         ]
     }
 }

--- a/Tests/AWSSDKSwiftTests/Services/APIGateway/APIGatewayTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/APIGateway/APIGatewayTests.swift
@@ -77,7 +77,7 @@ class APIGatewayTests: XCTestCase {
     //MARK: TESTS
 
     func testGetRestApis() {
-        let name = TestEnvironment.getName(#function)
+        let name = TestEnvironment.generateResourceName()
         let response = testRestApi(name: name) { id in
             let request = APIGateway.GetRestApisRequest()
             return self.apiGateway.getRestApis(request)
@@ -91,7 +91,7 @@ class APIGatewayTests: XCTestCase {
     }
 
     func testGetRestApi() {
-        let name = TestEnvironment.getName(#function)
+        let name = TestEnvironment.generateResourceName()
         let response = testRestApi(name: name) { id in
             let request = APIGateway.GetRestApiRequest(restApiId: id)
             return self.apiGateway.getRestApi(request)
@@ -103,7 +103,7 @@ class APIGatewayTests: XCTestCase {
     }
 
     func testCreateGetResource() {
-        let name = TestEnvironment.getName(#function)
+        let name = TestEnvironment.generateResourceName()
         let response = testRestApi(name: name) { id in
             // get parent resource
             let request = APIGateway.GetResourcesRequest(restApiId: id)

--- a/Tests/AWSSDKSwiftTests/Services/Dynamodb/DynamoDBTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/Dynamodb/DynamoDBTests.swift
@@ -23,11 +23,21 @@ import XCTest
 class DynamoDBTests: XCTestCase {
 
     var dynamoDB = DynamoDB(
+        accessKeyId: TestEnvironment.accessKeyId,
+        secretAccessKey: TestEnvironment.secretAccessKey,
         region: .useast1,
         endpoint: TestEnvironment.getEndPoint(environment: "DYNAMODB_ENDPOINT", default: "http://localhost:4569"),
         middlewares: TestEnvironment.middlewares,
         httpClientProvider: .createNew
     )
+
+    override class func setUp() {
+        if TestEnvironment.isUsingLocalstack {
+            print("Connecting to Localstack")
+        } else {
+            print("Connecting to AWS")
+        }
+    }
 
     func createTable(name: String, hashKey: String) -> EventLoopFuture<Void> {
         let input = DynamoDB.CreateTableInput(

--- a/Tests/AWSSDKSwiftTests/Services/Dynamodb/DynamoDBTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/Dynamodb/DynamoDBTests.swift
@@ -76,7 +76,7 @@ class DynamoDBTests: XCTestCase {
     //MARK: TESTS
 
     func testCreateDeleteTable() {
-        let tableName = TestEnvironment.getName(#function)
+        let tableName = TestEnvironment.generateResourceName()
         let response = createTable(name: tableName, hashKey: "ID")
             .flatAlways { _ in
                 return self.deleteTable(name: tableName)
@@ -85,7 +85,7 @@ class DynamoDBTests: XCTestCase {
     }
     
     func testGetObject() {
-        let tableName = TestEnvironment.getName(#function)
+        let tableName = TestEnvironment.generateResourceName()
         let response = createTable(name: tableName, hashKey: "ID")
             .flatMap { _ in
                 return self.putItem(tableName: tableName, values: ["ID": "first", "First name": "John", "Surname": "Smith"])
@@ -105,7 +105,7 @@ class DynamoDBTests: XCTestCase {
     }
     
     func testDataItem() {
-        let tableName = TestEnvironment.getName(#function)
+        let tableName = TestEnvironment.generateResourceName()
         let data = Data("testdata".utf8)
         let response = createTable(name: tableName, hashKey: "ID")
             .flatMap { _ in
@@ -125,7 +125,7 @@ class DynamoDBTests: XCTestCase {
     }
     
     func testNumberSetItem() {
-        let tableName = TestEnvironment.getName(#function)
+        let tableName = TestEnvironment.generateResourceName()
         let response = createTable(name: tableName, hashKey: "ID")
             .flatMap { _ in
                 return self.putItem(tableName: tableName, values: ["ID": "1", "numbers": [2,4.001,-6,8]])

--- a/Tests/AWSSDKSwiftTests/Services/Dynamodb/DynamoDBTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/Dynamodb/DynamoDBTests.swift
@@ -24,8 +24,8 @@ class DynamoDBTests: XCTestCase {
 
     var dynamoDB = DynamoDB(
         region: .useast1,
-        endpoint: endpoint(environment: "DYNAMODB_ENDPOINT", default: "http://localhost:4569"),
-        middlewares: middlewares(),
+        endpoint: TestEnvironment.getEndPoint(environment: "DYNAMODB_ENDPOINT", default: "http://localhost:4569"),
+        middlewares: TestEnvironment.middlewares,
         httpClientProvider: .createNew
     )
 
@@ -76,7 +76,7 @@ class DynamoDBTests: XCTestCase {
     //MARK: TESTS
 
     func testCreateDeleteTable() {
-        let tableName = #function.filter { return $0.isLetter }
+        let tableName = TestEnvironment.getName(#function)
         let response = createTable(name: tableName, hashKey: "ID")
             .flatAlways { _ in
                 return self.deleteTable(name: tableName)
@@ -85,7 +85,7 @@ class DynamoDBTests: XCTestCase {
     }
     
     func testGetObject() {
-        let tableName = #function.filter { return $0.isLetter }
+        let tableName = TestEnvironment.getName(#function)
         let response = createTable(name: tableName, hashKey: "ID")
             .flatMap { _ in
                 return self.putItem(tableName: tableName, values: ["ID": "first", "First name": "John", "Surname": "Smith"])
@@ -105,7 +105,7 @@ class DynamoDBTests: XCTestCase {
     }
     
     func testDataItem() {
-        let tableName = #function.filter { return $0.isLetter }
+        let tableName = TestEnvironment.getName(#function)
         let data = Data("testdata".utf8)
         let response = createTable(name: tableName, hashKey: "ID")
             .flatMap { _ in
@@ -125,7 +125,7 @@ class DynamoDBTests: XCTestCase {
     }
     
     func testNumberSetItem() {
-        let tableName = #function.filter { return $0.isLetter }
+        let tableName = TestEnvironment.getName(#function)
         let response = createTable(name: tableName, hashKey: "ID")
             .flatMap { _ in
                 return self.putItem(tableName: tableName, values: ["ID": "1", "numbers": [2,4.001,-6,8]])

--- a/Tests/AWSSDKSwiftTests/Services/Dynamodb/DynamoDBTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/Dynamodb/DynamoDBTests.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import NIO
 import XCTest
 
 @testable import AWSDynamoDB
@@ -21,80 +22,163 @@ import XCTest
 
 class DynamoDBTests: XCTestCase {
 
-    var client = DynamoDB(
-        accessKeyId: "key",
-        secretAccessKey: "secret",
+    var dynamoDB = DynamoDB(
         region: .useast1,
-        endpoint: ProcessInfo.processInfo.environment["DYNAMODB_ENDPOINT"] ?? "http://localhost:4569",
-        middlewares: (ProcessInfo.processInfo.environment["AWS_ENABLE_LOGGING"] == "true") ? [AWSLoggingMiddleware()] : [],
+        endpoint: endpoint(environment: "DYNAMODB_ENDPOINT", default: "http://localhost:4569"),
+        middlewares: middlewares(),
         httpClientProvider: .createNew
     )
 
-    class TestData {
-        var client: DynamoDB
-        var tableName: String
-
-        init(_ testName: String, client: DynamoDB) throws {
-            let testName = testName.lowercased().filter { return $0.isLetter }
-            self.client = client
-            self.tableName = "\(testName)-tablename"
-
-            let createTableInput = DynamoDB.CreateTableInput(
-                attributeDefinitions: [
-                    .init(attributeName: "hashKey", attributeType: .s),
-                    .init(attributeName: "rangeKey", attributeType: .s),
-                ],
-                keySchema: [
-                    DynamoDB.KeySchemaElement(attributeName: "hashKey", keyType: .hash),
-                    DynamoDB.KeySchemaElement(attributeName: "rangeKey", keyType: .range),
-                ],
-                provisionedThroughput: DynamoDB.ProvisionedThroughput(readCapacityUnits: 10, writeCapacityUnits: 10),
-                tableName: self.tableName
-            )
-            _ = try client.createTable(createTableInput).wait()
-
-            let putItemInput = DynamoDB.PutItemInput(
-                item: [
-                    "hashKey": DynamoDB.AttributeValue(s: "hello"),
-                    "rangeKey": DynamoDB.AttributeValue(s: "world"),
-                ],
-                tableName: self.tableName
-            )
-            _ = try client.putItem(putItemInput).wait()
+    func createTable(name: String, hashKey: String) -> EventLoopFuture<Void> {
+        let input = DynamoDB.CreateTableInput(
+            attributeDefinitions: [.init(attributeName: hashKey, attributeType: .s)],
+            keySchema: [.init(attributeName: hashKey, keyType: .hash)],
+            provisionedThroughput: .init(readCapacityUnits: 5, writeCapacityUnits: 5),
+            tableName: name
+        )
+        return dynamoDB.createTable(input)
+            .map { response in
+                XCTAssertEqual(response.tableDescription?.tableName, name)
+                return
         }
-
-        deinit {
-            attempt {
-                let input = DynamoDB.DeleteTableInput(tableName: self.tableName)
-                _ = try client.deleteTable(input).wait()
+        .flatMapErrorThrowing { error in
+            switch error {
+            case DynamoDBErrorType.resourceInUseException(_):
+                print("Table (\(name)) already exists")
+                return
+            default:
+                throw error
             }
         }
-    }
-
-    //MARK: TESTS
-
-    func testGetObject() {
-        attempt {
-
-            let testData = try TestData(#function, client: client)
-
-            let input = DynamoDB.GetItemInput(
-                key: [
-                    "hashKey": DynamoDB.AttributeValue(s: "hello"),
-                    "rangeKey": DynamoDB.AttributeValue(s: "world"),
-                ],
-                tableName: testData.tableName
-            )
-
-            let output = try client.getItem(input).wait()
-            XCTAssertEqual(output.item?["hashKey"]?.s, "hello")
-            XCTAssertEqual(output.item?["rangeKey"]?.s, "world")
+        .flatMap { (_) -> EventLoopFuture<Void> in
+            // wait ten seconds for table to be created
+            let eventLoop = self.dynamoDB.client.eventLoopGroup.next()
+            let scheduled: Scheduled<Void> = eventLoop.flatScheduleTask(deadline: .now() + .seconds(10)) { return eventLoop.makeSucceededFuture(()) }
+            return scheduled.futureResult
         }
     }
+    
+    func deleteTable(name: String) -> EventLoopFuture<DynamoDB.DeleteTableOutput> {
+        let input = DynamoDB.DeleteTableInput(tableName: name)
+        return dynamoDB.deleteTable(input)
+    }
+    
+    func putItem(tableName: String, values: [String: Any]) -> EventLoopFuture<DynamoDB.PutItemOutput> {
+        let input = DynamoDB.PutItemInput(item: values.mapValues { DynamoDB.AttributeValue(any: $0) }, tableName: tableName)
+        return dynamoDB.putItem(input)
+    }
+    
+    func getItem(tableName: String, keys: [String: String]) -> EventLoopFuture<DynamoDB.GetItemOutput> {
+        let input = DynamoDB.GetItemInput(key: keys.mapValues { DynamoDB.AttributeValue(s: $0) }, tableName: tableName)
+        return dynamoDB.getItem(input)
+    }
+    
+    //MARK: TESTS
 
+    func testCreateDeleteTable() {
+        let tableName = #function.filter { return $0.isLetter }
+        let response = createTable(name: tableName, hashKey: "ID")
+            .flatAlways { _ in
+                return self.deleteTable(name: tableName)
+        }
+        XCTAssertNoThrow(try response.wait())
+    }
+    
+    func testGetObject() {
+        let tableName = #function.filter { return $0.isLetter }
+        let response = createTable(name: tableName, hashKey: "ID")
+            .flatMap { _ in
+                return self.putItem(tableName: tableName, values: ["ID": "first", "First name": "John", "Surname": "Smith"])
+        }
+        .flatMap { (_) -> EventLoopFuture<DynamoDB.GetItemOutput> in
+            return self.getItem(tableName: tableName, keys: ["ID": "first"])
+        }
+        .map { response -> Void in
+            XCTAssertEqual(response.item?["ID"]?.s, "first")
+            XCTAssertEqual(response.item?["First name"]?.s, "John")
+            XCTAssertEqual(response.item?["Surname"]?.s, "Smith")
+        }
+        .flatAlways { _ in
+                return self.deleteTable(name: tableName)
+        }
+        XCTAssertNoThrow(try response.wait())
+    }
+    
+    func testDataItem() {
+        let tableName = #function.filter { return $0.isLetter }
+        let data = Data("testdata".utf8)
+        let response = createTable(name: tableName, hashKey: "ID")
+            .flatMap { _ in
+                return self.putItem(tableName: tableName, values: ["ID": "1", "data": data])
+        }
+        .flatMap { (_) -> EventLoopFuture<DynamoDB.GetItemOutput> in
+            return self.getItem(tableName: tableName, keys: ["ID": "1"])
+        }
+        .map { response -> Void in
+            XCTAssertEqual(response.item?["ID"]?.s, "1")
+            XCTAssertEqual(response.item?["data"]?.b, data)
+        }
+        .flatAlways { _ in
+                return self.deleteTable(name: tableName)
+        }
+        XCTAssertNoThrow(try response.wait())
+    }
+    
+    func testNumberSetItem() {
+        let tableName = #function.filter { return $0.isLetter }
+        let response = createTable(name: tableName, hashKey: "ID")
+            .flatMap { _ in
+                return self.putItem(tableName: tableName, values: ["ID": "1", "numbers": [2,4.001,-6,8]])
+        }
+        .flatMap { (_) -> EventLoopFuture<DynamoDB.GetItemOutput> in
+            return self.getItem(tableName: tableName, keys: ["ID": "1"])
+        }
+        .flatMapThrowing { response -> Void in
+            XCTAssertEqual(response.item?["ID"]?.s, "1")
+            let numbers = try XCTUnwrap(response.item?["numbers"]?.ns)
+            let numberSet = Set(numbers)
+            XCTAssert(numberSet.contains("2"))
+            XCTAssert(numberSet.contains("4.001"))
+            XCTAssert(numberSet.contains("-6"))
+            XCTAssert(numberSet.contains("8"))
+        }
+        .flatAlways { _ in
+                return self.deleteTable(name: tableName)
+        }
+        XCTAssertNoThrow(try response.wait())
+    }
+    
     static var allTests: [(String, (DynamoDBTests) -> () throws -> Void)] {
         return [
+            ("testCreateDeleteTable", testCreateDeleteTable),
             ("testGetObject", testGetObject),
+            ("testDataItem", testDataItem),
+            ("testNumberSetItem", testNumberSetItem),
         ]
+    }
+}
+
+extension DynamoDB.AttributeValue {
+    convenience init(any: Any) {
+        switch any {
+        case let data as Data:
+            self.init(b: data)
+        case let bool as Bool:
+            self.init(bool: bool)
+        case let int as Int:
+            self.init(n: int.description)
+        case let ints as [Int]:
+            self.init(ns: ints.map {$0.description})
+        case let float as Float:
+            self.init(n: float.description)
+        case let double as Double:
+            self.init(n: double.description)
+        case let doubles as [Double]:
+            self.init(ns: doubles.map {$0.description})
+        case let string as String:
+            self.init(s: string)
+        default:
+            self.init(s: String(reflecting: any))
+        }
     }
 }

--- a/Tests/AWSSDKSwiftTests/Services/Dynamodb/DynamoDBTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/Dynamodb/DynamoDBTests.swift
@@ -51,8 +51,11 @@ class DynamoDBTests: XCTestCase {
             }
         }
         .flatMap { (_) -> EventLoopFuture<Void> in
-            // wait ten seconds for table to be created
             let eventLoop = self.dynamoDB.client.eventLoopGroup.next()
+            if TestEnvironment.isUsingLocalstack {
+                return eventLoop.makeSucceededFuture(())
+            }
+            // wait ten seconds for table to be created. If you don't subsequent commands will fail
             let scheduled: Scheduled<Void> = eventLoop.flatScheduleTask(deadline: .now() + .seconds(10)) { return eventLoop.makeSucceededFuture(()) }
             return scheduled.futureResult
         }

--- a/Tests/AWSSDKSwiftTests/Services/IAM/IAMTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/IAM/IAMTests.swift
@@ -23,7 +23,7 @@ class IAMTests: XCTestCase {
 
     let iam = IAM(
         endpoint: endpoint(environment: "IAM_ENDPOINT", default: "http://localhost:4593"),
-        middlewares: (ProcessInfo.processInfo.environment["AWS_ENABLE_LOGGING"] == "true") ? [AWSLoggingMiddleware()] : [],
+        middlewares: middlewares(),
         httpClientProvider: .createNew
     )
 

--- a/Tests/AWSSDKSwiftTests/Services/IAM/IAMTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/IAM/IAMTests.swift
@@ -27,6 +27,14 @@ class IAMTests: XCTestCase {
         httpClientProvider: .createNew
     )
 
+    override class func setUp() {
+        if TestEnvironment.isUsingLocalstack {
+            print("Connecting to Localstack")
+        } else {
+            print("Connecting to AWS")
+        }
+    }
+
     func createUser(userName: String) -> EventLoopFuture<Void> {
         let request = IAM.CreateUserRequest(userName: userName)
         return iam.createUser(request)

--- a/Tests/AWSSDKSwiftTests/Services/IAM/IAMTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/IAM/IAMTests.swift
@@ -52,7 +52,7 @@ class IAMTests: XCTestCase {
     //MARK: TESTS
 
     func testCreateDeleteUser() {
-        let username = TestEnvironment.getName(#function)
+        let username = TestEnvironment.generateResourceName()
         let response = createUser(userName: username)
             .flatMap { _ in self.deleteUser(userName: username) }
         XCTAssertNoThrow(try response.wait())
@@ -76,7 +76,7 @@ class IAMTests: XCTestCase {
                 ]
             }
             """
-        let username = TestEnvironment.getName(#function)
+        let username = TestEnvironment.generateResourceName()
         let response = createUser(userName: username)
             .flatMap { (_) -> EventLoopFuture<IAM.GetUserResponse> in
                 let request = IAM.GetUserRequest(userName: username)

--- a/Tests/AWSSDKSwiftTests/Services/IAM/IAMTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/IAM/IAMTests.swift
@@ -12,9 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import XCTest
-
 @testable import AWSIAM
 
 //testing query service

--- a/Tests/AWSSDKSwiftTests/Services/IAM/IAMTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/IAM/IAMTests.swift
@@ -22,8 +22,8 @@ import XCTest
 class IAMTests: XCTestCase {
 
     let iam = IAM(
-        endpoint: endpoint(environment: "IAM_ENDPOINT", default: "http://localhost:4593"),
-        middlewares: middlewares(),
+        endpoint: TestEnvironment.getEndPoint(environment: "IAM_ENDPOINT", default: "http://localhost:4593"),
+        middlewares: TestEnvironment.middlewares,
         httpClientProvider: .createNew
     )
 
@@ -52,7 +52,7 @@ class IAMTests: XCTestCase {
     //MARK: TESTS
 
     func testCreateDeleteUser() {
-        let username = #function.filter { $0.isLetter }
+        let username = TestEnvironment.getName(#function)
         let response = createUser(userName: username)
             .flatMap { _ in self.deleteUser(userName: username) }
         XCTAssertNoThrow(try response.wait())
@@ -76,7 +76,7 @@ class IAMTests: XCTestCase {
                 ]
             }
             """
-        let username = #function.filter { $0.isLetter }
+        let username = TestEnvironment.getName(#function)
         let response = createUser(userName: username)
             .flatMap { (_) -> EventLoopFuture<IAM.GetUserResponse> in
                 let request = IAM.GetUserRequest(userName: username)

--- a/Tests/AWSSDKSwiftTests/Services/S3/S3Tests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/S3/S3Tests.swift
@@ -21,11 +21,6 @@ import XCTest
 @testable import AWSS3
 @testable import AWSSDKSwiftCore
 
-// testing S3 service
-enum S3TestErrors: Error {
-    case error(String)
-}
-
 class S3Tests: XCTestCase {
 
     var s3 = S3(

--- a/Tests/AWSSDKSwiftTests/Services/S3/S3Tests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/S3/S3Tests.swift
@@ -29,6 +29,8 @@ enum S3TestErrors: Error {
 class S3Tests: XCTestCase {
 
     var s3 = S3(
+        accessKeyId: TestEnvironment.accessKeyId,
+        secretAccessKey: TestEnvironment.secretAccessKey,
         region: .euwest1,
         endpoint: TestEnvironment.getEndPoint(environment: "S3_ENDPOINT", default: "http://localhost:4572"),
         middlewares: TestEnvironment.middlewares,
@@ -274,6 +276,8 @@ class S3Tests: XCTestCase {
             XCTAssertNoThrow(try httpClient.syncShutdown())
         }
         let s3 = S3(
+            accessKeyId: TestEnvironment.accessKeyId,
+            secretAccessKey: TestEnvironment.secretAccessKey,
             region: .euwest1,
             endpoint: TestEnvironment.getEndPoint(environment: "S3_ENDPOINT", default: "http://localhost:4572"),
             middlewares: TestEnvironment.middlewares,

--- a/Tests/AWSSDKSwiftTests/Services/S3/S3Tests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/S3/S3Tests.swift
@@ -35,43 +35,11 @@ class S3Tests: XCTestCase {
         httpClientProvider: .createNew
     )
 
-    class TestData {
-        let s3: S3
-        let bucket: String
-        let bodyData: Data
-        let key: String
-
-        init(_ testName: String, s3: S3) throws {
-            let testName = testName.lowercased().filter { return $0.isLetter }
-            self.s3 = s3
-            self.bucket = "\(testName)-bucket"
-            self.bodyData = "\(testName) hello world".data(using: .utf8)!
-            self.key = "\(testName)-key.txt"
-
-            do {
-                let bucketRequest = S3.CreateBucketRequest(bucket: self.bucket)
-                _ = try s3.createBucket(bucketRequest).wait()
-            } catch S3ErrorType.bucketAlreadyOwnedByYou(_) {
-                print("Bucket (\(self.bucket)) already owned by you")
-            } catch S3ErrorType.bucketAlreadyExists(_) {
-                print("Bucket (\(self.bucket)) already exists")
-            }
-        }
-
-        deinit {
-            attempt {
-                let objects = try s3.listObjects(S3.ListObjectsRequest(bucket: self.bucket)).wait()
-                if let objects = objects.contents {
-                    for object in objects {
-                        if let key = object.key {
-                            let deleteRequest = S3.DeleteObjectRequest(bucket: self.bucket, key: key)
-                            _ = try s3.deleteObject(deleteRequest).wait()
-                        }
-                    }
-                }
-                let deleteRequest = S3.DeleteBucketRequest(bucket: self.bucket)
-                _ = try s3.deleteBucket(deleteRequest).wait()
-            }
+    override class func setUp() {
+        if TestEnvironment.isUsingLocalstack {
+            print("Connecting to Localstack")
+        } else {
+            print("Connecting to AWS")
         }
     }
 
@@ -84,7 +52,8 @@ class S3Tests: XCTestCase {
         return data
     }
     
-    func createBucket(name: String) -> EventLoopFuture<Void> {
+    func createBucket(name: String, s3: S3? = nil) -> EventLoopFuture<Void> {
+        let s3 = s3 ?? self.s3
         let bucketRequest = S3.CreateBucketRequest(bucket: name)
         return s3.createBucket(bucketRequest)
             .map { _ in }
@@ -103,18 +72,19 @@ class S3Tests: XCTestCase {
         }
     }
     
-    func deleteBucket(name: String) -> EventLoopFuture<Void> {
+    func deleteBucket(name: String, s3: S3? = nil) -> EventLoopFuture<Void> {
+        let s3 = s3 ?? self.s3
         let request = S3.ListObjectsV2Request(bucket: name)
         return s3.listObjectsV2(request)
             .flatMap { response -> EventLoopFuture<Void> in
-                let eventLoop = self.s3.client.eventLoopGroup.next()
+                let eventLoop = s3.client.eventLoopGroup.next()
                 guard let objects = response.contents else { return eventLoop.makeSucceededFuture(())}
-                let deleteFutureResults = objects.compactMap { $0.key.map { self.s3.deleteObject(.init(bucket: name, key: $0)) } }
+                let deleteFutureResults = objects.compactMap { $0.key.map { s3.deleteObject(.init(bucket: name, key: $0)) } }
                 return EventLoopFuture.andAllSucceed(deleteFutureResults, on: eventLoop)
         }
         .flatMap { _ in
             let request = S3.DeleteBucketRequest(bucket: name)
-            return self.s3.deleteBucket(request).map { _ in }
+            return s3.deleteBucket(request).map { _ in }
         }
     }
     
@@ -304,42 +274,42 @@ class S3Tests: XCTestCase {
             XCTAssertNoThrow(try httpClient.syncShutdown())
         }
         let s3 = S3(
-            accessKeyId: "key",
-            secretAccessKey: "secret",
             region: .euwest1,
-            endpoint: ProcessInfo.processInfo.environment["S3_ENDPOINT"] ?? "http://localhost:4572",
+            endpoint: TestEnvironment.getEndPoint(environment: "S3_ENDPOINT", default: "http://localhost:4572"),
+            middlewares: TestEnvironment.middlewares,
             httpClientProvider: .shared(httpClient)
         )
+        let name = TestEnvironment.generateResourceName()
+        let dataSize = 240*1024
+        let blockSize = 64*1024
+        let data = createRandomBuffer(size: 240*1024)
+        var byteBuffer = ByteBufferAllocator().buffer(capacity: dataSize)
+        byteBuffer.writeBytes(data)
 
-        attempt {
-            let testData = try TestData(#function, s3: s3)
-            // create buffer
-            let dataSize = 240*1024
-            var data = Data(count: dataSize)
-            for i in 0..<dataSize {
-                data[i] = UInt8.random(in:0...255)
-            }
-            var byteBuffer = ByteBufferAllocator().buffer(capacity: dataSize)
-            byteBuffer.writeBytes(data)
-
-            let blockSize = 64*1024
-            let payload = AWSPayload.stream(size: dataSize) { eventLoop in
-                let size = min(blockSize, byteBuffer.readableBytes)
-                if size == 0 {
-                    return eventLoop.makeSucceededFuture(byteBuffer)
+        let response = createBucket(name: name, s3: s3)
+            .flatMap { _ -> EventLoopFuture<Void> in
+                let payload = AWSPayload.stream(size: dataSize) { eventLoop in
+                    let size = min(blockSize, byteBuffer.readableBytes)
+                    if size == 0 {
+                        return eventLoop.makeSucceededFuture(byteBuffer)
+                    }
+                    let slice = byteBuffer.readSlice(length: size)!
+                    return eventLoop.makeSucceededFuture(slice)
                 }
-                let slice = byteBuffer.readSlice(length: size)!
-                return eventLoop.makeSucceededFuture(slice)
-            }
-            
-            let putRequest = S3.PutObjectRequest(body: payload, bucket: testData.bucket, key: "tempfile")
-            _ = try s3.putObject(putRequest).wait()
-
-            let getRequest = S3.GetObjectRequest(bucket: testData.bucket, key: "tempfile")
-            let response = try s3.getObject(getRequest).wait()
-
-            XCTAssertEqual(data, response.body?.asData())
+                let request = S3.PutObjectRequest(body: payload, bucket: name, key: "tempfile")
+                return s3.putObject(request).map { _ in }
         }
+        .flatMap { _ -> EventLoopFuture<S3.GetObjectOutput> in
+            return s3.getObject(.init(bucket: name, key: "tempfile"))
+        }
+        .map { response in
+            XCTAssertEqual(response.body?.asData(), data)
+        }
+        .flatAlways { _ in
+            self.deleteBucket(name: name, s3: s3)
+        }
+        
+        XCTAssertNoThrow(try response.wait())
     }
 
     /// test bucket location is correctly returned.
@@ -360,135 +330,149 @@ class S3Tests: XCTestCase {
 
     /// test lifecycle rules are uploaded and downloaded ok
     func testLifecycleRule() {
-        attempt {
-            let testData = try TestData(#function, s3: s3)
-
-            // set lifecycle rules
-            let incompleteMultipartUploads = S3.AbortIncompleteMultipartUpload(daysAfterInitiation: 7)  // clear incomplete multipart uploads after 7 days
-            let filter = S3.LifecycleRuleFilter(prefix: "")  // everything
-            let transitions = [S3.Transition(days: 14, storageClass: .glacier)]  // transition objects to glacier after 14 days
-            let lifecycleRules = S3.LifecycleRule(
-                abortIncompleteMultipartUpload: incompleteMultipartUploads,
-                filter: filter,
-                id: "aws-test",
-                status: .enabled,
-                transitions: transitions
-            )
-            let putBucketLifecycleRequest = S3.PutBucketLifecycleConfigurationRequest(
-                bucket: testData.bucket,
-                lifecycleConfiguration: S3.BucketLifecycleConfiguration(rules: [lifecycleRules])
-            )
-            try s3.putBucketLifecycleConfiguration(putBucketLifecycleRequest).wait()
-
-            // get lifecycle rules
-            let getBucketLifecycleRequest = S3.GetBucketLifecycleConfigurationRequest(bucket: testData.bucket)
-            let getBucketLifecycleResult = try s3.getBucketLifecycleConfiguration(getBucketLifecycleRequest).wait()
-
-            XCTAssertEqual(getBucketLifecycleResult.rules?[0].transitions?[0].storageClass, .glacier)
-            XCTAssertEqual(getBucketLifecycleResult.rules?[0].transitions?[0].days, 14)
-            XCTAssertEqual(getBucketLifecycleResult.rules?[0].abortIncompleteMultipartUpload?.daysAfterInitiation, 7)
+        let name = TestEnvironment.generateResourceName()
+        let response = createBucket(name: name)
+            .flatMap { _ -> EventLoopFuture<Void> in
+                // set lifecycle rules
+                let incompleteMultipartUploads = S3.AbortIncompleteMultipartUpload(daysAfterInitiation: 7)  // clear incomplete multipart uploads after 7 days
+                let filter = S3.LifecycleRuleFilter(prefix: "")  // everything
+                let transitions = [S3.Transition(days: 14, storageClass: .glacier)]  // transition objects to glacier after 14 days
+                let lifecycleRules = S3.LifecycleRule(
+                    abortIncompleteMultipartUpload: incompleteMultipartUploads,
+                    filter: filter,
+                    id: "aws-test",
+                    status: .enabled,
+                    transitions: transitions
+                )
+                let request = S3.PutBucketLifecycleConfigurationRequest(bucket: name, lifecycleConfiguration: .init(rules: [lifecycleRules]))
+                return self.s3.putBucketLifecycleConfiguration(request)
         }
+        .flatMap { _ in
+            return self.s3.getBucketLifecycleConfiguration(.init(bucket: name))
+        }
+        .map { response -> Void in
+            XCTAssertEqual(response.rules?[0].transitions?[0].storageClass, .glacier)
+            XCTAssertEqual(response.rules?[0].transitions?[0].days, 14)
+            XCTAssertEqual(response.rules?[0].abortIncompleteMultipartUpload?.daysAfterInitiation, 7)
+        }
+        .flatAlways { _ in
+            return self.deleteBucket(name: name)
+        }
+        XCTAssertNoThrow(try response.wait())
     }
 
     /// test metadata is uploaded and downloaded ok
     func testMetaData() {
-        attempt {
-            let testData = try TestData(#function, s3: s3)
-
-            let putObjectRequest = S3.PutObjectRequest(
-                body: .data(testData.bodyData),
-                bucket: testData.bucket,
-                key: testData.key,
-                metadata: ["Test": "testing", "first": "one"]
-            )
-            _ = try s3.putObject(putObjectRequest).wait()
-
-            let getObjectRequest = S3.GetObjectRequest(bucket: testData.bucket, key: testData.key)
-            let result = try s3.getObject(getObjectRequest).wait()
-            XCTAssertEqual(result.metadata?["test"], "testing")
-            XCTAssertEqual(result.metadata?["first"], "one")
+        let name = TestEnvironment.generateResourceName()
+        let contents = "testing metadata header"
+        let response = createBucket(name: name)
+            .flatMap { (_) -> EventLoopFuture<S3.PutObjectOutput> in
+                let putRequest = S3.PutObjectRequest(
+                    body: .string(contents),
+                    bucket: name,
+                    key: name,
+                    metadata: ["Test": "testing", "first": "one"]
+                )
+                return self.s3.putObject(putRequest)
         }
+        .flatMap { _ -> EventLoopFuture<S3.GetObjectOutput> in
+            return self.s3.getObject(.init(bucket: name, key: name))
+        }
+        .map { response -> Void in
+            XCTAssertEqual(response.metadata?["test"], "testing")
+            XCTAssertEqual(response.metadata?["first"], "one")
+        }
+        .flatAlways { _ in
+            return self.deleteBucket(name: name)
+        }
+        XCTAssertNoThrow(try response.wait())
     }
 
     func testMultipleUpload() {
-        attempt {
-            let testData = try TestData(#function, s3: s3)
-
-            // uploads 100 files at the same time and then downloads them to check they uploaded correctly
-            var responses: [EventLoopFuture<Void>] = []
-            for i in 0..<16 {
-                let objectName = "testMultiple\(i).txt"
-                let text = "Testing, testing,1,2,1,\(i)"
-
-                let request = S3.PutObjectRequest(body: .string(text), bucket: testData.bucket, key: objectName)
-                let response = s3.putObject(request)
-                    .flatMap { (response) -> EventLoopFuture<S3.GetObjectOutput> in
-                        let request = S3.GetObjectRequest(bucket: testData.bucket, key: objectName)
-                        return self.s3.getObject(request)
-                    }
-                    .flatMapThrowing { response in
-                        guard let body = response.body else { throw S3TestErrors.error("Get \(objectName) failed") }
-                        guard text == body.asString() else { throw S3TestErrors.error("Get \(objectName) contents is incorrect") }
-                        return
-                    }
-                responses.append(response)
+        func putGet(body: String, bucket: String, key: String) -> EventLoopFuture<Void> {
+            return s3.putObject(.init(body: .string(body), bucket: bucket, key: key))
+                .flatMap { _ in
+                    return self.s3.getObject(.init(bucket: bucket, key: key))
             }
-
-            let results = try EventLoopFuture.whenAllComplete(responses, on: s3.client.eventLoopGroup.next()).wait()
-
-            for r in results {
-                if case .failure(let error) = r {
-                    XCTFail(error.localizedDescription)
-                }
+            .flatMapThrowing { response in
+                let getBody = try XCTUnwrap(response.body)
+                XCTAssertEqual(getBody.asString(), body)
             }
         }
+        
+        let name = TestEnvironment.generateResourceName()
+        let eventLoop = s3.client.eventLoopGroup.next()
+        let response = createBucket(name: name)
+            .flatMap { (_) -> EventLoopFuture<Void> in
+                let futureResults = (1...32).map { index -> EventLoopFuture<Void> in
+                    let body = "testMultipleUpload - " + index.description
+                    let filename = "file" + index.description
+                    return putGet(body: body, bucket: name, key: filename)
+                }
+                return EventLoopFuture.whenAllSucceed(futureResults, on: eventLoop).map { _ in }
+        }
+        .flatAlways { _ in
+            return self.deleteBucket(name: name)
+        }
+        XCTAssertNoThrow(try response.wait())
     }
 
+    /// testing decoding of values in xml attributes
     func testGetAclRequestPayer() {
-        attempt {
-            let testData = try TestData(#function, s3: s3)
-            let putRequest = S3.PutObjectRequest(
-                body: .data(testData.bodyData),
-                bucket: testData.bucket,
-                contentLength: Int64(testData.bodyData.count),
-                key: testData.key
-            )
-            _ = try s3.putObject(putRequest).wait()
-            let request = S3.GetObjectAclRequest(bucket: testData.bucket, key: testData.key, requestPayer: .requester)
-            _ = try s3.getObjectAcl(request).wait()
+        let name = TestEnvironment.generateResourceName()
+        let contents = "testing metadata header"
+        let response = createBucket(name: name)
+            .flatMap { (_) -> EventLoopFuture<S3.PutObjectOutput> in
+                let putRequest = S3.PutObjectRequest(
+                    body: .string(contents),
+                    bucket: name,
+                    key: name,
+                    metadata: ["Test": "testing", "first": "one"]
+                )
+                return self.s3.putObject(putRequest)
         }
+        .flatMap { _ -> EventLoopFuture<S3.GetObjectAclOutput> in
+            return self.s3.getObjectAcl(.init(bucket: name, key: name, requestPayer: .requester))
+        }
+        .flatAlways { _ in
+            return self.deleteBucket(name: name)
+        }
+        XCTAssertNoThrow(try response.wait())
     }
 
     func testListPaginator() {
-        attempt {
-            let testData = try TestData(#function, s3: s3)
-
-            // uploads 16 files
-            var responses: [EventLoopFuture<Void>] = []
-            for i in 0..<16 {
-                let objectName = "testMultiple\(i).txt"
-                let text = "Testing, testing,1,2,1,\(i)"
-
-                let request = S3.PutObjectRequest(body: .string(text), bucket: testData.bucket, key: objectName)
-                let response = s3.putObject(request).map { _ in }
-                responses.append(response)
-            }
-            _ = try EventLoopFuture.whenAllSucceed(responses, on: s3.client.eventLoopGroup.next()).wait()
-
-            let request = S3.ListObjectsV2Request(bucket: testData.bucket, maxKeys: 5)
-            var list: [S3.Object] = []
-            try s3.listObjectsV2Paginator(request) { result, eventLoop in
+        let name = TestEnvironment.generateResourceName()
+        let eventLoop = s3.client.eventLoopGroup.next()
+        var list: [S3.Object] = []
+        let response = createBucket(name: name)
+            .flatMap { (_) -> EventLoopFuture<Void> in
+                // put 16 files into bucket
+                let futureResults: [EventLoopFuture<S3.PutObjectOutput>] = (1...16).map {
+                    let body = "testMultipleUpload - " + $0.description
+                    let filename = "file" + $0.description
+                    return self.s3.putObject(.init(body: .string(body), bucket: name, key: filename))
+                }
+                return EventLoopFuture.whenAllSucceed(futureResults, on: eventLoop).map { _ in }
+        }
+        .flatMap { _ in
+            return self.s3.listObjectsV2Paginator(.init(bucket: name, maxKeys: 5)) { result, eventLoop in
                 list.append(contentsOf: result.contents ?? [])
                 return eventLoop.makeSucceededFuture(true)
-            }.wait()
-
-            let request2 = S3.ListObjectsV2Request(bucket: testData.bucket)
-            let response = try s3.listObjectsV2(request2).wait()
-            XCTAssertEqual(list.count, 16)
+            }
+        }
+        .flatMap { _ in
+            return self.s3.listObjectsV2(.init(bucket: name))
+        }
+        .map { response in
+            XCTAssertEqual(list.count, response.contents?.count)
             for i in 0..<list.count {
                 XCTAssertEqual(list[i].key, response.contents?[i].key)
             }
         }
+        .flatAlways { _ in
+            return self.deleteBucket(name: name)
+        }
+        XCTAssertNoThrow(try response.wait())
     }
 
     func testS3VirtualAddressing(_ urlString: String) throws -> String {

--- a/Tests/AWSSDKSwiftTests/Services/S3/S3Tests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/S3/S3Tests.swift
@@ -403,7 +403,7 @@ class S3Tests: XCTestCase {
         let eventLoop = s3.client.eventLoopGroup.next()
         let response = createBucket(name: name)
             .flatMap { (_) -> EventLoopFuture<Void> in
-                let futureResults = (1...32).map { index -> EventLoopFuture<Void> in
+                let futureResults = (1...16).map { index -> EventLoopFuture<Void> in
                     let body = "testMultipleUpload - " + index.description
                     let filename = "file" + index.description
                     return putGet(body: body, bucket: name, key: filename)
@@ -419,21 +419,21 @@ class S3Tests: XCTestCase {
     /// testing decoding of values in xml attributes
     func testGetAclRequestPayer() {
         let name = TestEnvironment.generateResourceName()
-        let contents = "testing metadata header"
+        let contents = "testing xml attributes header"
         let response = createBucket(name: name)
             .flatMap { (_) -> EventLoopFuture<S3.PutObjectOutput> in
                 let putRequest = S3.PutObjectRequest(
                     body: .string(contents),
                     bucket: name,
-                    key: name,
-                    metadata: ["Test": "testing", "first": "one"]
+                    key: name
                 )
                 return self.s3.putObject(putRequest)
         }
         .flatMap { _ -> EventLoopFuture<S3.GetObjectAclOutput> in
             return self.s3.getObjectAcl(.init(bucket: name, key: name, requestPayer: .requester))
         }
-        .flatAlways { _ in
+        .flatAlways { response -> EventLoopFuture<Void> in
+            print(response)
             return self.deleteBucket(name: name)
         }
         XCTAssertNoThrow(try response.wait())

--- a/Tests/AWSSDKSwiftTests/Services/S3/S3Tests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/S3/S3Tests.swift
@@ -490,25 +490,11 @@ class S3Tests: XCTestCase {
     }
 
     func testS3VirtualAddressing() {
-        attempt {
-            XCTAssertEqual(try testS3VirtualAddressing("https://s3.us-east-1.amazonaws.com/bucket"), "https://bucket.s3.us-east-1.amazonaws.com/")
-            XCTAssertEqual(
-                try testS3VirtualAddressing("https://s3.us-east-1.amazonaws.com/bucket/filename"),
-                "https://bucket.s3.us-east-1.amazonaws.com/filename"
-            )
-            XCTAssertEqual(
-                try testS3VirtualAddressing("https://s3.us-east-1.amazonaws.com/bucket/filename?test=test&test2=test2"),
-                "https://bucket.s3.us-east-1.amazonaws.com/filename?test=test&test2=test2"
-            )
-            XCTAssertEqual(
-                try testS3VirtualAddressing("https://s3.us-east-1.amazonaws.com/bucket/filename?test=%3D"),
-                "https://bucket.s3.us-east-1.amazonaws.com/filename?test=%3D"
-            )
-            XCTAssertEqual(
-                try testS3VirtualAddressing("https://s3.us-east-1.amazonaws.com/bucket/file%20name"),
-                "https://bucket.s3.us-east-1.amazonaws.com/file%20name"
-            )
-        }
+        XCTAssertEqual(try testS3VirtualAddressing("https://s3.us-east-1.amazonaws.com/bucket"), "https://bucket.s3.us-east-1.amazonaws.com/")
+        XCTAssertEqual(try testS3VirtualAddressing("https://s3.us-east-1.amazonaws.com/bucket/filename"), "https://bucket.s3.us-east-1.amazonaws.com/filename")
+        XCTAssertEqual(try testS3VirtualAddressing("https://s3.us-east-1.amazonaws.com/bucket/filename?test=test&test2=test2"), "https://bucket.s3.us-east-1.amazonaws.com/filename?test=test&test2=test2")
+        XCTAssertEqual(try testS3VirtualAddressing("https://s3.us-east-1.amazonaws.com/bucket/filename?test=%3D"), "https://bucket.s3.us-east-1.amazonaws.com/filename?test=%3D")
+        XCTAssertEqual(try testS3VirtualAddressing("https://s3.us-east-1.amazonaws.com/bucket/file%20name"), "https://bucket.s3.us-east-1.amazonaws.com/file%20name")
     }
 
     static var allTests: [(String, (S3Tests) -> () throws -> Void)] {

--- a/Tests/AWSSDKSwiftTests/Services/SNS/SNSTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/SNS/SNSTests.swift
@@ -25,88 +25,85 @@ enum SNSTestsError: Error {
 
 class SNSTests: XCTestCase {
 
-    let client = SNS(
-        accessKeyId: "key",
-        secretAccessKey: "secret",
+    let sns = SNS(
         region: .useast1,
-        endpoint: ProcessInfo.processInfo.environment["SNS_ENDPOINT"] ?? "http://localhost:4575",
-        middlewares: (ProcessInfo.processInfo.environment["AWS_ENABLE_LOGGING"] == "true") ? [AWSLoggingMiddleware()] : [],
+        endpoint: TestEnvironment.getEndPoint(environment: "SNS_ENDPOINT", default: "http://localhost:4575"),
+        middlewares: TestEnvironment.middlewares,
         httpClientProvider: .createNew
     )
 
-    class TestData {
-        var client: SNS
-        var topicName: String
-        var topicArn: String
-
-        init(_ testName: String, client: SNS) throws {
-            let testName = testName.lowercased().filter { return $0.isLetter }
-            self.client = client
-            self.topicName = "\(testName)-topic"
-
-            let request = SNS.CreateTopicInput(name: topicName)
-            let response = try client.createTopic(request).wait()
-            guard let topicArn = response.topicArn else { throw SNSTestsError.noTopicArn }
-
-            self.topicArn = topicArn
+    /// create SNS topic with supplied name and run supplied closure
+    func testTopic(name: String, body: @escaping (String) -> EventLoopFuture<Void>) -> EventLoopFuture<Void> {
+        let eventLoop = self.sns.client.eventLoopGroup.next()
+        var topicArn : String? = nil
+        
+        let request = SNS.CreateTopicInput(name: name)
+        return sns.createTopic(request)
+            .flatMapThrowing { response in
+                topicArn = try XCTUnwrap(response.topicArn)
+                return topicArn!
         }
-
-        deinit {
-            attempt {
-                // disabled until we get valid topic arn's returned from Localstack
-                #if false
-                    let request = SNS.DeleteTopicInput(topicArn: self.topicArn)
-                    _ = try client.deleteTopic(request).wait()
-                #endif
+        .flatMap(body)
+        .flatAlways { (_) -> EventLoopFuture<Void> in
+            if let topicArn = topicArn {
+                let request = SNS.DeleteTopicInput(topicArn: topicArn)
+                return self.sns.deleteTopic(request)
+            } else {
+                return eventLoop.makeSucceededFuture(())
             }
         }
     }
-
+    
     //MARK: TESTS
 
     func testCreateDelete() {
-        attempt {
-            _ = try TestData(#function, client: client)
+        let name = TestEnvironment.getName(#function)
+        let response = testTopic(name: name) { topicArn in
+            return self.sns.client.eventLoopGroup.next().makeSucceededFuture(())
         }
+        XCTAssertNoThrow(try response.wait())
     }
 
     func testListTopics() {
-        attempt {
-            let testData = try TestData(#function, client: client)
-
+        let name = TestEnvironment.getName(#function)
+        let response = testTopic(name: name) { topicArn in
             let request = SNS.ListTopicsInput()
-            let response = try client.listTopics(request).wait()
-            let topic = response.topics?.first { $0.topicArn == testData.topicArn }
-            XCTAssertNotNil(topic)
+            return self.sns.listTopics(request)
+                .map { response in
+                    let topic = response.topics?.first { $0.topicArn == topicArn }
+                    XCTAssertNotNil(topic)
+            }
         }
+        XCTAssertNoThrow(try response.wait())
     }
 
     // disabled until we get valid topic arn's returned from Localstack
-    #if false
-        func testSetTopicAttributes() {
-            attempt {
-                let testData = try TestData(#function, client: client)
-
-                let setTopicAttributesInput = SNS.SetTopicAttributesInput(
-                    attributeName: "DisplayName",
-                    attributeValue: "aws-test topic",
-                    topicArn: testData.topicArn
-                )
-                try client.setTopicAttributes(setTopicAttributesInput).wait()
-
-                let getTopicAttributesInput = SNS.GetTopicAttributesInput(topicArn: testData.topicArn)
-                let getTopicAttributesResponse = try client.getTopicAttributes(getTopicAttributesInput).wait()
-
-                XCTAssertEqual(getTopicAttributesResponse.attributes?["DisplayName"], "aws-test topic")
+    func testSetTopicAttributes() {
+        guard !TestEnvironment.isUsingLocalstack else { return }
+        let name = TestEnvironment.getName(#function)
+        let response = testTopic(name: name) { topicArn in
+            let request = SNS.SetTopicAttributesInput(
+                attributeName: "DisplayName",
+                attributeValue: "aws-test topic &",
+                topicArn: topicArn
+            )
+            return self.sns.setTopicAttributes(request)
+                .flatMap { (_) -> EventLoopFuture<SNS.GetTopicAttributesResponse> in
+                    let request = SNS.GetTopicAttributesInput(topicArn: topicArn)
+                    return self.sns.getTopicAttributes(request)
+            }
+            .map { response in
+                XCTAssertEqual(response.attributes?["DisplayName"], "aws-test topic &")
             }
         }
-    #endif
+        XCTAssertNoThrow(try response.wait())
+    }
 
     static var allTests: [(String, (SNSTests) -> () throws -> Void)] {
         return [
             ("testCreateDelete", testCreateDelete),
             ("testListTopics", testListTopics),
-            //            ("testSetTopicAttributes", testSetTopicAttributes),
+            ("testSetTopicAttributes", testSetTopicAttributes),
         ]
     }
 }

--- a/Tests/AWSSDKSwiftTests/Services/SNS/SNSTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/SNS/SNSTests.swift
@@ -57,7 +57,7 @@ class SNSTests: XCTestCase {
     //MARK: TESTS
 
     func testCreateDelete() {
-        let name = TestEnvironment.getName(#function)
+        let name = TestEnvironment.generateResourceName()
         let response = testTopic(name: name) { topicArn in
             return self.sns.client.eventLoopGroup.next().makeSucceededFuture(())
         }
@@ -65,7 +65,7 @@ class SNSTests: XCTestCase {
     }
 
     func testListTopics() {
-        let name = TestEnvironment.getName(#function)
+        let name = TestEnvironment.generateResourceName()
         let response = testTopic(name: name) { topicArn in
             let request = SNS.ListTopicsInput()
             return self.sns.listTopics(request)
@@ -80,7 +80,7 @@ class SNSTests: XCTestCase {
     // disabled until we get valid topic arn's returned from Localstack
     func testSetTopicAttributes() {
         guard !TestEnvironment.isUsingLocalstack else { return }
-        let name = TestEnvironment.getName(#function)
+        let name = TestEnvironment.generateResourceName()
         let response = testTopic(name: name) { topicArn in
             let request = SNS.SetTopicAttributesInput(
                 attributeName: "DisplayName",

--- a/Tests/AWSSDKSwiftTests/Services/SNS/SNSTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/SNS/SNSTests.swift
@@ -26,11 +26,21 @@ enum SNSTestsError: Error {
 class SNSTests: XCTestCase {
 
     let sns = SNS(
+        accessKeyId: TestEnvironment.accessKeyId,
+        secretAccessKey: TestEnvironment.secretAccessKey,
         region: .useast1,
         endpoint: TestEnvironment.getEndPoint(environment: "SNS_ENDPOINT", default: "http://localhost:4575"),
         middlewares: TestEnvironment.middlewares,
         httpClientProvider: .createNew
     )
+
+    override class func setUp() {
+        if TestEnvironment.isUsingLocalstack {
+            print("Connecting to Localstack")
+        } else {
+            print("Connecting to AWS")
+        }
+    }
 
     /// create SNS topic with supplied name and run supplied closure
     func testTopic(name: String, body: @escaping (String) -> EventLoopFuture<Void>) -> EventLoopFuture<Void> {

--- a/Tests/AWSSDKSwiftTests/Services/SNS/SNSTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/SNS/SNSTests.swift
@@ -12,14 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import XCTest
-
 @testable import AWSSNS
-
-enum SNSTestsError: Error {
-    case noTopicArn
-}
 
 // testing query service
 

--- a/Tests/AWSSDKSwiftTests/Services/SQS/SQSTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/SQS/SQSTests.swift
@@ -32,6 +32,14 @@ class SQSTests: XCTestCase {
         httpClientProvider: .createNew
     )
 
+    override class func setUp() {
+        if TestEnvironment.isUsingLocalstack {
+            print("Connecting to Localstack")
+        } else {
+            print("Connecting to AWS")
+        }
+    }
+
     /// create SQS queue with supplied name and run supplied closure
     func testQueue(name: String, body: @escaping (String) -> EventLoopFuture<Void>) -> EventLoopFuture<Void> {
         let eventLoop = self.sqs.client.eventLoopGroup.next()

--- a/Tests/AWSSDKSwiftTests/Services/SQS/SQSTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/SQS/SQSTests.swift
@@ -12,14 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import XCTest
-
 @testable import AWSSQS
-
-enum SQSTestsError: Error {
-    case noQueueUrl
-}
 
 // testing query service
 

--- a/Tests/AWSSDKSwiftTests/Services/SQS/SQSTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/SQS/SQSTests.swift
@@ -32,32 +32,6 @@ class SQSTests: XCTestCase {
         httpClientProvider: .createNew
     )
 
-    class TestData {
-        var sqs: SQS
-        var queueName: String
-        var queueUrl: String
-
-        init(_ testName: String, sqs: SQS) throws {
-            let testName = testName.lowercased().filter { return $0.isLetter }
-            self.sqs = sqs
-            self.queueName = "\(testName)-queue"
-
-            let request = SQS.CreateQueueRequest(queueName: self.queueName)
-            let response = try sqs.createQueue(request).wait()
-            XCTAssertNotNil(response.queueUrl)
-            guard let queueUrl = response.queueUrl else { throw SQSTestsError.noQueueUrl }
-
-            self.queueUrl = queueUrl
-        }
-
-        deinit {
-            attempt {
-                let request = SQS.DeleteQueueRequest(queueUrl: self.queueUrl)
-                try sqs.deleteQueue(request).wait()
-            }
-        }
-    }
-
     /// create SQS queue with supplied name and run supplied closure
     func testQueue(name: String, body: @escaping (String) -> EventLoopFuture<Void>) -> EventLoopFuture<Void> {
         let eventLoop = self.sqs.client.eventLoopGroup.next()

--- a/Tests/AWSSDKSwiftTests/Services/SSM/SSMTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/SSM/SSMTests.swift
@@ -12,14 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import XCTest
-
 @testable import AWSSSM
-
-enum SSMTestsError: Error {
-    case noTopicArn
-}
 
 // testing json service
 

--- a/Tests/AWSSDKSwiftTests/Services/SSM/SSMTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/SSM/SSMTests.swift
@@ -32,29 +32,6 @@ class SSMTests: XCTestCase {
         httpClientProvider: .createNew
     )
 
-    class TestData {
-        var ssm: SSM
-        var parameterName: String
-        var parameterValue: String
-
-        init(_ testName: String, ssm: SSM) throws {
-            self.ssm = ssm
-            let testName = testName.lowercased().filter { return $0.isLetter || $0.isNumber }
-            self.parameterName = "/awssdkswift/\(testName)"
-            self.parameterValue = "value:\(testName)"
-
-            let request = SSM.PutParameterRequest(name: parameterName, overwrite: true, type: .string, value: parameterValue)
-            _ = try ssm.putParameter(request).wait()
-        }
-
-        deinit {
-            attempt {
-                let request = SSM.DeleteParameterRequest(name: parameterName)
-                _ = try ssm.deleteParameter(request).wait()
-            }
-        }
-    }
-
     func putParameter(name: String, value: String) -> EventLoopFuture<Void> {
         let request = SSM.PutParameterRequest(name: name, overwrite: true, type: .string, value: value)
         return ssm.putParameter(request).map { _ in }

--- a/Tests/AWSSDKSwiftTests/Services/SSM/SSMTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/SSM/SSMTests.swift
@@ -45,7 +45,8 @@ class SSMTests: XCTestCase {
     //MARK: TESTS
 
     func testGetParameter() {
-        let name = TestEnvironment.generateResourceName()
+        // parameter names cannot begin wih "aws"
+        let name = "test" + TestEnvironment.generateResourceName()
         let response = putParameter(name: name, value: "testdata")
             .flatMap { (_) -> EventLoopFuture<SSM.GetParameterResult> in
                 let request = SSM.GetParameterRequest(name: name)
@@ -63,10 +64,10 @@ class SSMTests: XCTestCase {
     }
 
     func testGetParametersByPath() {
-        let name = "/awssdkswift/" + TestEnvironment.generateResourceName()
+        let name = "/test/" + TestEnvironment.generateResourceName()
         let response = putParameter(name: name, value: "testdata2")
             .flatMap { (_) -> EventLoopFuture<SSM.GetParametersByPathResult> in
-                let request = SSM.GetParametersByPathRequest(path: "/awssdkswift/")
+                let request = SSM.GetParametersByPathRequest(path: "/test/")
                 return self.ssm.getParametersByPath(request)
         }
         .flatMapThrowing { response in

--- a/Tests/AWSSDKSwiftTests/Services/SSM/SSMTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/SSM/SSMTests.swift
@@ -32,6 +32,14 @@ class SSMTests: XCTestCase {
         httpClientProvider: .createNew
     )
 
+    override class func setUp() {
+        if TestEnvironment.isUsingLocalstack {
+            print("Connecting to Localstack")
+        } else {
+            print("Connecting to AWS")
+        }
+    }
+
     func putParameter(name: String, value: String) -> EventLoopFuture<Void> {
         let request = SSM.PutParameterRequest(name: name, overwrite: true, type: .string, value: value)
         return ssm.putParameter(request).map { _ in }

--- a/Tests/AWSSDKSwiftTests/Services/STS/STSTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/STS/STSTests.swift
@@ -19,7 +19,7 @@ import XCTest
 
 class STSTests: XCTestCase {
 
-    let sqs = STS(
+    let sts = STS(
         region: .useast1,
         endpoint: TestEnvironment.getEndPoint(environment: "STS_ENDPOINT", default: "http://localhost:4592"),
         middlewares: TestEnvironment.middlewares,
@@ -34,11 +34,31 @@ class STSTests: XCTestCase {
         }
     }
 
+    func testGetCallerIdentity() {
+        let response = sts.getCallerIdentity(.init())
+        XCTAssertNoThrow(try response.wait())
+    }
+
+    func testErrorCodes() {
+        let request = STS.AssumeRoleWithWebIdentityRequest(roleArn: "arn:aws:iam::000000000000:role/Admin", roleSessionName: "now", webIdentityToken: "webtoken")
+        let response = sts.assumeRoleWithWebIdentity(request)
+            .map { _ in }
+            .flatMapErrorThrowing { error in
+                switch error {
+                case STSErrorType.invalidIdentityTokenException(_):
+                    return
+                default:
+                    throw error
+                }
+        }
+        XCTAssertNoThrow(try response.wait())
+    }
 
 
-    static var allTests: [(String, (SQSTests) -> () throws -> Void)] {
+    static var allTests: [(String, (STSTests) -> () throws -> Void)] {
         return [
- //           ("testSendReceiveAndDelete", testSendReceiveAndDelete),
+            ("testGetCallerIdentity", testGetCallerIdentity),
+            ("testErrorCodes", testErrorCodes),
         ]
     }
 }

--- a/Tests/AWSSDKSwiftTests/Services/STS/STSTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/STS/STSTests.swift
@@ -1,0 +1,45 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the AWSSDKSwift open source project
+//
+// Copyright (c) 2017-2020 the AWSSDKSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of AWSSDKSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+@testable import AWSSTS
+
+// testing query service
+
+class STSTests: XCTestCase {
+
+    let sqs = STS(
+        region: .useast1,
+        endpoint: TestEnvironment.getEndPoint(environment: "STS_ENDPOINT", default: "http://localhost:4592"),
+        middlewares: TestEnvironment.middlewares,
+        httpClientProvider: .createNew
+    )
+
+    override class func setUp() {
+        if TestEnvironment.isUsingLocalstack {
+            print("Connecting to Localstack")
+        } else {
+            print("Connecting to AWS")
+        }
+    }
+
+
+
+    static var allTests: [(String, (SQSTests) -> () throws -> Void)] {
+        return [
+ //           ("testSendReceiveAndDelete", testSendReceiveAndDelete),
+        ]
+    }
+}
+

--- a/Tests/AWSSDKSwiftTests/test.swift
+++ b/Tests/AWSSDKSwiftTests/test.swift
@@ -17,21 +17,6 @@ import Foundation
 import NIO
 import XCTest
 
-func attempt(function: () throws -> Void) {
-    do {
-        try function()
-    } catch let error as AWSErrorType {
-        XCTFail("\(error)")
-    } catch DecodingError.typeMismatch(let type, let context) {
-        print(type, context)
-        XCTFail()
-    } catch let error as NIO.ChannelError {
-        XCTFail("\(error)")
-    } catch {
-        XCTFail("\(error)")
-    }
-}
-
 extension EventLoopFuture {
     /// When EventLoopFuture has any result the callback is called with the Result. The callback returns an EventLoopFuture<>
     /// which should be completed before result is passed on

--- a/Tests/AWSSDKSwiftTests/test.swift
+++ b/Tests/AWSSDKSwiftTests/test.swift
@@ -38,7 +38,13 @@ extension EventLoopFuture {
 struct TestEnvironment {
     /// are we using Localstack to test
     static var isUsingLocalstack: Bool { return ProcessInfo.processInfo.environment["AWS_DISABLE_LOCALSTACK"] != "true" }
-    
+
+    /// access key id. Some services on Localstack require some semblence of an authorisation header, even though it doesnt test if it is valid
+    static var accessKeyId: String? { return isUsingLocalstack ? "foo" : nil }
+
+    /// secret access key. Some services on Localstack require some semblence of an authorisation header, even though it doesnt test if it is valid
+    static var secretAccessKey: String? { return isUsingLocalstack ? "bar" : nil }
+
     /// current list of middleware
     static var middlewares: [AWSServiceMiddleware] {
         return (ProcessInfo.processInfo.environment["AWS_ENABLE_LOGGING"] == "true") ? [AWSLoggingMiddleware()] : []
@@ -54,4 +60,5 @@ struct TestEnvironment {
     static func generateResourceName(_ function: String = #function) -> String {
         return "awssdkswift-" + function.filter { $0.isLetter }
     }
+    
 }

--- a/Tests/AWSSDKSwiftTests/test.swift
+++ b/Tests/AWSSDKSwiftTests/test.swift
@@ -37,6 +37,10 @@ func endpoint(environment: String, default: String) -> String? {
     return ProcessInfo.processInfo.environment[environment] ?? `default`
 }
 
+func middlewares() -> [AWSServiceMiddleware] {
+    return (ProcessInfo.processInfo.environment["AWS_ENABLE_LOGGING"] == "true") ? [AWSLoggingMiddleware()] : []
+}
+
 extension EventLoopFuture {
     // When EventLoopFuture has any result the callback is called with the Result. The callback returns an EventLoopFuture<>
     // which should be completed before result is passed on

--- a/Tests/AWSSDKSwiftTests/test.swift
+++ b/Tests/AWSSDKSwiftTests/test.swift
@@ -66,7 +66,7 @@ struct TestEnvironment {
     }
     
     /// get name to use for AWS resource
-    static func getName(_ function: String) -> String {
+    static func generateResourceName(_ function: String = #function) -> String {
         return "awssdkswift-" + function.filter { $0.isLetter }
     }
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -19,9 +19,11 @@ import XCTest
 XCTMain([
     testCase(APIGatewayTests.allTests),
     testCase(AWSRequestTests.allTests),
-    testCase(IAMTests.allTests),
     testCase(DynamoDBTests.allTests),
+    testCase(IAMTests.allTests),
     testCase(S3Tests.allTests),
     testCase(SNSTests.allTests),
     testCase(SQSTests.allTests),
+    testCase(SSMTests.allTests),
+    testCase(STSTests.allTests),
 ])

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,12 +24,13 @@ services:
       - SNS_ENDPOINT=http://localstack:4575
       - SQS_ENDPOINT=http://localstack:4576
       - SSM_ENDPOINT=http://localstack:4583
+      - STS_ENDPOINT=http://localstack:4592
     command: /bin/bash -xcl "swift test"
 
   localstack:
     image: localstack/localstack
     environment:
-      - SERVICES=apigateway,dynamodb,iam,s3,sns,sqs,ssm
+      - SERVICES=apigateway,dynamodb,iam,s3,sns,sqs,ssm,sts
     volumes:
       - "/tmp/localstack:/tmp/localstack"
 

--- a/scripts/localstack.sh
+++ b/scripts/localstack.sh
@@ -17,7 +17,7 @@ get_container_id()
 start()
 {
     if [ -z "$CONTAINER_ID" ]; then
-        docker run -d -p 4567-4597:4567-4597 -e SERVICES='apigateway,dynamodb,iam,s3,sns,sqs,ssm' localstack/localstack
+        docker run -d -p 4567-4597:4567-4597 -e SERVICES='apigateway,dynamodb,iam,s3,sns,sqs,ssm,sts' localstack/localstack
     else
         echo "Localstack is already running"
     fi


### PR DESCRIPTION
- All tests now use chaining so there is only one response.
- Each test ends with `XCTAssertNoThrow(try response.wait())`
- Got rid of `TestData` objects and replaced with helper functions that can be included in chain. 
- Extended `EventLoopFuture` with `flatAlways` which is similar to `always` except the callback returns an `EventLoopFuture`.
- Add `TestEnvironment` object which holds any data common to all tests.
- When environment variable AWS_DISABLE_LOCALSTACK is set to true, the tests will talk to AWS servers instead of Localstack.
