### PR TITLE
S3 multipart upload now uses streaming

### DIFF
--- a/Tests/AWSSDKSwiftTests/Services/S3/S3ExtensionTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/S3/S3ExtensionTests.swift
@@ -142,7 +142,7 @@ class S3ExtensionTests: XCTestCase {
     }
 
     func testMultiPartUpload() {
-        let data = S3Tests.createRandomBuffer(size: 10 * 1024 * 1024)
+        let data = S3Tests.createRandomBuffer(size: 11 * 1024 * 1024)
         let name = TestEnvironment.generateResourceName()
         let filename = "S3MultipartUploadTest"
 


### PR DESCRIPTION
Use AWSPayload streaming in MultipartUpload helper functions. This means uploads use very little memory and progress function gets called more often, so updates are smoother