### PR TITLE
STS/CognitoIdentity credential providers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -295,7 +295,7 @@ let package = Package(
         .target(name: "AWSCodeStar", dependencies: ["AWSSDKSwiftCore"], path: "./Sources/AWSSDKSwift/Services/CodeStar"),
         .target(name: "AWSCodeStarNotifications", dependencies: ["AWSSDKSwiftCore"], path: "./Sources/AWSSDKSwift/Services/CodeStarNotifications"),
         .target(name: "AWSCodeStarconnections", dependencies: ["AWSSDKSwiftCore"], path: "./Sources/AWSSDKSwift/Services/CodeStarconnections"),
-        .target(name: "AWSCognitoIdentity", dependencies: ["AWSSDKSwiftCore"], path: "./Sources/AWSSDKSwift/Services/CognitoIdentity"),
+        .target(name: "AWSCognitoIdentity", dependencies: ["AWSSDKSwiftCore"], path: "./Sources/AWSSDKSwift/", sources: ["Services/CognitoIdentity", "Extensions/CognitoIdentity"]),
         .target(name: "AWSCognitoIdentityProvider", dependencies: ["AWSSDKSwiftCore"], path: "./Sources/AWSSDKSwift/Services/CognitoIdentityProvider"),
         .target(name: "AWSCognitoSync", dependencies: ["AWSSDKSwiftCore"], path: "./Sources/AWSSDKSwift/Services/CognitoSync"),
         .target(name: "AWSComprehend", dependencies: ["AWSSDKSwiftCore"], path: "./Sources/AWSSDKSwift/Services/Comprehend"),

--- a/Package.swift
+++ b/Package.swift
@@ -443,7 +443,7 @@ let package = Package(
         .target(name: "AWSSSM", dependencies: ["AWSSDKSwiftCore"], path: "./Sources/AWSSDKSwift/Services/SSM"),
         .target(name: "AWSSSO", dependencies: ["AWSSDKSwiftCore"], path: "./Sources/AWSSDKSwift/Services/SSO"),
         .target(name: "AWSSSOOIDC", dependencies: ["AWSSDKSwiftCore"], path: "./Sources/AWSSDKSwift/Services/SSOOIDC"),
-        .target(name: "AWSSTS", dependencies: ["AWSSDKSwiftCore"], path: "./Sources/AWSSDKSwift/Services/STS"),
+        .target(name: "AWSSTS", dependencies: ["AWSSDKSwiftCore"], path: "./Sources/AWSSDKSwift/", sources: ["Services/STS", "Extensions/STS"]),
         .target(name: "AWSSWF", dependencies: ["AWSSDKSwiftCore"], path: "./Sources/AWSSDKSwift/Services/SWF"),
         .target(name: "AWSSageMaker", dependencies: ["AWSSDKSwiftCore"], path: "./Sources/AWSSDKSwift/Services/SageMaker"),
         .target(name: "AWSSageMakerRuntime", dependencies: ["AWSSDKSwiftCore"], path: "./Sources/AWSSDKSwift/Services/SageMakerRuntime"),

--- a/Sources/AWSSDKSwift/Extensions/CognitoIdentity/CognitoIdentity+CredentialProvider.swift
+++ b/Sources/AWSSDKSwift/Extensions/CognitoIdentity/CognitoIdentity+CredentialProvider.swift
@@ -1,0 +1,95 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the AWSSDKSwift open source project
+//
+// Copyright (c) 2017-2020 the AWSSDKSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of AWSSDKSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import AWSSDKSwiftCore
+import struct Foundation.Date
+import typealias Foundation.TimeInterval
+import NIO
+
+extension CognitoIdentity {
+    struct RotatingCredential: ExpiringCredential {
+        func isExpiring(within interval: TimeInterval) -> Bool {
+            return self.expiration.timeIntervalSinceNow < interval
+        }
+
+        let accessKeyId: String
+        let secretAccessKey: String
+        let sessionToken: String?
+        let expiration: Date
+    }
+
+    struct IdentityCredentialProvider: CredentialProvider {
+        let logins: [String: String]
+        let client: AWSClient
+        let cognitoIdentity: CognitoIdentity
+        let idPromise: EventLoopPromise<String>
+
+        init(identityPoolId: String, logins: [String: String], region: Region, eventLoop: EventLoop, httpClient: AWSHTTPClient) {
+            self.client = AWSClient(credentialProvider: .empty, httpClientProvider: .shared(httpClient))
+            self.cognitoIdentity = CognitoIdentity(client: self.client, region: region)
+            self.logins = logins
+            self.idPromise = eventLoop.makePromise(of: String.self)
+
+            // only getId once and store in promise
+            let request = CognitoIdentity.GetIdInput(identityPoolId: identityPoolId, logins: logins)
+            cognitoIdentity.getId(request).flatMapThrowing { response -> String in
+                guard let identityId = response.identityId else { throw CredentialProviderError.noProvider }
+                return identityId
+            }.cascade(to: idPromise)
+        }
+
+        func getCredential(on eventLoop: EventLoop) -> EventLoopFuture<Credential> {
+            return self.idPromise.futureResult.flatMap { identityId -> EventLoopFuture<GetCredentialsForIdentityResponse> in
+                let credentialsRequest = CognitoIdentity.GetCredentialsForIdentityInput(identityId: identityId, logins: self.logins)
+                return self.cognitoIdentity.getCredentialsForIdentity(credentialsRequest)
+            }
+            .flatMapThrowing { response in
+                guard let credentials = response.credentials,
+                    let accessKeyId = credentials.accessKeyId,
+                    let secretAccessKey = credentials.secretKey,
+                    let sessionToken = credentials.sessionToken,
+                    let expiration = credentials.expiration?.dateValue else {
+                        throw CredentialProviderError.noProvider
+                }
+                return RotatingCredential(
+                    accessKeyId: accessKeyId,
+                    secretAccessKey: secretAccessKey,
+                    sessionToken: sessionToken,
+                    expiration: expiration
+                )
+            }.hop(to: eventLoop)
+        }
+
+        func syncShutdown() throws {
+            try client.syncShutdown()
+        }
+    }
+
+}
+
+extension CredentialProviderFactory {
+    public static func cognitoIdentity(identityPoolId: String, logins: [String: String], region: Region) -> CredentialProviderFactory {
+        .custom { context in
+            let provider = CognitoIdentity.IdentityCredentialProvider(
+                identityPoolId: identityPoolId,
+                logins: logins,
+                region: region,
+                eventLoop: context.eventLoop,
+                httpClient: context.httpClient
+            )
+            return RotatingCredentialProvider(eventLoop: context.eventLoop, provider: provider)
+        }
+    }
+
+}

--- a/Sources/AWSSDKSwift/Extensions/CognitoIdentity/CognitoIdentity+CredentialProvider.swift
+++ b/Sources/AWSSDKSwift/Extensions/CognitoIdentity/CognitoIdentity+CredentialProvider.swift
@@ -30,12 +30,12 @@ extension CognitoIdentity {
     }
 
     struct IdentityCredentialProvider: CredentialProvider {
-        let logins: [String: String]
+        let logins: [String: String]?
         let client: AWSClient
         let cognitoIdentity: CognitoIdentity
         let idPromise: EventLoopPromise<String>
 
-        init(identityPoolId: String, logins: [String: String], region: Region, eventLoop: EventLoop, httpClient: AWSHTTPClient) {
+        init(identityPoolId: String, logins: [String: String]?, region: Region, eventLoop: EventLoop, httpClient: AWSHTTPClient) {
             self.client = AWSClient(credentialProvider: .empty, httpClientProvider: .shared(httpClient))
             self.cognitoIdentity = CognitoIdentity(client: self.client, region: region)
             self.logins = logins
@@ -79,7 +79,12 @@ extension CognitoIdentity {
 }
 
 extension CredentialProviderFactory {
-    public static func cognitoIdentity(identityPoolId: String, logins: [String: String], region: Region) -> CredentialProviderFactory {
+    /// Use CognitoIdentity GetId and GetCredentialsForIdentity to provide credentials
+    /// - Parameters:
+    ///   - identityPoolId: Identity pool to get identity from
+    ///   - logins: Optional tokens for authenticating login
+    ///   - region: Region where we can find the identity pool
+    public static func cognitoIdentity(identityPoolId: String, logins: [String: String]?, region: Region) -> CredentialProviderFactory {
         .custom { context in
             let provider = CognitoIdentity.IdentityCredentialProvider(
                 identityPoolId: identityPoolId,

--- a/Sources/AWSSDKSwift/Extensions/CognitoIdentity/CognitoIdentity+CredentialProvider.swift
+++ b/Sources/AWSSDKSwift/Extensions/CognitoIdentity/CognitoIdentity+CredentialProvider.swift
@@ -71,8 +71,15 @@ extension CognitoIdentity {
             }.hop(to: eventLoop)
         }
 
-        func syncShutdown() throws {
-            try client.syncShutdown()
+        func shutdown(on eventLoop: EventLoop) -> EventLoopFuture<Void> {
+            // can call client.syncShutdown here as it has an empty credential provider and
+            // uses the http client supplied at initialisation.
+            do {
+                try client.syncShutdown()
+                return eventLoop.makeSucceededFuture(())
+            } catch {
+                return eventLoop.makeFailedFuture(error)
+            }
         }
     }
 

--- a/Sources/AWSSDKSwift/Extensions/CognitoIdentity/CognitoIdentity+CredentialProvider.swift
+++ b/Sources/AWSSDKSwift/Extensions/CognitoIdentity/CognitoIdentity+CredentialProvider.swift
@@ -72,14 +72,16 @@ extension CognitoIdentity {
         }
 
         func shutdown(on eventLoop: EventLoop) -> EventLoopFuture<Void> {
-            // can call client.syncShutdown here as it has an empty credential provider and
-            // uses the http client supplied at initialisation.
-            do {
-                try client.syncShutdown()
-                return eventLoop.makeSucceededFuture(())
-            } catch {
-                return eventLoop.makeFailedFuture(error)
+            // shutdown AWSClient
+            let promise = eventLoop.makePromise(of: Void.self)
+            client.shutdown { error in
+                if let error = error {
+                    promise.completeWith(.failure(error))
+                } else {
+                    promise.completeWith(.success(()))
+                }
             }
+            return promise.futureResult
         }
     }
 

--- a/Sources/AWSSDKSwift/Extensions/CognitoIdentity/CognitoIdentity+CredentialProvider.swift
+++ b/Sources/AWSSDKSwift/Extensions/CognitoIdentity/CognitoIdentity+CredentialProvider.swift
@@ -59,8 +59,9 @@ extension CognitoIdentity {
                     let accessKeyId = credentials.accessKeyId,
                     let secretAccessKey = credentials.secretKey,
                     let sessionToken = credentials.sessionToken,
-                    let expiration = credentials.expiration?.dateValue else {
-                        throw CredentialProviderError.noProvider
+                    let expiration = credentials.expiration?.dateValue
+                else {
+                    throw CredentialProviderError.noProvider
                 }
                 return RotatingCredential(
                     accessKeyId: accessKeyId,
@@ -84,7 +85,6 @@ extension CognitoIdentity {
             return promise.futureResult
         }
     }
-
 }
 
 extension CredentialProviderFactory {
@@ -105,5 +105,4 @@ extension CredentialProviderFactory {
             return RotatingCredentialProvider(context: context, provider: provider)
         }
     }
-
 }

--- a/Sources/AWSSDKSwift/Extensions/STS/STS+CredentialProvider.swift
+++ b/Sources/AWSSDKSwift/Extensions/STS/STS+CredentialProvider.swift
@@ -115,7 +115,7 @@ extension STS {
 
 extension CredentialProviderFactory {
 
-    public static func assumeRole(
+    public static func stsAssumeRole(
         request: STS.AssumeRoleRequest,
         credentialProvider: CredentialProviderFactory = .default,
         region: Region
@@ -131,14 +131,14 @@ extension CredentialProviderFactory {
         }
     }
     
-    public static func saml(request: STS.AssumeRoleWithSAMLRequest, region: Region) -> CredentialProviderFactory {
+    public static func stsSAML(request: STS.AssumeRoleWithSAMLRequest, region: Region) -> CredentialProviderFactory {
         .custom { context in
             let provider = STS.AssumeRoleWithSAMLCredentialProvider(request: request, region: region, httpClient: context.httpClient)
             return RotatingCredentialProvider(eventLoop: context.eventLoop, provider: provider)
         }
     }
     
-    public static func webIdentity(request: STS.AssumeRoleWithWebIdentityRequest, region: Region) -> CredentialProviderFactory {
+    public static func stsWebIdentity(request: STS.AssumeRoleWithWebIdentityRequest, region: Region) -> CredentialProviderFactory {
         .custom { context in
             let provider = STS.AssumeRoleWithWebIdentityCredentialProvider(request: request, region: region, httpClient: context.httpClient)
             return RotatingCredentialProvider(eventLoop: context.eventLoop, provider: provider)

--- a/Sources/AWSSDKSwift/Extensions/STS/STS+CredentialProvider.swift
+++ b/Sources/AWSSDKSwift/Extensions/STS/STS+CredentialProvider.swift
@@ -52,9 +52,16 @@ extension STS {
         }
 
         func shutdown(on eventLoop: EventLoop) -> EventLoopFuture<Void> {
-            // can call client.syncShutdown here as we have shutdown the credential provider and the
-            // client uses the http client supplied at initialisation.
-            return client.credentialProvider.shutdown(on: eventLoop).flatMapThrowing { _ in try self.client.syncShutdown() }
+            // shutdown AWSClient
+            let promise = eventLoop.makePromise(of: Void.self)
+            client.shutdown { error in
+                if let error = error {
+                    promise.completeWith(.failure(error))
+                } else {
+                    promise.completeWith(.success(()))
+                }
+            }
+            return promise.futureResult
         }
     }
     
@@ -82,14 +89,16 @@ extension STS {
         }
 
         func shutdown(on eventLoop: EventLoop) -> EventLoopFuture<Void> {
-            // can call client.syncShutdown here as it has an empty credential provider and
-            // uses the http client supplied at initialisation.
-            do {
-                try client.syncShutdown()
-                return eventLoop.makeSucceededFuture(())
-            } catch {
-                return eventLoop.makeFailedFuture(error)
+            // shutdown AWSClient
+            let promise = eventLoop.makePromise(of: Void.self)
+            client.shutdown { error in
+                if let error = error {
+                    promise.completeWith(.failure(error))
+                } else {
+                    promise.completeWith(.success(()))
+                }
             }
+            return promise.futureResult
         }
     }
     
@@ -117,14 +126,16 @@ extension STS {
         }
 
         func shutdown(on eventLoop: EventLoop) -> EventLoopFuture<Void> {
-            // can call client.syncShutdown here as it has an empty credential provider and
-            // uses the http client supplied at initialisation.
-            do {
-                try client.syncShutdown()
-                return eventLoop.makeSucceededFuture(())
-            } catch {
-                return eventLoop.makeFailedFuture(error)
+            // shutdown AWSClient
+            let promise = eventLoop.makePromise(of: Void.self)
+            client.shutdown { error in
+                if let error = error {
+                    promise.completeWith(.failure(error))
+                } else {
+                    promise.completeWith(.success(()))
+                }
             }
+            return promise.futureResult
         }
     }
 }

--- a/Sources/AWSSDKSwift/Extensions/STS/STS+CredentialProvider.swift
+++ b/Sources/AWSSDKSwift/Extensions/STS/STS+CredentialProvider.swift
@@ -51,8 +51,10 @@ extension STS {
             }.hop(to: eventLoop)
         }
 
-        func syncShutdown() throws {
-            try client.syncShutdown()
+        func shutdown(on eventLoop: EventLoop) -> EventLoopFuture<Void> {
+            // can call client.syncShutdown here as we have shutdown the credential provider and the
+            // client uses the http client supplied at initialisation.
+            return client.credentialProvider.shutdown(on: eventLoop).flatMapThrowing { _ in try self.client.syncShutdown() }
         }
     }
     
@@ -79,8 +81,15 @@ extension STS {
             }.hop(to: eventLoop)
         }
 
-        func syncShutdown() throws {
-            try client.syncShutdown()
+        func shutdown(on eventLoop: EventLoop) -> EventLoopFuture<Void> {
+            // can call client.syncShutdown here as it has an empty credential provider and
+            // uses the http client supplied at initialisation.
+            do {
+                try client.syncShutdown()
+                return eventLoop.makeSucceededFuture(())
+            } catch {
+                return eventLoop.makeFailedFuture(error)
+            }
         }
     }
     
@@ -107,8 +116,15 @@ extension STS {
             }.hop(to: eventLoop)
         }
 
-        func syncShutdown() throws {
-            try client.syncShutdown()
+        func shutdown(on eventLoop: EventLoop) -> EventLoopFuture<Void> {
+            // can call client.syncShutdown here as it has an empty credential provider and
+            // uses the http client supplied at initialisation.
+            do {
+                try client.syncShutdown()
+                return eventLoop.makeSucceededFuture(())
+            } catch {
+                return eventLoop.makeFailedFuture(error)
+            }
         }
     }
 }

--- a/Sources/AWSSDKSwift/Extensions/STS/STS+CredentialProvider.swift
+++ b/Sources/AWSSDKSwift/Extensions/STS/STS+CredentialProvider.swift
@@ -1,0 +1,104 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the AWSSDKSwift open source project
+//
+// Copyright (c) 2017-2020 the AWSSDKSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of AWSSDKSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import AWSSDKSwiftCore
+import struct Foundation.Date
+import typealias Foundation.TimeInterval
+
+extension STS {
+    struct RotatingCredential: ExpiringCredential {
+        func isExpiring(within interval: TimeInterval) -> Bool {
+            return self.expiration.timeIntervalSinceNow < interval
+        }
+        
+        let accessKeyId: String
+        let secretAccessKey: String
+        let sessionToken: String?
+        let expiration: Date
+    }
+    
+    struct AssumeRoleCredentialProvider: CredentialProvider {
+        let request: STS.AssumeRoleRequest
+        let client: STS
+        
+        func getCredential(on eventLoop: EventLoop) -> EventLoopFuture<Credential> {
+            return client.assumeRole(request).flatMapThrowing { response in
+                guard let credentials = response.credentials else { throw CredentialProviderError.noProvider }
+                return RotatingCredential(
+                    accessKeyId: credentials.accessKeyId,
+                    secretAccessKey: credentials.secretAccessKey,
+                    sessionToken: credentials.sessionToken,
+                    expiration: credentials.expiration.dateValue
+                )
+            }.hop(to: eventLoop)
+        }
+    }
+    
+    struct AssumeRoleWithSAMLCredentialProvider: CredentialProvider {
+        let request: STS.AssumeRoleWithSAMLRequest
+        let client: STS
+        
+        func getCredential(on eventLoop: EventLoop) -> EventLoopFuture<Credential> {
+            return client.assumeRoleWithSAML(request).flatMapThrowing { response in
+                guard let credentials = response.credentials else { throw CredentialProviderError.noProvider }
+                return RotatingCredential(
+                    accessKeyId: credentials.accessKeyId,
+                    secretAccessKey: credentials.secretAccessKey,
+                    sessionToken: credentials.sessionToken,
+                    expiration: credentials.expiration.dateValue
+                )
+            }.hop(to: eventLoop)
+        }
+    }
+    
+    struct AssumeRoleWithWebIdentityCredentialProvider: CredentialProvider {
+        let request: STS.AssumeRoleWithWebIdentityRequest
+        let client: STS
+        
+        func getCredential(on eventLoop: EventLoop) -> EventLoopFuture<Credential> {
+            return client.assumeRoleWithWebIdentity(request).flatMapThrowing { response in
+                guard let credentials = response.credentials else { throw CredentialProviderError.noProvider }
+                return RotatingCredential(
+                    accessKeyId: credentials.accessKeyId,
+                    secretAccessKey: credentials.secretAccessKey,
+                    sessionToken: credentials.sessionToken,
+                    expiration: credentials.expiration.dateValue
+                )
+            }.hop(to: eventLoop)
+        }
+    }
+}
+
+extension CredentialProviderFactory {
+    public static func assumeRole(request: STS.AssumeRoleRequest, client: STS) -> CredentialProviderFactory {
+        .custom { context in
+            let provider = STS.AssumeRoleCredentialProvider(request: request, client: client)
+            return RotatingCredentialProvider(eventLoop: context.eventLoop, client: provider)
+        }
+    }
+    
+    public static func saml(request: STS.AssumeRoleWithSAMLRequest, client: STS) -> CredentialProviderFactory {
+        .custom { context in
+            let provider = STS.AssumeRoleWithSAMLCredentialProvider(request: request, client: client)
+            return RotatingCredentialProvider(eventLoop: context.eventLoop, client: provider)
+        }
+    }
+    
+    public static func webIdentity(request: STS.AssumeRoleWithWebIdentityRequest, client: STS) -> CredentialProviderFactory {
+        .custom { context in
+            let provider = STS.AssumeRoleWithWebIdentityCredentialProvider(request: request, client: client)
+            return RotatingCredentialProvider(eventLoop: context.eventLoop, client: provider)
+        }
+    }
+}

--- a/Sources/AWSSDKSwift/Extensions/STS/STS+CredentialProvider.swift
+++ b/Sources/AWSSDKSwift/Extensions/STS/STS+CredentialProvider.swift
@@ -39,8 +39,8 @@ extension STS {
             self.request = request
         }
         
-        func getCredential(on eventLoop: EventLoop) -> EventLoopFuture<Credential> {
-            return sts.assumeRole(request).flatMapThrowing { response in
+        func getCredential(on eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<Credential> {
+            return sts.assumeRole(request, on: eventLoop).flatMapThrowing { response in
                 guard let credentials = response.credentials else { throw CredentialProviderError.noProvider }
                 return RotatingCredential(
                     accessKeyId: credentials.accessKeyId,
@@ -48,7 +48,7 @@ extension STS {
                     sessionToken: credentials.sessionToken,
                     expiration: credentials.expiration.dateValue
                 )
-            }.hop(to: eventLoop)
+            }
         }
 
         func shutdown(on eventLoop: EventLoop) -> EventLoopFuture<Void> {
@@ -69,8 +69,8 @@ extension STS {
             self.request = request
         }
 
-        func getCredential(on eventLoop: EventLoop) -> EventLoopFuture<Credential> {
-            return sts.assumeRoleWithSAML(request).flatMapThrowing { response in
+        func getCredential(on eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<Credential> {
+            return sts.assumeRoleWithSAML(request, on: eventLoop).flatMapThrowing { response in
                 guard let credentials = response.credentials else { throw CredentialProviderError.noProvider }
                 return RotatingCredential(
                     accessKeyId: credentials.accessKeyId,
@@ -78,7 +78,7 @@ extension STS {
                     sessionToken: credentials.sessionToken,
                     expiration: credentials.expiration.dateValue
                 )
-            }.hop(to: eventLoop)
+            }
         }
 
         func shutdown(on eventLoop: EventLoop) -> EventLoopFuture<Void> {
@@ -104,8 +104,8 @@ extension STS {
             self.request = request
         }
 
-        func getCredential(on eventLoop: EventLoop) -> EventLoopFuture<Credential> {
-            return sts.assumeRoleWithWebIdentity(request).flatMapThrowing { response in
+        func getCredential(on eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<Credential> {
+            return sts.assumeRoleWithWebIdentity(request, on: eventLoop).flatMapThrowing { response in
                 guard let credentials = response.credentials else { throw CredentialProviderError.noProvider }
                 return RotatingCredential(
                     accessKeyId: credentials.accessKeyId,
@@ -113,7 +113,7 @@ extension STS {
                     sessionToken: credentials.sessionToken,
                     expiration: credentials.expiration.dateValue
                 )
-            }.hop(to: eventLoop)
+            }
         }
 
         func shutdown(on eventLoop: EventLoop) -> EventLoopFuture<Void> {
@@ -148,7 +148,7 @@ extension CredentialProviderFactory {
                 region: region,
                 httpClient: context.httpClient
             )
-            return RotatingCredentialProvider(eventLoop: context.eventLoop, provider: provider)
+            return RotatingCredentialProvider(context: context, provider: provider)
         }
     }
     
@@ -159,7 +159,7 @@ extension CredentialProviderFactory {
     public static func stsSAML(request: STS.AssumeRoleWithSAMLRequest, region: Region) -> CredentialProviderFactory {
         .custom { context in
             let provider = STS.AssumeRoleWithSAMLCredentialProvider(request: request, region: region, httpClient: context.httpClient)
-            return RotatingCredentialProvider(eventLoop: context.eventLoop, provider: provider)
+            return RotatingCredentialProvider(context: context, provider: provider)
         }
     }
 
@@ -170,7 +170,7 @@ extension CredentialProviderFactory {
     public static func stsWebIdentity(request: STS.AssumeRoleWithWebIdentityRequest, region: Region) -> CredentialProviderFactory {
         .custom { context in
             let provider = STS.AssumeRoleWithWebIdentityCredentialProvider(request: request, region: region, httpClient: context.httpClient)
-            return RotatingCredentialProvider(eventLoop: context.eventLoop, provider: provider)
+            return RotatingCredentialProvider(context: context, provider: provider)
         }
     }
 }

--- a/Sources/AWSSDKSwift/Extensions/STS/STS+CredentialProvider.swift
+++ b/Sources/AWSSDKSwift/Extensions/STS/STS+CredentialProvider.swift
@@ -115,6 +115,11 @@ extension STS {
 
 extension CredentialProviderFactory {
 
+    /// Use AssumeRole to provide credentials
+    /// - Parameters:
+    ///   - request: AssumeRole request structure
+    ///   - credentialProvider: Credential provider used in client that runs the AssumeRole operation
+    ///   - region: Region to run request in
     public static func stsAssumeRole(
         request: STS.AssumeRoleRequest,
         credentialProvider: CredentialProviderFactory = .default,
@@ -131,13 +136,21 @@ extension CredentialProviderFactory {
         }
     }
     
+    /// Use AssumeRoleWithSAML to provide credentials
+    /// - Parameters:
+    ///   - request: AssumeRoleWithSAML request struct
+    ///   - region: Region to run request in
     public static func stsSAML(request: STS.AssumeRoleWithSAMLRequest, region: Region) -> CredentialProviderFactory {
         .custom { context in
             let provider = STS.AssumeRoleWithSAMLCredentialProvider(request: request, region: region, httpClient: context.httpClient)
             return RotatingCredentialProvider(eventLoop: context.eventLoop, provider: provider)
         }
     }
-    
+
+    /// Use AssumeRoleWithWebIdentity to provide credentials
+    /// - Parameters:
+    ///   - request: AssumeRoleWithWebIdentity request struct
+    ///   - region: Region to run request in
     public static func stsWebIdentity(request: STS.AssumeRoleWithWebIdentityRequest, region: Region) -> CredentialProviderFactory {
         .custom { context in
             let provider = STS.AssumeRoleWithWebIdentityCredentialProvider(request: request, region: region, httpClient: context.httpClient)

--- a/Sources/AWSSDKSwift/Extensions/STS/STS+CredentialProvider.swift
+++ b/Sources/AWSSDKSwift/Extensions/STS/STS+CredentialProvider.swift
@@ -21,13 +21,13 @@ extension STS {
         func isExpiring(within interval: TimeInterval) -> Bool {
             return self.expiration.timeIntervalSinceNow < interval
         }
-        
+
         let accessKeyId: String
         let secretAccessKey: String
         let sessionToken: String?
         let expiration: Date
     }
-    
+
     struct AssumeRoleCredentialProvider: CredentialProvider {
         let request: STS.AssumeRoleRequest
         let client: AWSClient
@@ -38,7 +38,7 @@ extension STS {
             self.sts = STS(client: self.client, region: region)
             self.request = request
         }
-        
+
         func getCredential(on eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<Credential> {
             return sts.assumeRole(request, on: eventLoop).flatMapThrowing { response in
                 guard let credentials = response.credentials else { throw CredentialProviderError.noProvider }
@@ -64,12 +64,12 @@ extension STS {
             return promise.futureResult
         }
     }
-    
+
     struct AssumeRoleWithSAMLCredentialProvider: CredentialProvider {
         let request: STS.AssumeRoleWithSAMLRequest
         let client: AWSClient
         let sts: STS
-        
+
         init(request: STS.AssumeRoleWithSAMLRequest, region: Region, httpClient: AWSHTTPClient) {
             self.client = AWSClient(credentialProvider: .empty, httpClientProvider: .shared(httpClient))
             self.sts = STS(client: self.client, region: region)
@@ -101,7 +101,7 @@ extension STS {
             return promise.futureResult
         }
     }
-    
+
     struct AssumeRoleWithWebIdentityCredentialProvider: CredentialProvider {
         let request: STS.AssumeRoleWithWebIdentityRequest
         let client: AWSClient
@@ -141,7 +141,6 @@ extension STS {
 }
 
 extension CredentialProviderFactory {
-
     /// Use AssumeRole to provide credentials
     /// - Parameters:
     ///   - request: AssumeRole request structure
@@ -162,7 +161,7 @@ extension CredentialProviderFactory {
             return RotatingCredentialProvider(context: context, provider: provider)
         }
     }
-    
+
     /// Use AssumeRoleWithSAML to provide credentials
     /// - Parameters:
     ///   - request: AssumeRoleWithSAML request struct

--- a/Tests/AWSSDKSwiftTests/Services/STS/STSTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/STS/STSTests.swift
@@ -60,8 +60,8 @@ class STSTests: XCTestCase {
         XCTAssertNoThrow(try response.wait())
     }
     
-    func testCredentialProviderShutdown() {
-        let client = AWSClient(credentialProvider: .stsAssumeRole(request: .init(roleArn: "arn:aws:iam::000000000000:role/Admin", roleSessionName: "now"), region: .euwest2), httpClientProvider: .createNew)
+    func testSTSCredentialProviderShutdown() {
+        let client = AWSClient(credentialProvider: .stsAssumeRole(request: .init(roleArn: "arn:aws:iam::000000000000:role/Admin", roleSessionName: "test-session"), region: .euwest2), httpClientProvider: .createNew)
         XCTAssertNoThrow(try client.syncShutdown())
     }
 }

--- a/Tests/AWSSDKSwiftTests/Services/STS/STSTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/STS/STSTests.swift
@@ -59,4 +59,9 @@ class STSTests: XCTestCase {
             }
         XCTAssertNoThrow(try response.wait())
     }
+    
+    func testCredentialProviderShutdown() {
+        let client = AWSClient(credentialProvider: .stsAssumeRole(request: .init(roleArn: "arn:aws:iam::000000000000:role/Admin", roleSessionName: "now"), region: .euwest2), httpClientProvider: .createNew)
+        XCTAssertNoThrow(try client.syncShutdown())
+    }
 }

--- a/Tests/AWSSDKSwiftTests/Services/STS/STSTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/STS/STSTests.swift
@@ -59,7 +59,7 @@ class STSTests: XCTestCase {
             }
         XCTAssertNoThrow(try response.wait())
     }
-    
+
     func testSTSCredentialProviderShutdown() {
         let client = AWSClient(credentialProvider: .stsAssumeRole(request: .init(roleArn: "arn:aws:iam::000000000000:role/Admin", roleSessionName: "test-session"), region: .euwest2), httpClientProvider: .createNew)
         XCTAssertNoThrow(try client.syncShutdown())


### PR DESCRIPTION
Adds credential providers using `CognitoIdentity.getCredentialsForIdentity`, `STS.AssumeRole`, `STS.AssumeRoleWithSAML` and `STS.AssumeRoleWithWebIdentity`. To access CognitoIdentity provider use the following
```
import CognitoIdentity

let credentialProvider: CredentialProviderFactory = .cognitoIdentity(
    identityPoolId: poolId, 
    logins: ["appleid.apple.com": "APPLETOKEN"],
    region: .useast1
)
let client = AWSClient(credentialProvider: credentialProvider)
```
STS credential providers are all setup in a similar way. You create a request struct which stores all the info required and pass to credential provider factory
```
import STS

let request = STS.AssumeRoleWithWebIdentityRequest(...)
let client = AWSClient(credentialProvider: .stsWebIdentity(request: request, region: .euwest1))
```
