### PR TITLE
Cleanup S3 paths when an endpoint is set

### DIFF
--- a/Sources/AWSSDKSwift/Extensions/S3/S3RequestMiddleware.swift
+++ b/Sources/AWSSDKSwift/Extensions/S3/S3RequestMiddleware.swift
@@ -44,7 +44,7 @@ public struct S3RequestMiddleware: AWSServiceMiddleware {
 
     func virtualAddressFixup(request: inout AWSRequest) {
         /// process URL into form ${bucket}.s3.amazon.com
-        let paths = request.url.path.components(separatedBy: "/").filter({ $0 != "" })
+        let paths = request.url.path.split(separator: "/", omittingEmptySubsequences: true)
         if paths.count > 0 {
             guard var host = request.url.host else { return }
             if let port = request.url.port {
@@ -57,7 +57,7 @@ public struct S3RequestMiddleware: AWSServiceMiddleware {
             if host.contains("amazonaws.com") && !bucket.contains(".") {
                 let pathsWithoutBucket = paths.dropFirst()  // bucket
                 urlPath = pathsWithoutBucket.joined(separator: "/")
-                if let firstHostComponent = host.components(separatedBy: ".").first, bucket == firstHostComponent {
+                if let firstHostComponent = host.split(separator: ".").first, bucket == firstHostComponent {
                     // Bucket name is part of host. No need to append bucket
                     urlHost = host
                 } else {

--- a/Tests/AWSSDKSwiftTests/Services/S3/S3Tests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/S3/S3Tests.swift
@@ -490,10 +490,14 @@ class S3Tests: XCTestCase {
 
     func testS3VirtualAddressing() {
         XCTAssertEqual(try testS3VirtualAddressing("https://s3.us-east-1.amazonaws.com/bucket"), "https://bucket.s3.us-east-1.amazonaws.com/")
-        XCTAssertEqual(try testS3VirtualAddressing("https://s3.us-east-1.amazonaws.com/bucket/filename"), "https://bucket.s3.us-east-1.amazonaws.com/filename")
+        XCTAssertEqual(try testS3VirtualAddressing("https://s3.us-east-1.amazonaws.com/bucket//filename"), "https://bucket.s3.us-east-1.amazonaws.com/filename")
         XCTAssertEqual(try testS3VirtualAddressing("https://s3.us-east-1.amazonaws.com/bucket/filename?test=test&test2=test2"), "https://bucket.s3.us-east-1.amazonaws.com/filename?test=test&test2=test2")
         XCTAssertEqual(try testS3VirtualAddressing("https://s3.us-east-1.amazonaws.com/bucket/filename?test=%3D"), "https://bucket.s3.us-east-1.amazonaws.com/filename?test=%3D")
         XCTAssertEqual(try testS3VirtualAddressing("https://s3.us-east-1.amazonaws.com/bucket/file%20name"), "https://bucket.s3.us-east-1.amazonaws.com/file%20name")
+        XCTAssertEqual(try testS3VirtualAddressing("http://localhost:8000/bucket/filename"), "http://localhost:8000/bucket/filename")
+        XCTAssertEqual(try testS3VirtualAddressing("http://localhost:8000//bucket/filename"), "http://localhost:8000/bucket/filename")
+        XCTAssertEqual(try testS3VirtualAddressing("http://localhost:8000/bucket//filename"), "http://localhost:8000/bucket/filename")
+        XCTAssertEqual(try testS3VirtualAddressing("https://localhost:8000/bucket/file%20name"), "https://localhost:8000/bucket/file%20name")
     }
 
     static var allTests: [(String, (S3Tests) -> () throws -> Void)] {
@@ -508,6 +512,7 @@ class S3Tests: XCTestCase {
             ("testMetaData", testMetaData),
             ("testMultipleUpload", testMultipleUpload),
             ("testListPaginator", testListPaginator),
+            ("testS3VirtualAddressing", testS3VirtualAddressing)
         ]
     }
 }


### PR DESCRIPTION
We now cleanup S3 URLs even if they don't use virtual addressing.
Added additional tests in `S3Tests.testS3VirtualAddressing`
One thing of note, aws-sdk-go provide options to disable the URL cleanup. This might be something we want to add but we have no mechanism for adding options to a service yet will add a separate issue for this.