### PR TITLE
Request middleware changes for HTTPHeaders

### DIFF
--- a/Sources/AWSSDKSwift/Extensions/APIGateway/APIGatewayMiddleware.swift
+++ b/Sources/AWSSDKSwift/Extensions/APIGateway/APIGatewayMiddleware.swift
@@ -18,8 +18,8 @@ public struct APIGatewayMiddleware: AWSServiceMiddleware {
     public func chain(request: AWSRequest) throws -> AWSRequest {
         var request = request
         // have to set Accept header to application/json otherwise errors are not returned correctly
-        if request.httpHeaders["Accept"] == nil {
-            request.httpHeaders["Accept"] = "application/json"
+        if request.httpHeaders["Accept"].first == nil {
+            request.httpHeaders.replaceOrAdd(name: "Accept", value: "application/json")
         }
         return request
     }

--- a/Sources/AWSSDKSwift/Extensions/Glacier/GlacierRequestMiddleware.swift
+++ b/Sources/AWSSDKSwift/Extensions/Glacier/GlacierRequestMiddleware.swift
@@ -33,14 +33,12 @@ public struct GlacierRequestMiddleware: AWSServiceMiddleware {
 
     public func chain(request: AWSRequest) throws -> AWSRequest {
         var request = request
-        request.addValue(apiVersion, forHTTPHeaderField: "x-amz-glacier-version")
+        request.httpHeaders.replaceOrAdd(name: "x-amz-glacier-version", value: apiVersion)
 
-        let treeHashHeader = "x-amz-sha256-tree-hash"
-
-        if request.httpHeaders[treeHashHeader] == nil {
+        if request.httpHeaders["x-amz-sha256-tree-hash"].first == nil {
             if let byteBuffer = request.body.asByteBuffer() {
                 let treeHash = try computeTreeHash(byteBuffer).hexDigest()
-                request.addValue(treeHash, forHTTPHeaderField: treeHashHeader)
+                request.httpHeaders.replaceOrAdd(name: "x-amz-sha256-tree-hash",  value: treeHash)
             }
         }
 

--- a/Sources/AWSSDKSwift/Extensions/S3Control/S3ControlMiddleware.swift
+++ b/Sources/AWSSDKSwift/Extensions/S3Control/S3ControlMiddleware.swift
@@ -33,8 +33,8 @@ public struct S3ControlMiddleware: AWSServiceMiddleware {
     }
 
     func virtualAddressFixup(request: inout AWSRequest) {
-        /// process URL into form ${account-id}.s3control.${region}.amazon.com
-        guard let accountId = request.httpHeaders["x-amz-account-id"] else { return }
+        /// convert URL into form ${account-id}.s3control.${region}.amazon.com
+        guard let accountId = request.httpHeaders["x-amz-account-id"].first else { return }
         guard let host = request.url.host else { return }
         let urlHost = "\(accountId).\(host)"
         var urlPath = "\(urlHost)\(request.url.path)"


### PR DESCRIPTION
Changes required for https://github.com/swift-aws/aws-sdk-swift-core/pull/301

Mainly replacing dictionary lookup for `HTTPHeader` interfaces.
Also remove S3RequestMiddleware.metadataFixup(request:) as it unnecessary as work is done in aws-sdk-swift-core