### PR TITLE
Use LocalStack when running a GitHub action with no AWS_ACCESS_KEY_ID

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,23 @@ jobs:
     strategy:
       matrix:
         image: ['swift:5.1', 'swift:5.2']
+    services:
+      localstack:
+        image: localstack/localstack
+        env:
+          SERVICES: 'apigateway,dynamodb,ec2,iam,s3,sns,sqs,ssm,sts'
     container:
       image: ${{ matrix.image }}
+      env:
+        APIGATEWAY_ENDPOINT : "http://localstack:4566"
+        DYNAMODB_ENDPOINT   : "http://localstack:4566"
+        EC2_ENDPOINT        : "http://localstack:4566"
+        IAM_ENDPOINT        : "http://localstack:4566"
+        S3_ENDPOINT         : "http://localstack:4566"
+        SNS_ENDPOINT        : "http://localstack:4566"
+        SQS_ENDPOINT        : "http://localstack:4566"
+        SSM_ENDPOINT        : "http://localstack:4566"
+        STS_ENDPOINT        : "http://localstack:4566"
     steps:
     - name: Checkout
       uses: actions/checkout@v1

--- a/Tests/AWSSDKSwiftTests/test.swift
+++ b/Tests/AWSSDKSwiftTests/test.swift
@@ -39,7 +39,7 @@ struct TestEnvironment {
     /// are we using Localstack to test. Also return use localstack if we are running a github action and don't have an access key if
     static var isUsingLocalstack: Bool {
         return Environment["AWS_DISABLE_LOCALSTACK"] != "true" ||
-            (Environment["GITHUB_ACTIONS"] == "true" && Environment["AWS_ACCESS_KEY_ID"] == nil)
+            (Environment["GITHUB_ACTIONS"] == "true" && Environment["AWS_ACCESS_KEY_ID"] == "")
     }
 
     static var credentialProvider: CredentialProviderFactory { return isUsingLocalstack ? .static(accessKeyId: "foo", secretAccessKey: "bar") : .default }


### PR DESCRIPTION
If running a GitHub action and there is no AWS_ACCESS_KEY_ID environment variable then use LocalStack for tests.
Catches situation where someone is doing PR from a fork