### PR TITLE
Added S3.resumeMultipartUpload

### DIFF
--- a/Sources/AWSSDKSwift/Extensions/S3/S3+multipart_API.swift
+++ b/Sources/AWSSDKSwift/Extensions/S3/S3+multipart_API.swift
@@ -289,7 +289,7 @@ extension S3 {
         inputStream: @escaping (EventLoop) -> EventLoopFuture<AWSPayload>,
         skipStream: @escaping (EventLoop) -> EventLoopFuture<Bool>
     ) -> EventLoopFuture<CompleteMultipartUploadOutput> {
-        //var completedParts: [S3.CompletedPart] = []
+        // var completedParts: [S3.CompletedPart] = []
         let listPartsRequest = ListPartsRequest(
             bucket: input.bucket,
             key: input.key,
@@ -297,12 +297,12 @@ extension S3 {
             uploadId: uploadId
         )
         /* commented out until paginators with more_results flag are working
-        return listPartsPaginator(listPartsRequest) { output, eventLoop in
-            if let parts = output.parts {
-                completedParts += parts.map { CompletedPart(eTag: $0.eTag, partNumber: $0.partNumber)}
-            }
-            return eventLoop.makeSucceededFuture(true)
-        }*/
+         return listPartsPaginator(listPartsRequest) { output, eventLoop in
+             if let parts = output.parts {
+                 completedParts += parts.map { CompletedPart(eTag: $0.eTag, partNumber: $0.partNumber)}
+             }
+             return eventLoop.makeSucceededFuture(true)
+         }*/
         return listParts(listPartsRequest).flatMap { response in
             let completedParts = response.parts?.map { CompletedPart(eTag: $0.eTag, partNumber: $0.partNumber) } ?? []
             // upload all the parts
@@ -377,7 +377,7 @@ extension S3 {
                 uploadId: uploadId,
                 abortOnFail: abortOnFail,
                 on: eventLoop,
-                inputStream:  { eventLoop in
+                inputStream: { eventLoop in
                     let size = min(partSize, fileSize - progressAmount)
                     guard size > 0 else { return eventLoop.makeSucceededFuture(.empty) }
                     prevProgressAmount = progressAmount
@@ -397,7 +397,8 @@ extension S3 {
                     let size = min(partSize, fileSize - progressAmount)
                     progressAmount += size
                     return eventLoop.makeSucceededFuture(size == 0)
-            })
+                }
+            )
         }
     }
 }
@@ -439,7 +440,6 @@ extension S3 {
                     return rt
                 }
         }
-
     }
 
     /// used internally in multipartUpload, loads all the parts once the multipart upload has been initiated

--- a/Tests/AWSSDKSwiftTests/Services/S3/S3ExtensionTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/S3/S3ExtensionTests.swift
@@ -186,8 +186,8 @@ class S3ExtensionTests: XCTestCase {
             .flatMap { (_) -> EventLoopFuture<S3.CompleteMultipartUploadOutput> in
                 let request = S3.CreateMultipartUploadRequest(bucket: name, key: name)
                 return Self.s3.multipartUpload(request, partSize: 5 * 1024 * 1024, filename: filename, abortOnFail: false) {
-                    guard $0 < 0.95 else { throw CancelError()}
-                    print("Progress \($0*100)")
+                    guard $0 < 0.95 else { throw CancelError() }
+                    print("Progress \($0 * 100)")
                 }
             }.flatMapThrowing { _ -> String in
                 XCTFail("First multipartUpload was successful")
@@ -202,7 +202,7 @@ class S3ExtensionTests: XCTestCase {
                 }
             }.flatMap { uploadId -> EventLoopFuture<S3.CompleteMultipartUploadOutput> in
                 let request = S3.CreateMultipartUploadRequest(bucket: name, key: name)
-                return Self.s3.resumeMultipartUpload(request, uploadId: uploadId, partSize: 5 * 1024 * 1024, filename: filename) { print("Progress \($0*100)") }
+                return Self.s3.resumeMultipartUpload(request, uploadId: uploadId, partSize: 5 * 1024 * 1024, filename: filename) { print("Progress \($0 * 100)") }
             }
             .flatMap { _ -> EventLoopFuture<S3.GetObjectOutput> in
                 return Self.s3.getObject(.init(bucket: name, key: name))

--- a/Tests/AWSSDKSwiftTests/Services/S3/S3ExtensionTests.swift
+++ b/Tests/AWSSDKSwiftTests/Services/S3/S3ExtensionTests.swift
@@ -171,6 +171,51 @@ class S3ExtensionTests: XCTestCase {
         XCTAssertNoThrow(try response.wait())
     }
 
+    func testResumeMultiPartUpload() {
+        struct CancelError: Error {}
+        let data = S3Tests.createRandomBuffer(size: 11 * 1024 * 1024)
+        let name = TestEnvironment.generateResourceName()
+        let filename = "S3MultipartUploadTest"
+
+        XCTAssertNoThrow(try data.write(to: URL(fileURLWithPath: filename)))
+        defer {
+            XCTAssertNoThrow(try FileManager.default.removeItem(atPath: filename))
+        }
+
+        let response = S3Tests.createBucket(name: name, s3: Self.s3)
+            .flatMap { (_) -> EventLoopFuture<S3.CompleteMultipartUploadOutput> in
+                let request = S3.CreateMultipartUploadRequest(bucket: name, key: name)
+                return Self.s3.multipartUpload(request, partSize: 5 * 1024 * 1024, filename: filename, abortOnFail: false) {
+                    guard $0 < 0.95 else { throw CancelError()}
+                    print("Progress \($0*100)")
+                }
+            }.flatMapThrowing { _ -> String in
+                XCTFail("First multipartUpload was successful")
+                throw CancelError()
+            }.flatMapErrorThrowing { error -> String in
+                switch error {
+                case S3ErrorType.multipart.abortedUpload(let uploadId, _):
+                    return uploadId
+                default:
+                    XCTFail("First multipartUpload threw the wrong error")
+                    throw CancelError()
+                }
+            }.flatMap { uploadId -> EventLoopFuture<S3.CompleteMultipartUploadOutput> in
+                let request = S3.CreateMultipartUploadRequest(bucket: name, key: name)
+                return Self.s3.resumeMultipartUpload(request, uploadId: uploadId, partSize: 5 * 1024 * 1024, filename: filename) { print("Progress \($0*100)") }
+            }
+            .flatMap { _ -> EventLoopFuture<S3.GetObjectOutput> in
+                return Self.s3.getObject(.init(bucket: name, key: name))
+            }
+            .map { response -> Void in
+                XCTAssertEqual(response.body?.asData(), data)
+            }
+            .flatAlways { _ in
+                return S3Tests.deleteBucket(name: name, s3: Self.s3)
+            }
+        XCTAssertNoThrow(try response.wait())
+    }
+
     func testMultiPartUploadFailure() {
         let data = S3Tests.createRandomBuffer(size: 10 * 1024 * 1024)
         let name = TestEnvironment.generateResourceName()


### PR DESCRIPTION
Add flag to `S3.multipartUpload` which doesn't abort the multipart upload when it fails. Instead it throws an error which includes the `uploadId` in it. This can then be sent to `S3.resumeMultipartUpload` to finish the upload at a later date