### PR TITLE
Don't output partition endpoint for regionalized services

### DIFF
--- a/Sources/AWSSDKSwift/Services/S3/S3_API.swift
+++ b/Sources/AWSSDKSwift/Services/S3/S3_API.swift
@@ -63,7 +63,6 @@ public struct S3 {
             apiVersion: "2006-03-01",
             endpoint: endpoint,
             serviceEndpoints: ["af-south-1": "s3.af-south-1.amazonaws.com", "ap-east-1": "s3.ap-east-1.amazonaws.com", "ap-northeast-1": "s3.ap-northeast-1.amazonaws.com", "ap-northeast-2": "s3.ap-northeast-2.amazonaws.com", "ap-south-1": "s3.ap-south-1.amazonaws.com", "ap-southeast-1": "s3.ap-southeast-1.amazonaws.com", "ap-southeast-2": "s3.ap-southeast-2.amazonaws.com", "aws-global": "s3.amazonaws.com", "ca-central-1": "s3.ca-central-1.amazonaws.com", "eu-central-1": "s3.eu-central-1.amazonaws.com", "eu-north-1": "s3.eu-north-1.amazonaws.com", "eu-south-1": "s3.eu-south-1.amazonaws.com", "eu-west-1": "s3.eu-west-1.amazonaws.com", "eu-west-2": "s3.eu-west-2.amazonaws.com", "eu-west-3": "s3.eu-west-3.amazonaws.com", "me-south-1": "s3.me-south-1.amazonaws.com", "sa-east-1": "s3.sa-east-1.amazonaws.com", "us-east-1": "s3.us-east-1.amazonaws.com", "us-east-2": "s3.us-east-2.amazonaws.com", "us-gov-east-1": "s3.us-gov-east-1.amazonaws.com", "us-gov-west-1": "s3.us-gov-west-1.amazonaws.com", "us-west-1": "s3.us-west-1.amazonaws.com", "us-west-2": "s3.us-west-2.amazonaws.com"],
-            partitionEndpoints: [.aws: (endpoint: "aws-global", region: .useast1)],
             retryPolicy: retryPolicy,
             middlewares: middlewares,
             possibleErrorTypes: [S3ErrorType.self],


### PR DESCRIPTION
For services that are explicitly regionalized don't output partition endpoint ie s3